### PR TITLE
Prettier: add end of line auto

### DIFF
--- a/client/.prettierrc.js
+++ b/client/.prettierrc.js
@@ -1,6 +1,7 @@
 module.exports = {
+  endOfLine: 'auto',
   semi: true,
   singleQuote: true,
-  trailingComma: "all",
+  trailingComma: 'all',
   tabWidth: 2,
 };


### PR DESCRIPTION
I get a lot of end of line errors unless I add this. A Windows thing perhaps?