### PR TITLE
refactor(auth): use useConvexAuth and remove roomUser state

### DIFF
--- a/convex/auth.ts
+++ b/convex/auth.ts
@@ -36,6 +36,10 @@ export const createAuth = (ctx: GenericCtx<DataModel>) => {
     session: {
       expiresIn: 60 * 60 * 24 * 365, // 1 year
       updateAge: 60 * 60 * 24 * 7,   // refresh weekly
+      cookieCache: {
+        enabled: true,
+        maxAge: 5 * 60, // Cache duration in seconds
+      },
     },
     trustedOrigins: [
       siteUrl,

--- a/src/components/navbar-actions.tsx
+++ b/src/components/navbar-actions.tsx
@@ -6,7 +6,7 @@ import { UserMenu } from "@/components/user-menu/user-menu";
 import { Button } from "@/components/ui/button";
 
 export function NavbarActions() {
-  const { authUser, isLoading } = useAuth();
+  const { isAuthenticated, isLoading } = useAuth();
 
   // Show nothing while loading to prevent flash
   if (isLoading) {
@@ -14,7 +14,7 @@ export function NavbarActions() {
   }
 
   // Show UserMenu if authenticated
-  if (authUser) {
+  if (isAuthenticated) {
     return <UserMenu />;
   }
 

--- a/src/components/room/canvas-navigation.tsx
+++ b/src/components/room/canvas-navigation.tsx
@@ -45,6 +45,7 @@ import {
   SheetTrigger,
 } from "@/components/ui/sheet";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
+import type { Id } from "@/convex/_generated/dataModel";
 import { copyTextToClipboard } from "@/utils/copy-text-to-clipboard";
 import { UserPresenceAvatars } from "./user-presence-avatars";
 
@@ -592,6 +593,7 @@ export const CanvasNavigation: FC<CanvasNavigationProps> = ({
       <RoomSettingsPanel
         roomData={roomData}
         usersWithPresence={usersWithPresence}
+        currentUserId={isDemoMode ? undefined : (currentUserId as Id<"users">)}
         isOpen={isSettingsOpen}
         onClose={() => setIsSettingsOpen(false)}
         triggerRef={settingsButtonRef}

--- a/src/components/room/join-room-dialog.tsx
+++ b/src/components/room/join-room-dialog.tsx
@@ -18,7 +18,7 @@ interface JoinRoomDialogProps {
 }
 
 export function JoinRoomDialog({ roomId, roomName }: JoinRoomDialogProps) {
-  const { setRoomUser, authUser } = useAuth();
+  const { authUserId } = useAuth();
   const joinRoom = useMutation(api.users.join);
 
   // Start with empty name for first-time users
@@ -35,7 +35,7 @@ export function JoinRoomDialog({ roomId, roomName }: JoinRoomDialogProps) {
     setIsJoining(true);
     try {
       // Create anonymous session if one doesn't exist
-      let currentAuthUserId = authUser?.authUserId;
+      let currentAuthUserId = authUserId;
       if (!currentAuthUserId) {
         const { data } = await authClient.signIn.anonymous();
         if (!data?.user?.id) {
@@ -45,20 +45,15 @@ export function JoinRoomDialog({ roomId, roomName }: JoinRoomDialogProps) {
         currentAuthUserId = data.user.id;
       }
 
-      const userId = await joinRoom({
+      await joinRoom({
         roomId,
         name: userName,
         isSpectator,
         authUserId: currentAuthUserId,
       });
 
-      setRoomUser({
-        id: userId,
-        name: userName,
-        roomId,
-      });
-
-      // Page will automatically re-render and show the room
+      // No need to set state - existingMembership query will auto-update
+      // and room-content.tsx will re-render with the new membership
     } catch (error) {
       console.error("Failed to join room:", error);
       toast.error("Failed to join room");

--- a/src/components/room/room-settings-panel.tsx
+++ b/src/components/room/room-settings-panel.tsx
@@ -29,7 +29,6 @@ import {
 } from "@/components/ui/alert-dialog";
 import { useClickOutside } from "@/hooks/use-click-outside";
 import { useToast } from "@/hooks/use-toast";
-import { useAuth } from "@/components/auth/auth-provider";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
 import { cn } from "@/lib/utils";
@@ -41,6 +40,7 @@ import { formatLastSeen } from "./user-presence-avatars";
 interface RoomSettingsPanelProps {
   roomData: RoomWithRelatedData;
   usersWithPresence: UserWithPresence[];
+  currentUserId?: Id<"users">;
   isOpen: boolean;
   onClose: () => void;
   triggerRef?: React.RefObject<HTMLButtonElement | null>;
@@ -50,13 +50,13 @@ interface RoomSettingsPanelProps {
 export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
   roomData,
   usersWithPresence,
+  currentUserId,
   isOpen,
   onClose,
   triggerRef,
   isDemoMode = false,
 }) => {
   const panelRef = useRef<HTMLDivElement>(null);
-  const { roomUser } = useAuth();
   const { toast } = useToast();
   const { theme, setTheme } = useTheme();
 
@@ -164,7 +164,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
 
   // Filter out current user and sort: online first, then by join time
   const otherUsers = usersWithPresence
-    .filter((u) => u._id !== roomUser?.id)
+    .filter((u) => u._id !== currentUserId)
     .sort((a, b) => {
       // Online users first
       if (a.isOnline !== b.isOnline) {


### PR DESCRIPTION
## Summary
- Replace `authClient.useSession()` with `useConvexAuth()` for auth state per Convex-BetterAuth best practices
- Remove `roomUser` client-side state - components now use Convex queries directly as single source of truth
- Simplify `AuthProvider` from 72 to 51 lines with cleaner interface
- Remove 3 useEffects in room-content.tsx that synchronized client state with queries

## Test plan
- [x] `npm run ts:check` - no type errors
- [x] `npm run lint` - no lint errors
- [x] Auth tests: 13/13 passed (session creation, auto-join, sign-out, refresh flicker)
- [x] Spectator tests: 9/9 passed (join as spectator, toggle mode, multi-user scenarios)
- [x] Room creation tests: passing
- [ ] Manual test: join room, refresh, auto-restore works
- [ ] Manual test: visit new room, auto-join with saved name works

🤖 Generated with [Claude Code](https://claude.com/claude-code)