### PR TITLE
refactor: consolidate authorization into one pure permission decision module

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,3 +176,17 @@ See [docs/releasing.md](docs/releasing.md) for full documentation.
 
 - Make the plan extremely concise. Sacrifice grammar for the sake of concision.
 - At the end of each plan, give me a list of unresolved questions to answer, if any.
+
+## Agent skills
+
+### Issue tracker
+
+Issues are tracked in this repo's GitHub Issues, managed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+The five canonical triage roles map to their default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context — one `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,64 @@
+# AgileKit
+
+Online planning poker for Scrum teams. This context covers the domain language teams and code share — rooms, roles, and who is allowed to do what inside a session.
+
+## Language
+
+### Authorization
+
+**Permission decision**:
+The pure verdict for "may this actor take this action in this room, right now". A single function (`evaluate`) of role × permission level × target role × lockdown — no IO, no identity. Distinct from the **permissions** config that feeds it.
+_Avoid_: permission check, access check, can-do
+
+**Decision**:
+The value a **permission decision** returns: `{ allowed: true }` or `{ allowed: false, reason }`. The reason classifies the denial; user-facing copy is derived from it, never embedded in it.
+_Avoid_: result, verdict, outcome
+
+**Action**:
+What an actor is attempting. Either a **category action** (one of the four configurable categories) or a **relationship action** (`remove` / `promote` / `demote`, which constrain the target's role; `transfer` / `changePerms`, which do not).
+_Avoid_: operation, command, capability
+
+**Permission guard**:
+The backend adapter (`requireCan`) over the **permission decision**. It does the IO — reads the room, the actor's membership, the target's membership, and whether the owner is absent — assembles the **Action**, calls `evaluate`, and throws a reason-derived message on denial. Identity rules (self-transfer, authoritative `ownerId`) stay in the calling handler, not the guard.
+_Avoid_: middleware, interceptor, auth wrapper
+
+**Denial reason**:
+Why a **Decision** was `allowed: false` — `insufficient-role`, `owner-absent`, or `target-rank` (acting on a target whose role forbids it). One reason maps to one message via a shared pure function used by both backend throws and frontend tooltips.
+_Avoid_: error code, status
+
+### Roles & permissions
+
+**Role**:
+A member's standing in one room: **owner** (exactly one; full control; transferable), **facilitator** (trusted helper, promoted by owner or another facilitator), or **participant** (default voter). A role is per-room, not global.
+_Avoid_: rank, level (reserve "level" for permission level), tier
+
+**Permission level**:
+The configurable threshold on a **permission category**: `everyone`, `facilitators`, or `owner`. Set by the owner; defaults to `everyone` so new rooms behave as before.
+_Avoid_: access level, role requirement
+
+**Permission category**:
+One of the four owner-configurable buckets of actions: **reveal cards**, **game flow**, **issue management**, **room settings**. Each carries one **permission level**.
+_Avoid_: permission group, scope
+
+**Lockdown**:
+The state after the owner *explicitly leaves* (membership deleted), detected at query time as "`ownerId` set, but no membership for that user". Owner-level and owner-only actions become unavailable. **Invariant:** lockdown is a *reason refinement, not a separate gate* — an absent owner already fails the role check, so lockdown only changes the **denial reason** to `owner-absent` (and thus the message/banner), never the allow/deny outcome (see [ADR-0001](docs/adr/0001-lockdown-is-a-denial-reason-not-a-gate.md)). Network disconnects do not trigger it.
+_Avoid_: orphaned, locked, frozen
+
+## Flagged ambiguities
+
+- **"Permission"** is overloaded: the **permissions** config (the levels an owner sets) versus a **permission decision** (the runtime verdict). Always qualify which one. The bare table/field name `permissions` always means the config.
+- **"Owner absent" vs "owner offline"**: only an explicit *leave* causes **lockdown**. Going offline (disconnect, tab close) is cosmetic presence and changes no permissions.
+
+## Example dialogue
+
+> **Dev:** When a facilitator clicks "reveal" and reveal cards is set to `owner`, what comes back?
+>
+> **Domain expert:** A **Decision** of `{ allowed: false, reason: "insufficient-role" }` — a facilitator doesn't meet the `owner` **permission level**.
+>
+> **Dev:** And if the owner has left?
+>
+> **Domain expert:** Same allow/deny — still denied — but the **denial reason** becomes `owner-absent`, because the room is in **lockdown**. The verdict didn't change; the reason did. That's why the **permission decision** takes "owner absent" as an input but never branches the outcome on it.
+>
+> **Dev:** So where does "a facilitator can't remove another facilitator" live?
+>
+> **Domain expert:** That's a `remove` **relationship action**. The **permission decision** returns `reason: "target-rank"`. The **permission guard** is what fetched the target's **role** to make that call — the decision itself stayed pure.

--- a/convex/integrations.ts
+++ b/convex/integrations.ts
@@ -6,7 +6,7 @@
 import { mutation, query } from "./_generated/server";
 import { internal } from "./_generated/api";
 import { v } from "convex/values";
-import { requireAuthUser, requireRoomMember, requireRoomPermission } from "./model/auth";
+import { requireAuthUser, requireRoomMember, requireCan } from "./model/auth";
 
 // ---------------------------------------------------------------------------
 // Connection queries & mutations
@@ -129,7 +129,7 @@ export const saveRoomMapping = mutation({
     autoPushEstimates: v.boolean(),
   },
   handler: async (ctx, args) => {
-    await requireRoomPermission(ctx, args.roomId, "roomSettings");
+    await requireCan(ctx, args.roomId, { kind: "category", category: "roomSettings" });
 
     // Verify the connection belongs to the current user
     const { user } = await requireAuthUser(ctx);
@@ -201,7 +201,7 @@ export const saveRoomMapping = mutation({
 export const removeRoomMapping = mutation({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    await requireRoomPermission(ctx, args.roomId, "roomSettings");
+    await requireCan(ctx, args.roomId, { kind: "category", category: "roomSettings" });
 
     const mapping = await ctx.db
       .query("integrationMappings")

--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -14,7 +14,14 @@ import { v } from "convex/values";
 import { Doc } from "../_generated/dataModel";
 import { ActionCtx } from "../_generated/server";
 import { encryptToken, decryptToken } from "../lib/encryption";
-import { requirePermission } from "../model/permissions";
+import {
+  Action,
+  evaluate,
+  denialMessage,
+  getEffectivePermissions,
+  getEffectiveRole,
+} from "../permissions";
+import { isRoomOwnerAbsent } from "../model/permissions";
 import { JiraClient } from "./jiraClient";
 
 function getTokenEncryptionKey(): string {
@@ -876,7 +883,23 @@ export const verifyRoomAccess = internalQuery({
     const room = await ctx.db.get(args.roomId);
     if (!room) throw new Error("Room not found");
 
-    await requirePermission(ctx, room, membership, "issueManagement");
+    // This internal query authenticates via an explicit authUserId rather than
+    // ctx.auth, so it can't use requireCan; it reaches the permission decision
+    // directly with the room and membership already in hand.
+    const permissions = getEffectivePermissions(room);
+    const action: Action = {
+      kind: "category",
+      category: "issueManagement",
+      level: permissions.issueManagement,
+    };
+    const decision = evaluate(action, {
+      actorRole: getEffectiveRole(membership),
+      permissions,
+      ownerAbsent: await isRoomOwnerAbsent(ctx, room),
+    });
+    if (!decision.allowed) {
+      throw new Error(denialMessage(action, decision.reason));
+    }
 
     return { userId: user._id };
   },

--- a/convex/issues.ts
+++ b/convex/issues.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { query, mutation } from "./_generated/server";
 import * as Issues from "./model/issues";
-import { requireRoomMember, requireRoomPermission } from "./model/auth";
+import { requireRoomMember, requireCan } from "./model/auth";
 
 /**
  * List all issues for a room, ordered by their order field
@@ -54,7 +54,7 @@ export const create = mutation({
     title: v.string(),
   },
   handler: async (ctx, args) => {
-    await requireRoomPermission(ctx, args.roomId, "issueManagement");
+    await requireCan(ctx, args.roomId, { kind: "category", category: "issueManagement" });
     return await Issues.createIssue(ctx, args);
   },
 });
@@ -70,7 +70,7 @@ export const updateTitle = mutation({
   handler: async (ctx, args) => {
     const issue = await ctx.db.get(args.issueId);
     if (!issue) throw new Error("Issue not found");
-    await requireRoomPermission(ctx, issue.roomId, "issueManagement");
+    await requireCan(ctx, issue.roomId, { kind: "category", category: "issueManagement" });
     await Issues.updateIssueTitle(ctx, args);
   },
 });
@@ -86,7 +86,7 @@ export const updateEstimate = mutation({
   handler: async (ctx, args) => {
     const issue = await ctx.db.get(args.issueId);
     if (!issue) throw new Error("Issue not found");
-    await requireRoomPermission(ctx, issue.roomId, "issueManagement");
+    await requireCan(ctx, issue.roomId, { kind: "category", category: "issueManagement" });
     await Issues.updateIssueEstimate(ctx, args);
   },
 });
@@ -99,7 +99,7 @@ export const remove = mutation({
   handler: async (ctx, args) => {
     const issue = await ctx.db.get(args.issueId);
     if (!issue) throw new Error("Issue not found");
-    await requireRoomPermission(ctx, issue.roomId, "issueManagement");
+    await requireCan(ctx, issue.roomId, { kind: "category", category: "issueManagement" });
     await Issues.removeIssue(ctx, args.issueId);
   },
 });
@@ -113,7 +113,7 @@ export const startVoting = mutation({
     issueId: v.id("issues"),
   },
   handler: async (ctx, args) => {
-    await requireRoomPermission(ctx, args.roomId, "gameFlow");
+    await requireCan(ctx, args.roomId, { kind: "category", category: "gameFlow" });
     await Issues.startVotingOnIssue(ctx, args);
   },
 });
@@ -127,7 +127,7 @@ export const reorder = mutation({
     issueIds: v.array(v.id("issues")),
   },
   handler: async (ctx, args) => {
-    await requireRoomPermission(ctx, args.roomId, "issueManagement");
+    await requireCan(ctx, args.roomId, { kind: "category", category: "issueManagement" });
     await Issues.reorderIssues(ctx, args);
   },
 });
@@ -138,7 +138,7 @@ export const reorder = mutation({
 export const clearCurrentIssue = mutation({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    await requireRoomPermission(ctx, args.roomId, "gameFlow");
+    await requireCan(ctx, args.roomId, { kind: "category", category: "gameFlow" });
     await Issues.clearCurrentIssue(ctx, args.roomId);
   },
 });

--- a/convex/model/auth.ts
+++ b/convex/model/auth.ts
@@ -1,7 +1,14 @@
 import { QueryCtx, MutationCtx } from "../_generated/server";
 import { Id, Doc } from "../_generated/dataModel";
-import { PermissionCategory } from "../permissions";
-import { requirePermission } from "./permissions";
+import {
+  PermissionCategory,
+  Action,
+  evaluate,
+  denialMessage,
+  getEffectivePermissions,
+  getEffectiveRole,
+} from "../permissions";
+import { isRoomOwnerAbsent } from "./permissions";
 
 /**
  * Auth identity returned by ctx.auth.getUserIdentity().
@@ -85,24 +92,96 @@ export async function requireRoomMember(
 }
 
 /**
- * Requires authentication, room membership, AND permission for a specific category.
- * Combines requireRoomMember + requirePermission in one call.
+ * What an authorization guard is being asked to permit. The caller names the
+ * category or relationship verb; it cannot know the target's role, so the
+ * guard fills targetRole itself for target-constrained verbs.
  */
-export async function requireRoomPermission(
+export type RequireCanSpec =
+  | { kind: "category"; category: PermissionCategory }
+  | {
+      kind: "relationship";
+      verb: "remove" | "promote" | "demote" | "transfer" | "changePerms";
+    };
+
+/**
+ * The permission guard: the single authorization entry point for room
+ * mutations. Does the IO — loads the room and memberships, computes owner
+ * absence, fetches the target for target-constrained verbs — assembles the
+ * precise Action, calls evaluate, and throws a reason-derived message on
+ * denial. Returns the loaded bundle so callers stop re-fetching.
+ *
+ * Identity rules (self-transfer, authoritative ownerId) are NOT enforced here;
+ * they stay in the calling handler, after the guard.
+ */
+export async function requireCan(
   ctx: QueryCtx | MutationCtx,
   roomId: Id<"rooms">,
-  category: PermissionCategory
+  spec: RequireCanSpec,
+  targetUserId?: Id<"users">
 ): Promise<{
   identity: AuthIdentity;
   user: Doc<"users">;
   membership: Doc<"roomMemberships">;
   room: Doc<"rooms">;
+  target?: Doc<"roomMemberships">;
 }> {
   const { identity, user, membership } = await requireRoomMember(ctx, roomId);
   const room = await ctx.db.get(roomId);
   if (!room) {
     throw new Error("Room not found");
   }
-  await requirePermission(ctx, room, membership, category);
-  return { identity, user, membership, room };
+
+  const permissions = getEffectivePermissions(room);
+  const ownerAbsent = await isRoomOwnerAbsent(ctx, room);
+  const actorRole = getEffectiveRole(membership);
+
+  let action: Action;
+  let target: Doc<"roomMemberships"> | undefined;
+
+  if (spec.kind === "category") {
+    action = {
+      kind: "category",
+      category: spec.category,
+      level: permissions[spec.category],
+    };
+  } else {
+    // Relationship verb. Fetch the target membership whenever a target is
+    // supplied; fill targetRole only for the target-constrained verbs.
+    if (targetUserId !== undefined) {
+      target =
+        (await ctx.db
+          .query("roomMemberships")
+          .withIndex("by_room_user", (q) =>
+            q.eq("roomId", roomId).eq("userId", targetUserId)
+          )
+          .first()) ?? undefined;
+      if (!target) {
+        throw new Error("Target user is not a member of this room");
+      }
+    }
+
+    if (
+      spec.verb === "remove" ||
+      spec.verb === "promote" ||
+      spec.verb === "demote"
+    ) {
+      if (!target) {
+        throw new Error("Target user is not a member of this room");
+      }
+      action = {
+        kind: "relationship",
+        verb: spec.verb,
+        targetRole: getEffectiveRole(target),
+      };
+    } else {
+      action = { kind: "relationship", verb: spec.verb };
+    }
+  }
+
+  const decision = evaluate(action, { actorRole, permissions, ownerAbsent });
+  if (!decision.allowed) {
+    throw new Error(denialMessage(action, decision.reason));
+  }
+
+  return { identity, user, membership, room, target };
 }

--- a/convex/model/auth.ts
+++ b/convex/model/auth.ts
@@ -5,6 +5,7 @@ import {
   Action,
   evaluate,
   denialMessage,
+  requiresOwnerLevel,
   getEffectivePermissions,
   getEffectiveRole,
 } from "../permissions";
@@ -132,7 +133,6 @@ export async function requireCan(
   }
 
   const permissions = getEffectivePermissions(room);
-  const ownerAbsent = await isRoomOwnerAbsent(ctx, room);
   const actorRole = getEffectiveRole(membership);
 
   let action: Action;
@@ -177,6 +177,12 @@ export async function requireCan(
       action = { kind: "relationship", verb: spec.verb };
     }
   }
+
+  // Owner absence only refines an owner-level denial (see evaluate); for any
+  // other action it can't change the result, so skip the DB read.
+  const ownerAbsent = requiresOwnerLevel(action)
+    ? await isRoomOwnerAbsent(ctx, room)
+    : false;
 
   const decision = evaluate(action, { actorRole, permissions, ownerAbsent });
   if (!decision.allowed) {

--- a/convex/model/permissions.ts
+++ b/convex/model/permissions.ts
@@ -1,33 +1,14 @@
 import { QueryCtx } from "../_generated/server";
 import { Doc } from "../_generated/dataModel";
-import {
-  MemberRole,
-  PermissionLevel,
-  PermissionCategory,
-  getEffectivePermissions,
-  getEffectiveRole,
-} from "../permissions";
 
 /**
- * Checks whether a role satisfies a required permission level.
- * - "everyone" → any role passes
- * - "facilitators" → facilitator or owner passes
- * - "owner" → only owner passes
- */
-export function roleSatisfiesLevel(
-  role: MemberRole,
-  level: PermissionLevel
-): boolean {
-  if (level === "everyone") return true;
-  if (level === "facilitators") return role === "facilitator" || role === "owner";
-  if (level === "owner") return role === "owner";
-  return false;
-}
-
-/**
- * Checks if the room owner has left (no active membership).
- * Only explicit leave removes membership — network disconnect does NOT trigger this.
- * Returns false for legacy rooms without an owner.
+ * Checks if the room owner has left (no active membership) — the lockdown
+ * condition. Only an explicit leave removes membership; a network disconnect
+ * does NOT trigger this. Returns false for legacy rooms without an owner.
+ *
+ * The role × level × target rule itself lives in the pure permission decision
+ * (`evaluate` in convex/permissions.ts); this is just the IO that feeds it
+ * the `ownerAbsent` input.
  */
 export async function isRoomOwnerAbsent(
   ctx: QueryCtx,
@@ -43,86 +24,4 @@ export async function isRoomOwnerAbsent(
     .first();
 
   return !ownerMembership;
-}
-
-/**
- * Permission guard for mutations. Throws if the actor's role doesn't satisfy
- * the required permission level for the given category.
- *
- * Lockdown logic: if the room owner is absent AND the category's permission
- * level is "owner", throws an error. Facilitator-level and everyone-level
- * actions are unaffected by lockdown.
- */
-export async function requirePermission(
-  ctx: QueryCtx,
-  room: Doc<"rooms">,
-  membership: Doc<"roomMemberships">,
-  category: PermissionCategory
-): Promise<void> {
-  const permissions = getEffectivePermissions(room);
-  const level = permissions[category];
-  const role = getEffectiveRole(membership);
-
-  // Check lockdown: if owner is absent and this action requires owner level
-  if (level === "owner") {
-    const ownerAbsent = await isRoomOwnerAbsent(ctx, room);
-    if (ownerAbsent) {
-      throw new Error(
-        "Room owner has left. Owner-level actions are disabled until the owner returns."
-      );
-    }
-  }
-
-  if (!roleSatisfiesLevel(role, level)) {
-    throw new Error(
-      `Permission denied: ${category} requires "${level}" level`
-    );
-  }
-}
-
-/**
- * Check if an actor can remove a target member.
- * - Owner can remove anyone
- * - Facilitator can remove participants only (not other facilitators or owner)
- * - Participant cannot remove anyone
- */
-export function canRemoveMember(
-  actorRole: MemberRole,
-  targetRole: MemberRole
-): boolean {
-  if (actorRole === "owner") return true;
-  if (actorRole === "facilitator") return targetRole === "participant";
-  return false;
-}
-
-/**
- * Check if an actor can promote a target to facilitator.
- * Owner and facilitator can promote participants.
- */
-export function canPromoteToFacilitator(actorRole: MemberRole): boolean {
-  return actorRole === "owner" || actorRole === "facilitator";
-}
-
-/**
- * Check if an actor can demote a facilitator to participant.
- * Only owner can demote.
- */
-export function canDemoteFacilitator(actorRole: MemberRole): boolean {
-  return actorRole === "owner";
-}
-
-/**
- * Check if an actor can transfer ownership.
- * Only owner can transfer.
- */
-export function canTransferOwnership(actorRole: MemberRole): boolean {
-  return actorRole === "owner";
-}
-
-/**
- * Check if an actor can change room permissions.
- * Only owner can change permissions.
- */
-export function canChangePermissions(actorRole: MemberRole): boolean {
-  return actorRole === "owner";
 }

--- a/convex/model/roles.ts
+++ b/convex/model/roles.ts
@@ -1,86 +1,42 @@
 import { MutationCtx } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
-import { RoomPermissions, getEffectiveRole } from "../permissions";
-import {
-  canPromoteToFacilitator,
-  canDemoteFacilitator,
-  canTransferOwnership,
-  canChangePermissions,
-} from "./permissions";
-import { requireRoomMember } from "./auth";
+import { RoomPermissions } from "../permissions";
+import { requireCan } from "./auth";
 
 /**
  * Promotes a participant to facilitator.
- * Caller must be owner or facilitator.
+ * Caller must be owner or facilitator; target must be a participant.
  */
 export async function promoteFacilitator(
   ctx: MutationCtx,
   args: { roomId: Id<"rooms">; targetUserId: Id<"users"> }
 ): Promise<void> {
-  const { membership: actorMembership } = await requireRoomMember(
+  const { target } = await requireCan(
     ctx,
-    args.roomId
+    args.roomId,
+    { kind: "relationship", verb: "promote" },
+    args.targetUserId
   );
-  const actorRole = getEffectiveRole(actorMembership);
 
-  if (!canPromoteToFacilitator(actorRole)) {
-    throw new Error("Only owners and facilitators can promote members");
-  }
-
-  const targetMembership = await ctx.db
-    .query("roomMemberships")
-    .withIndex("by_room_user", (q) =>
-      q.eq("roomId", args.roomId).eq("userId", args.targetUserId)
-    )
-    .first();
-
-  if (!targetMembership) {
-    throw new Error("Target user is not a member of this room");
-  }
-
-  const targetRole = getEffectiveRole(targetMembership);
-  if (targetRole !== "participant") {
-    throw new Error("Can only promote participants to facilitator");
-  }
-
-  await ctx.db.patch(targetMembership._id, { role: "facilitator" });
+  await ctx.db.patch(target!._id, { role: "facilitator" });
 }
 
 /**
  * Demotes a facilitator to participant.
- * Caller must be owner.
+ * Caller must be owner; target must be a facilitator.
  */
 export async function demoteFacilitator(
   ctx: MutationCtx,
   args: { roomId: Id<"rooms">; targetUserId: Id<"users"> }
 ): Promise<void> {
-  const { membership: actorMembership } = await requireRoomMember(
+  const { target } = await requireCan(
     ctx,
-    args.roomId
+    args.roomId,
+    { kind: "relationship", verb: "demote" },
+    args.targetUserId
   );
-  const actorRole = getEffectiveRole(actorMembership);
 
-  if (!canDemoteFacilitator(actorRole)) {
-    throw new Error("Only the owner can demote facilitators");
-  }
-
-  const targetMembership = await ctx.db
-    .query("roomMemberships")
-    .withIndex("by_room_user", (q) =>
-      q.eq("roomId", args.roomId).eq("userId", args.targetUserId)
-    )
-    .first();
-
-  if (!targetMembership) {
-    throw new Error("Target user is not a member of this room");
-  }
-
-  const targetRole = getEffectiveRole(targetMembership);
-  if (targetRole !== "facilitator") {
-    throw new Error("Target user is not a facilitator");
-  }
-
-  await ctx.db.patch(targetMembership._id, { role: "participant" });
+  await ctx.db.patch(target!._id, { role: "participant" });
 }
 
 /**
@@ -91,40 +47,25 @@ export async function transferOwnership(
   ctx: MutationCtx,
   args: { roomId: Id<"rooms">; targetUserId: Id<"users"> }
 ): Promise<void> {
-  const { user, membership: actorMembership } = await requireRoomMember(
+  const { user, membership: actorMembership, room, target } = await requireCan(
     ctx,
-    args.roomId
+    args.roomId,
+    { kind: "relationship", verb: "transfer" },
+    args.targetUserId
   );
-  const actorRole = getEffectiveRole(actorMembership);
 
-  if (!canTransferOwnership(actorRole)) {
-    throw new Error("Only the owner can transfer ownership");
-  }
-
-  // Authoritative check: membership role must match room.ownerId
-  const room = await ctx.db.get(args.roomId);
-  if (!room || room.ownerId !== user._id) {
+  // Identity rules stay in the handler, after the guard — these are identity,
+  // not role, so they do not belong in the pure decision.
+  if (room.ownerId !== user._id) {
     throw new Error("Only the room owner can transfer ownership");
   }
-
-  const targetMembership = await ctx.db
-    .query("roomMemberships")
-    .withIndex("by_room_user", (q) =>
-      q.eq("roomId", args.roomId).eq("userId", args.targetUserId)
-    )
-    .first();
-
-  if (!targetMembership) {
-    throw new Error("Target user is not a member of this room");
-  }
-
   if (args.targetUserId === user._id) {
     throw new Error("Cannot transfer ownership to yourself");
   }
 
   // Swap roles: old owner → participant, new owner → owner
   await ctx.db.patch(actorMembership._id, { role: "participant" });
-  await ctx.db.patch(targetMembership._id, { role: "owner" });
+  await ctx.db.patch(target!._id, { role: "owner" });
 
   // Update room's ownerId
   await ctx.db.patch(args.roomId, { ownerId: args.targetUserId });
@@ -138,15 +79,10 @@ export async function updatePermissions(
   ctx: MutationCtx,
   args: { roomId: Id<"rooms">; permissions: RoomPermissions }
 ): Promise<void> {
-  const { membership: actorMembership } = await requireRoomMember(
-    ctx,
-    args.roomId
-  );
-  const actorRole = getEffectiveRole(actorMembership);
-
-  if (!canChangePermissions(actorRole)) {
-    throw new Error("Only the owner can change room permissions");
-  }
+  await requireCan(ctx, args.roomId, {
+    kind: "relationship",
+    verb: "changePerms",
+  });
 
   await ctx.db.patch(args.roomId, { permissions: args.permissions });
 }

--- a/convex/permissions.test.ts
+++ b/convex/permissions.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import {
+  evaluate,
+  denialMessage,
+  type Action,
+  type Decision,
+  type DecisionContext,
+  type MemberRole,
+  type PermissionCategory,
+  type PermissionLevel,
+  type RoomPermissions,
+} from "./permissions";
+
+const allEveryone: RoomPermissions = {
+  revealCards: "everyone",
+  gameFlow: "everyone",
+  issueManagement: "everyone",
+  roomSettings: "everyone",
+};
+
+function ctx(over: Partial<DecisionContext> = {}): DecisionContext {
+  return {
+    actorRole: "participant",
+    permissions: allEveryone,
+    ownerAbsent: false,
+    ...over,
+  };
+}
+
+describe("evaluate — category actions", () => {
+  it("allows a participant when the category is set to everyone", () => {
+    const action: Action = {
+      kind: "category",
+      category: "revealCards",
+      level: "everyone",
+    };
+    expect(evaluate(action, ctx())).toEqual({ allowed: true });
+  });
+
+  // Explicit truth table: permission level × actor role × ownerAbsent.
+  // (owner role with ownerAbsent is impossible by invariant — owner present
+  // iff an owner-role membership exists — so those rows are omitted.)
+  const rows: Array<{
+    level: PermissionLevel;
+    role: MemberRole;
+    ownerAbsent: boolean;
+    expected: Decision;
+  }> = [
+    // everyone — anyone passes, lockdown irrelevant
+    { level: "everyone", role: "participant", ownerAbsent: false, expected: { allowed: true } },
+    { level: "everyone", role: "participant", ownerAbsent: true, expected: { allowed: true } },
+    { level: "everyone", role: "facilitator", ownerAbsent: false, expected: { allowed: true } },
+    { level: "everyone", role: "facilitator", ownerAbsent: true, expected: { allowed: true } },
+    { level: "everyone", role: "owner", ownerAbsent: false, expected: { allowed: true } },
+    // facilitators — facilitator+owner pass; not an owner-level requirement, so
+    // ownerAbsent never refines the reason
+    { level: "facilitators", role: "participant", ownerAbsent: false, expected: { allowed: false, reason: "insufficient-role" } },
+    { level: "facilitators", role: "participant", ownerAbsent: true, expected: { allowed: false, reason: "insufficient-role" } },
+    { level: "facilitators", role: "facilitator", ownerAbsent: false, expected: { allowed: true } },
+    { level: "facilitators", role: "facilitator", ownerAbsent: true, expected: { allowed: true } },
+    { level: "facilitators", role: "owner", ownerAbsent: false, expected: { allowed: true } },
+    // owner — only owner passes; under lockdown the reason refines to owner-absent
+    { level: "owner", role: "participant", ownerAbsent: false, expected: { allowed: false, reason: "insufficient-role" } },
+    { level: "owner", role: "participant", ownerAbsent: true, expected: { allowed: false, reason: "owner-absent" } },
+    { level: "owner", role: "facilitator", ownerAbsent: false, expected: { allowed: false, reason: "insufficient-role" } },
+    { level: "owner", role: "facilitator", ownerAbsent: true, expected: { allowed: false, reason: "owner-absent" } },
+    { level: "owner", role: "owner", ownerAbsent: false, expected: { allowed: true } },
+  ];
+
+  it.each(rows)(
+    "$level / $role / ownerAbsent=$ownerAbsent → $expected.allowed",
+    ({ level, role, ownerAbsent, expected }) => {
+      const action: Action = { kind: "category", category: "revealCards", level };
+      expect(evaluate(action, ctx({ actorRole: role, ownerAbsent }))).toEqual(
+        expected
+      );
+    }
+  );
+
+  const categories: PermissionCategory[] = [
+    "revealCards",
+    "gameFlow",
+    "issueManagement",
+    "roomSettings",
+  ];
+
+  it.each(categories)(
+    "treats all four categories identically (%s at facilitators denies a participant)",
+    (category) => {
+      const action: Action = { kind: "category", category, level: "facilitators" };
+      expect(evaluate(action, ctx())).toEqual({
+        allowed: false,
+        reason: "insufficient-role",
+      });
+    }
+  );
+});
+
+describe("evaluate — remove", () => {
+  const remove = (targetRole: MemberRole): Action => ({
+    kind: "relationship",
+    verb: "remove",
+    targetRole,
+  });
+
+  it("lets an owner remove anyone", () => {
+    expect(evaluate(remove("participant"), ctx({ actorRole: "owner" }))).toEqual({ allowed: true });
+    expect(evaluate(remove("facilitator"), ctx({ actorRole: "owner" }))).toEqual({ allowed: true });
+    expect(evaluate(remove("owner"), ctx({ actorRole: "owner" }))).toEqual({ allowed: true });
+  });
+
+  it("lets a facilitator remove participants only", () => {
+    expect(evaluate(remove("participant"), ctx({ actorRole: "facilitator" }))).toEqual({ allowed: true });
+  });
+
+  it("denies a facilitator removing a facilitator or owner with target-rank", () => {
+    expect(evaluate(remove("facilitator"), ctx({ actorRole: "facilitator" }))).toEqual({ allowed: false, reason: "target-rank" });
+    expect(evaluate(remove("owner"), ctx({ actorRole: "facilitator" }))).toEqual({ allowed: false, reason: "target-rank" });
+  });
+
+  it("denies a participant removing anyone with insufficient-role (role precedes target)", () => {
+    expect(evaluate(remove("participant"), ctx({ actorRole: "participant" }))).toEqual({ allowed: false, reason: "insufficient-role" });
+    expect(evaluate(remove("facilitator"), ctx({ actorRole: "participant" }))).toEqual({ allowed: false, reason: "insufficient-role" });
+  });
+});
+
+describe("evaluate — promote", () => {
+  const promote = (targetRole: MemberRole): Action => ({
+    kind: "relationship",
+    verb: "promote",
+    targetRole,
+  });
+
+  it("lets an owner or facilitator promote a participant", () => {
+    expect(evaluate(promote("participant"), ctx({ actorRole: "owner" }))).toEqual({ allowed: true });
+    expect(evaluate(promote("participant"), ctx({ actorRole: "facilitator" }))).toEqual({ allowed: true });
+  });
+
+  it("denies promoting someone who is not a participant with target-rank", () => {
+    expect(evaluate(promote("facilitator"), ctx({ actorRole: "owner" }))).toEqual({ allowed: false, reason: "target-rank" });
+    expect(evaluate(promote("owner"), ctx({ actorRole: "facilitator" }))).toEqual({ allowed: false, reason: "target-rank" });
+  });
+
+  it("denies a participant promoting with insufficient-role (role precedes target)", () => {
+    expect(evaluate(promote("participant"), ctx({ actorRole: "participant" }))).toEqual({ allowed: false, reason: "insufficient-role" });
+  });
+
+  it("keeps working under lockdown — promote is not owner-level, so no owner-absent refinement", () => {
+    expect(evaluate(promote("participant"), ctx({ actorRole: "facilitator", ownerAbsent: true }))).toEqual({ allowed: true });
+    expect(evaluate(promote("participant"), ctx({ actorRole: "participant", ownerAbsent: true }))).toEqual({ allowed: false, reason: "insufficient-role" });
+  });
+});
+
+describe("evaluate — demote", () => {
+  const demote = (targetRole: MemberRole): Action => ({
+    kind: "relationship",
+    verb: "demote",
+    targetRole,
+  });
+
+  it("lets an owner demote a facilitator", () => {
+    expect(evaluate(demote("facilitator"), ctx({ actorRole: "owner" }))).toEqual({ allowed: true });
+  });
+
+  it("denies demoting a non-facilitator with target-rank", () => {
+    expect(evaluate(demote("participant"), ctx({ actorRole: "owner" }))).toEqual({ allowed: false, reason: "target-rank" });
+  });
+
+  it("denies a non-owner demoting with insufficient-role (role precedes target)", () => {
+    expect(evaluate(demote("facilitator"), ctx({ actorRole: "facilitator" }))).toEqual({ allowed: false, reason: "insufficient-role" });
+    expect(evaluate(demote("facilitator"), ctx({ actorRole: "participant" }))).toEqual({ allowed: false, reason: "insufficient-role" });
+  });
+
+  it("refines to owner-absent under lockdown (owner-level requirement)", () => {
+    expect(evaluate(demote("facilitator"), ctx({ actorRole: "facilitator", ownerAbsent: true }))).toEqual({ allowed: false, reason: "owner-absent" });
+  });
+});
+
+describe("evaluate — transfer / changePerms (owner-only, no target)", () => {
+  const transfer: Action = { kind: "relationship", verb: "transfer" };
+  const changePerms: Action = { kind: "relationship", verb: "changePerms" };
+
+  it("allows the owner", () => {
+    expect(evaluate(transfer, ctx({ actorRole: "owner" }))).toEqual({ allowed: true });
+    expect(evaluate(changePerms, ctx({ actorRole: "owner" }))).toEqual({ allowed: true });
+  });
+
+  it("denies non-owners with insufficient-role", () => {
+    expect(evaluate(transfer, ctx({ actorRole: "facilitator" }))).toEqual({ allowed: false, reason: "insufficient-role" });
+    expect(evaluate(changePerms, ctx({ actorRole: "participant" }))).toEqual({ allowed: false, reason: "insufficient-role" });
+  });
+
+  it("refines to owner-absent under lockdown", () => {
+    expect(evaluate(transfer, ctx({ actorRole: "facilitator", ownerAbsent: true }))).toEqual({ allowed: false, reason: "owner-absent" });
+    expect(evaluate(changePerms, ctx({ actorRole: "facilitator", ownerAbsent: true }))).toEqual({ allowed: false, reason: "owner-absent" });
+  });
+});
+
+describe("denialMessage", () => {
+  const OWNER_ABSENT =
+    "Room owner has left. Owner-level actions are disabled until the owner returns.";
+  const ONLY_OWNER = "Only the owner can do this.";
+  const ONLY_FACILITATORS = "Only facilitators and the owner can do this.";
+
+  const category = (level: PermissionLevel): Action => ({
+    kind: "category",
+    category: "revealCards",
+    level,
+  });
+
+  it("owner-absent yields the lockdown copy regardless of action", () => {
+    expect(denialMessage(category("owner"), "owner-absent")).toBe(OWNER_ABSENT);
+    expect(denialMessage({ kind: "relationship", verb: "transfer" }, "owner-absent")).toBe(OWNER_ABSENT);
+    expect(denialMessage({ kind: "relationship", verb: "demote", targetRole: "facilitator" }, "owner-absent")).toBe(OWNER_ABSENT);
+  });
+
+  it("insufficient-role copy reflects the required threshold", () => {
+    // owner-level requirements
+    expect(denialMessage(category("owner"), "insufficient-role")).toBe(ONLY_OWNER);
+    expect(denialMessage({ kind: "relationship", verb: "transfer" }, "insufficient-role")).toBe(ONLY_OWNER);
+    expect(denialMessage({ kind: "relationship", verb: "changePerms" }, "insufficient-role")).toBe(ONLY_OWNER);
+    expect(denialMessage({ kind: "relationship", verb: "demote", targetRole: "facilitator" }, "insufficient-role")).toBe(ONLY_OWNER);
+    // facilitator-level requirements
+    expect(denialMessage(category("facilitators"), "insufficient-role")).toBe(ONLY_FACILITATORS);
+    expect(denialMessage({ kind: "relationship", verb: "promote", targetRole: "participant" }, "insufficient-role")).toBe(ONLY_FACILITATORS);
+    expect(denialMessage({ kind: "relationship", verb: "remove", targetRole: "participant" }, "insufficient-role")).toBe(ONLY_FACILITATORS);
+  });
+
+  it("target-rank copy is verb-specific", () => {
+    expect(denialMessage({ kind: "relationship", verb: "remove", targetRole: "facilitator" }, "target-rank")).toBe("Facilitators can only remove participants.");
+    expect(denialMessage({ kind: "relationship", verb: "promote", targetRole: "facilitator" }, "target-rank")).toBe("Only participants can be promoted to facilitator.");
+    expect(denialMessage({ kind: "relationship", verb: "demote", targetRole: "participant" }, "target-rank")).toBe("Only facilitators can be demoted.");
+  });
+});

--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -154,9 +154,10 @@ function assertNever(action: never): never {
 
 /**
  * Whether an action's role requirement is owner-level. Drives both the
- * owner-absent refinement and the "Only the owner..." denial copy.
+ * owner-absent refinement and the "Only the owner..." denial copy. Exported so
+ * the guard can skip the owner-absence DB read when it can't affect the result.
  */
-function requiresOwnerLevel(action: Action): boolean {
+export function requiresOwnerLevel(action: Action): boolean {
   if (action.kind === "category") return action.level === "owner";
   return (
     action.verb === "transfer" ||

--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -25,6 +25,189 @@ export const DEFAULT_PERMISSIONS: RoomPermissions = {
   roomSettings: "everyone",
 };
 
+// --- Permission decision (pure) ---
+
+/**
+ * Why a Decision was denied. The reason classifies the denial; user-facing
+ * copy is derived from it via denialMessage, never embedded here.
+ */
+export type DenialReason = "insufficient-role" | "owner-absent" | "target-rank";
+
+/**
+ * The verdict returned by evaluate. Pure value — no IO, no identity.
+ */
+export type Decision =
+  | { allowed: true }
+  | { allowed: false; reason: DenialReason };
+
+/**
+ * What an actor is attempting. Either a category action (one of the four
+ * configurable categories, carrying its resolved level for messaging) or a
+ * relationship action. Relationship verbs that constrain the target's role
+ * require targetRole in the type; transfer/changePerms do not.
+ */
+export type Action =
+  | { kind: "category"; category: PermissionCategory; level: PermissionLevel }
+  | {
+      kind: "relationship";
+      verb: "remove" | "promote" | "demote";
+      targetRole: MemberRole;
+    }
+  | { kind: "relationship"; verb: "transfer" | "changePerms" };
+
+/**
+ * The inputs the permission decision depends on: the actor's role, the room's
+ * permissions, and whether the owner is absent. No DB, no identity.
+ */
+export type DecisionContext = {
+  actorRole: MemberRole;
+  permissions: RoomPermissions;
+  ownerAbsent: boolean;
+};
+
+/**
+ * Whether a role satisfies a required permission level.
+ * - "everyone" → any role
+ * - "facilitators" → facilitator or owner
+ * - "owner" → owner only
+ */
+function roleSatisfiesLevel(role: MemberRole, level: PermissionLevel): boolean {
+  if (level === "everyone") return true;
+  if (level === "facilitators")
+    return role === "facilitator" || role === "owner";
+  return role === "owner";
+}
+
+/**
+ * The single permission decision: may an actor take an action in a room.
+ *
+ * Role check precedes target check — if the actor's role already fails, the
+ * reason is "insufficient-role" (or "owner-absent"), never "target-rank".
+ *
+ * ownerAbsent refines the reason, never the outcome: an absent owner already
+ * fails any owner-level role check, so ownerAbsent only flips the reason to
+ * "owner-absent". See docs/adr/0001-lockdown-is-a-denial-reason-not-a-gate.md.
+ */
+export function evaluate(action: Action, ctx: DecisionContext): Decision {
+  if (action.kind === "category") {
+    return decideRole(
+      ctx,
+      roleSatisfiesLevel(ctx.actorRole, action.level),
+      requiresOwnerLevel(action)
+    );
+  }
+
+  // Relationship actions: a role check, then (for target-constrained verbs) a
+  // target-rank check. Role always precedes target.
+  switch (action.verb) {
+    case "transfer":
+    case "changePerms": {
+      // Owner-only, no target constraint.
+      return decideRole(ctx, ctx.actorRole === "owner", requiresOwnerLevel(action));
+    }
+    case "demote": {
+      // Owner-only; target must be a facilitator.
+      const roleDecision = decideRole(
+        ctx,
+        ctx.actorRole === "owner",
+        requiresOwnerLevel(action)
+      );
+      if (!roleDecision.allowed) return roleDecision;
+      return action.targetRole === "facilitator"
+        ? { allowed: true }
+        : { allowed: false, reason: "target-rank" };
+    }
+    case "promote": {
+      // Owner or facilitator; target must be a participant.
+      const roleDecision = decideRole(
+        ctx,
+        ctx.actorRole === "owner" || ctx.actorRole === "facilitator",
+        requiresOwnerLevel(action)
+      );
+      if (!roleDecision.allowed) return roleDecision;
+      return action.targetRole === "participant"
+        ? { allowed: true }
+        : { allowed: false, reason: "target-rank" };
+    }
+    case "remove": {
+      // owner removes anyone; facilitator removes participants only.
+      const roleDecision = decideRole(
+        ctx,
+        ctx.actorRole !== "participant",
+        requiresOwnerLevel(action)
+      );
+      if (!roleDecision.allowed) return roleDecision;
+      if (ctx.actorRole === "owner") return { allowed: true };
+      return action.targetRole === "participant"
+        ? { allowed: true }
+        : { allowed: false, reason: "target-rank" };
+    }
+    default:
+      return assertNever(action);
+  }
+}
+
+/** Exhaustiveness guard — unreachable for a well-typed Action. */
+function assertNever(action: never): never {
+  throw new Error(`Unhandled action: ${JSON.stringify(action)}`);
+}
+
+/**
+ * Whether an action's role requirement is owner-level. Drives both the
+ * owner-absent refinement and the "Only the owner..." denial copy.
+ */
+function requiresOwnerLevel(action: Action): boolean {
+  if (action.kind === "category") return action.level === "owner";
+  return (
+    action.verb === "transfer" ||
+    action.verb === "changePerms" ||
+    action.verb === "demote"
+  );
+}
+
+/**
+ * The single source of denial copy, derived from the action and reason and
+ * shared by the backend guard's throw and the frontend tooltip. Copy is never
+ * embedded in the Decision — it is reconstructed here.
+ */
+export function denialMessage(action: Action, reason: DenialReason): string {
+  if (reason === "owner-absent") {
+    return "Room owner has left. Owner-level actions are disabled until the owner returns.";
+  }
+
+  if (reason === "target-rank") {
+    if (action.kind === "relationship") {
+      if (action.verb === "remove")
+        return "Facilitators can only remove participants.";
+      if (action.verb === "promote")
+        return "Only participants can be promoted to facilitator.";
+      if (action.verb === "demote") return "Only facilitators can be demoted.";
+    }
+    return "You don't have permission to do this.";
+  }
+
+  // insufficient-role
+  return requiresOwnerLevel(action)
+    ? "Only the owner can do this."
+    : "Only facilitators and the owner can do this.";
+}
+
+/**
+ * Builds a Decision from a role check, refining the denial reason to
+ * "owner-absent" when an owner-level requirement fails under lockdown.
+ */
+function decideRole(
+  ctx: DecisionContext,
+  roleOk: boolean,
+  requiresOwner: boolean
+): Decision {
+  if (roleOk) return { allowed: true };
+  return {
+    allowed: false,
+    reason: requiresOwner && ctx.ownerAbsent ? "owner-absent" : "insufficient-role",
+  };
+}
+
 // --- Helpers ---
 
 /**

--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -4,7 +4,7 @@ import * as Rooms from "./model/rooms";
 import {
   requireAuth,
   requireAuthUser,
-  requireRoomPermission,
+  requireCan,
 } from "./model/auth";
 
 // Internal mutation called by scheduler for auto-reveal
@@ -89,7 +89,7 @@ export const updateActivity = mutation({
 export const showCards = mutation({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    await requireRoomPermission(ctx, args.roomId, "revealCards");
+    await requireCan(ctx, args.roomId, { kind: "category", category: "revealCards" });
     await Rooms.showRoomCards(ctx, args.roomId);
   },
 });
@@ -98,7 +98,7 @@ export const showCards = mutation({
 export const resetGame = mutation({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    await requireRoomPermission(ctx, args.roomId, "gameFlow");
+    await requireCan(ctx, args.roomId, { kind: "category", category: "gameFlow" });
     await Rooms.resetRoomGame(ctx, args.roomId);
   },
 });
@@ -107,7 +107,7 @@ export const resetGame = mutation({
 export const toggleAutoComplete = mutation({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    const { room } = await requireRoomPermission(ctx, args.roomId, "roomSettings");
+    const { room } = await requireCan(ctx, args.roomId, { kind: "category", category: "roomSettings" });
     // Cancel any scheduled reveal when toggling
     if (room.autoRevealScheduledId) {
       try {
@@ -129,7 +129,7 @@ export const toggleAutoComplete = mutation({
 export const cancelAutoRevealCountdown = mutation({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    const { room } = await requireRoomPermission(ctx, args.roomId, "revealCards");
+    const { room } = await requireCan(ctx, args.roomId, { kind: "category", category: "revealCards" });
     if (room.autoRevealCountdownStartedAt) {
       // Cancel the scheduled job if it exists
       if (room.autoRevealScheduledId) {
@@ -154,7 +154,7 @@ export const rename = mutation({
     name: v.string(),
   },
   handler: async (ctx, args) => {
-    await requireRoomPermission(ctx, args.roomId, "roomSettings");
+    await requireCan(ctx, args.roomId, { kind: "category", category: "roomSettings" });
     await ctx.db.patch(args.roomId, {
       name: args.name,
       lastActivityAt: Date.now(),

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -4,11 +4,9 @@ import * as Users from "./model/users";
 import {
   requireAuth,
   requireAuthUser,
-  requireRoomMember,
+  requireCan,
   getOptionalAuthUser,
 } from "./model/auth";
-import { getEffectiveRole } from "./permissions";
-import { canRemoveMember } from "./model/permissions";
 
 function validateName(name: string): string {
   const trimmed = name.trim();
@@ -128,29 +126,12 @@ export const remove = mutation({
     roomId: v.id("rooms"),
   },
   handler: async (ctx, args) => {
-    const { membership: actorMembership } = await requireRoomMember(
+    await requireCan(
       ctx,
-      args.roomId
+      args.roomId,
+      { kind: "relationship", verb: "remove" },
+      args.userId
     );
-    const actorRole = getEffectiveRole(actorMembership);
-
-    // Get target's membership to check their role
-    const targetMembership = await ctx.db
-      .query("roomMemberships")
-      .withIndex("by_room_user", (q) =>
-        q.eq("roomId", args.roomId).eq("userId", args.userId)
-      )
-      .first();
-
-    if (!targetMembership) {
-      throw new Error("Target user is not a member of this room");
-    }
-
-    const targetRole = getEffectiveRole(targetMembership);
-
-    if (!canRemoveMember(actorRole, targetRole)) {
-      throw new Error("You don't have permission to remove this user");
-    }
 
     await Users.leaveRoom(ctx, args.userId, args.roomId);
   },

--- a/docs/adr/0001-lockdown-is-a-denial-reason-not-a-gate.md
+++ b/docs/adr/0001-lockdown-is-a-denial-reason-not-a-gate.md
@@ -1,0 +1,15 @@
+# Lockdown is a denial reason, not a separate gate
+
+**Status:** accepted
+
+The **permission decision** (`evaluate`) does not short-circuit on **lockdown** before checking the actor's **role**. An absent owner already fails any owner-level **permission level** — by invariant, an `owner`-role membership exists iff the owner is present — so owner-level and owner-only actions are denied by the role check alone whether or not the owner is there. We therefore treat `ownerAbsent` as input that *refines the denial reason* (`owner-absent` instead of `insufficient-role`), never as a gate that changes the allow/deny outcome. This keeps the decision a single linear rule with one source of truth, and lets lockdown drive the distinct banner/message without duplicating control flow.
+
+## Considered Options
+
+- **Lockdown as an explicit pre-check** (the original shape: `if level === "owner" && ownerAbsent → throw`). Rejected because it is redundant with the role check for outcome, existed in two drifting copies (backend `requirePermission` and frontend `canDoAction`), and invited readers to believe lockdown gates actions that the role check already gates.
+- **Lockdown as reason refinement** (chosen). One rule, one place; the `owner-absent` reason carries the user-facing distinction.
+
+## Consequences
+
+- A reader scanning `evaluate` will see no lockdown branch guarding the outcome. That is deliberate — do not "fix" it by adding one. The behaviour in `docs/room-permissions-ba.md` (owner-level actions unavailable in lockdown, with a distinct banner) is fully preserved via the `owner-absent` reason.
+- The decision depends on the invariant that `role === "owner"` membership ⟺ the owner is present. If that invariant is ever broken (e.g. multiple owner-role memberships, or an owner-role membership for a non-owner), this reasoning no longer holds and lockdown would need revisiting.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/package-lock.json
+++ b/package-lock.json
@@ -62,6 +62,10 @@
         "tw-animate-css": "1.4.0",
         "typescript": "5.9.3",
         "vitest": "4.0.18"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-linux-x64-gnu": "4.2.0",
+        "lightningcss-linux-x64-gnu": "1.31.1"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -2049,6 +2053,22 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.0.tgz",
+      "integrity": "sha512-/hlXCBqn9K6fi7eAM0RsobHwJYa5V/xzWspVTzxnX+Ft9v6n+30Pz8+RxCn7sQL/vRHHLS30iQPrHQunu6/vJA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 20"
@@ -6937,6 +6957,26 @@
       "optional": true,
       "os": [
         "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.31.1.tgz",
+      "integrity": "sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
       ],
       "engines": {
         "node": ">= 12.0.0"

--- a/package.json
+++ b/package.json
@@ -70,5 +70,9 @@
     "tw-animate-css": "1.4.0",
     "typescript": "5.9.3",
     "vitest": "4.0.18"
+  },
+  "optionalDependencies": {
+    "@tailwindcss/oxide-linux-x64-gnu": "4.2.0",
+    "lightningcss-linux-x64-gnu": "1.31.1"
   }
 }

--- a/src/components/room/room-canvas.tsx
+++ b/src/components/room/room-canvas.tsx
@@ -39,6 +39,7 @@ import {
 import { DEMO_VIEWER_ID, type CustomNodeType, type PlayerNodeData } from "./types";
 import type { RoomWithRelatedData, SanitizedVote } from "@/convex/model/rooms";
 import { usePermissions } from "@/hooks/usePermissions";
+import type { MemberRole } from "@/convex/permissions";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -228,7 +229,7 @@ function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedd
       // Find the target user's role for permission check
       const targetUser = roomData?.users.find((u) => u._id === userId);
       const targetRole = targetUser?.role ?? "participant";
-      if (!permissions.canRemoveTarget(targetRole)) return;
+      if (!permissions.removeTarget(targetRole).allowed) return;
       setPendingDeleteUserId({ id: userId, name: userName });
     },
     [isDemoMode, roomData?.users, permissions]
@@ -297,10 +298,11 @@ function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedd
     currentUserId,
     selectedCardValue,
     isDemoMode,
-    canRevealCards: permissions.canRevealCards,
-    canControlGameFlow: permissions.canControlGameFlow,
-    canChangeRoomSettings: permissions.canChangeRoomSettings,
-    canRemoveTarget: permissions.canRemoveTarget,
+    canRevealCards: permissions.revealCards.allowed,
+    canControlGameFlow: permissions.gameFlow.allowed,
+    canChangeRoomSettings: permissions.roomSettings.allowed,
+    canRemoveTarget: (targetRole: MemberRole) =>
+      permissions.removeTarget(targetRole).allowed,
     onRevealCards: handleRevealCards,
     onResetGame: handleResetGame,
     onCardSelect: handleCardSelect,
@@ -547,8 +549,8 @@ function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedd
         isOpen={isIssuesPanelOpen}
         onClose={() => setIsIssuesPanelOpen(false)}
         isDemoMode={isDemoMode}
-        canManageIssues={permissions.canManageIssues}
-        canControlGameFlow={permissions.canControlGameFlow}
+        canManageIssues={permissions.issueManagement.allowed}
+        canControlGameFlow={permissions.gameFlow.allowed}
       />
     </div>
   );

--- a/src/components/room/room-settings-panel.tsx
+++ b/src/components/room/room-settings-panel.tsx
@@ -54,7 +54,8 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { usePermissions, getPermissionDeniedTooltip } from "@/hooks/usePermissions";
+import { usePermissions } from "@/hooks/usePermissions";
+import { denialMessage } from "@/convex/permissions";
 import { IntegrationSettingsSection } from "./integration-settings";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -281,6 +282,18 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
 
   const currentPermissions = getEffectivePermissions(roomData.room);
 
+  // Tooltip for the room-name controls, routed through the shared denial copy.
+  const roomSettingsTooltip = perms.roomSettings.allowed
+    ? undefined
+    : denialMessage(
+        {
+          kind: "category",
+          category: "roomSettings",
+          level: currentPermissions.roomSettings,
+        },
+        perms.roomSettings.reason
+      );
+
   return (
     <>
     <SidePanel isOpen={isOpen} onClose={onClose}>
@@ -336,27 +349,27 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                 <Input
                   id="room-name"
                   value={roomName}
-                  onChange={(e) => !isDemoMode && perms.canChangeRoomSettings && setRoomName(e.target.value)}
+                  onChange={(e) => !isDemoMode && perms.roomSettings.allowed && setRoomName(e.target.value)}
                   onKeyDown={(e) => {
-                    if (e.key === "Enter" && !isDemoMode && perms.canChangeRoomSettings) handleSaveRoomName();
+                    if (e.key === "Enter" && !isDemoMode && perms.roomSettings.allowed) handleSaveRoomName();
                   }}
                   placeholder="Enter room name"
                   className="h-10 text-sm bg-gray-50 dark:bg-surface-2"
-                  readOnly={isDemoMode || !perms.canChangeRoomSettings}
-                  title={!perms.canChangeRoomSettings ? getPermissionDeniedTooltip(currentPermissions.roomSettings) : undefined}
+                  readOnly={isDemoMode || !perms.roomSettings.allowed}
+                  title={roomSettingsTooltip}
                 />
                 {!isDemoMode && (
                   <Button
                     size="default"
                     onClick={handleSaveRoomName}
                     disabled={
-                      !perms.canChangeRoomSettings ||
+                      !perms.roomSettings.allowed ||
                       isSaving ||
                       !roomName.trim() ||
                       roomName === roomData.room.name
                     }
                     className="h-10 px-4 whitespace-nowrap"
-                    title={!perms.canChangeRoomSettings ? getPermissionDeniedTooltip(currentPermissions.roomSettings) : undefined}
+                    title={roomSettingsTooltip}
                   >
                     {isSaving ? "Saving..." : "Save"}
                   </Button>
@@ -380,8 +393,8 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
               <Switch
                 id="auto-reveal"
                 checked={roomData.room.autoCompleteVoting}
-                onCheckedChange={isDemoMode || !perms.canChangeRoomSettings ? undefined : handleToggleAutoReveal}
-                disabled={isDemoMode || !perms.canChangeRoomSettings}
+                onCheckedChange={isDemoMode || !perms.roomSettings.allowed ? undefined : handleToggleAutoReveal}
+                disabled={isDemoMode || !perms.roomSettings.allowed}
                 className="data-[state=checked]:bg-primary"
               />
             </div>
@@ -478,7 +491,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                       <div className="flex items-center gap-1.5 p-3 rounded-lg bg-gray-50 dark:bg-surface-3 border border-gray-100 dark:border-border/50">
                         <Info className="h-4 w-4 text-blue-500 shrink-0" />
                         <span className="text-xs text-gray-600 dark:text-gray-300">
-                          {perms.canChangePermissionsFlag ? "As the owner, you can control who can perform actions in this room." : "Only the room owner can change these permissions."}
+                          {perms.changePermissions.allowed ? "As the owner, you can control who can perform actions in this room." : "Only the room owner can change these permissions."}
                         </span>
                       </div>
                       <div className="space-y-2">
@@ -500,7 +513,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                                 </div>
                               </div>
                               <div className="shrink-0">
-                                {perms.canChangePermissionsFlag ? (
+                                {perms.changePermissions.allowed ? (
                                   <Select
                                     value={currentPermissions[category]}
                                     onValueChange={(value) => handlePermissionChange(category, value as PermissionLevel)}
@@ -571,10 +584,10 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                   sortedUsers.map((u) => {
                     const userRole = u.role ?? "participant";
                     const isMe = u._id === currentUserId;
-                    const canRemoveThis = perms.canRemoveTarget(userRole);
-                    const canPromoteThis = perms.canPromoteTarget(userRole);
-                    const canDemoteThis = perms.canDemoteFacilitatorFlag && userRole === "facilitator";
-                    const canTransfer = perms.canTransferOwnershipFlag;
+                    const canRemoveThis = perms.removeTarget(userRole).allowed;
+                    const canPromoteThis = perms.promoteTarget(userRole).allowed;
+                    const canDemoteThis = perms.demoteTarget(userRole).allowed;
+                    const canTransfer = perms.transfer.allowed;
 
                     return (
                       <div

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -3,40 +3,39 @@ import type { RoomWithRelatedData } from "@/convex/model/rooms";
 import type { Id } from "@/convex/_generated/dataModel";
 import {
   type MemberRole,
-  type PermissionLevel,
   type RoomPermissions,
+  type Decision,
+  type PermissionCategory,
   DEFAULT_PERMISSIONS,
   getEffectivePermissions,
+  evaluate,
 } from "@/convex/permissions";
-import {
-  roleSatisfiesLevel,
-  canRemoveMember,
-  canPromoteToFacilitator,
-  canDemoteFacilitator,
-  canTransferOwnership,
-  canChangePermissions,
-} from "@/convex/model/permissions";
 
 export interface UsePermissionsReturn {
   role: MemberRole;
   isOwner: boolean;
   isFacilitator: boolean;
   isOwnerAbsent: boolean;
-  canRevealCards: boolean;
-  canControlGameFlow: boolean;
-  canManageIssues: boolean;
-  canChangeRoomSettings: boolean;
-  canRemoveTarget: (targetRole: MemberRole) => boolean;
-  canPromoteTarget: (targetRole: MemberRole) => boolean;
-  canDemoteFacilitatorFlag: boolean;
-  canTransferOwnershipFlag: boolean;
-  canChangePermissionsFlag: boolean;
+  /** Per-category permission decisions. Consumers read `.allowed` / `.reason`. */
+  revealCards: Decision;
+  gameFlow: Decision;
+  issueManagement: Decision;
+  roomSettings: Decision;
+  /** Per-target relationship decisions — the target's role refines the verdict. */
+  removeTarget: (targetRole: MemberRole) => Decision;
+  promoteTarget: (targetRole: MemberRole) => Decision;
+  demoteTarget: (targetRole: MemberRole) => Decision;
+  transfer: Decision;
+  changePermissions: Decision;
   permissions: RoomPermissions;
 }
 
+const ALLOWED: Decision = { allowed: true };
+const DENIED: Decision = { allowed: false, reason: "insufficient-role" };
+
 /**
- * Returns permission flags computed from room data and the current user's role.
- * Pure computation — no queries or mutations.
+ * Maps room data to permission Decisions through the shared `evaluate` decision.
+ * Pure computation — no queries or mutations, and no duplicated lockdown logic.
  */
 export function usePermissions(
   roomData: RoomWithRelatedData | null | undefined,
@@ -44,20 +43,22 @@ export function usePermissions(
 ): UsePermissionsReturn {
   return useMemo(() => {
     if (!roomData || !currentUserId) {
+      // Optimistic defaults before data loads: configurable actions open,
+      // relationship actions closed (mirrors prior behaviour).
       return {
         role: "participant" as MemberRole,
         isOwner: false,
         isFacilitator: false,
         isOwnerAbsent: false,
-        canRevealCards: true,
-        canControlGameFlow: true,
-        canManageIssues: true,
-        canChangeRoomSettings: true,
-        canRemoveTarget: () => false,
-        canPromoteTarget: () => false,
-        canDemoteFacilitatorFlag: false,
-        canTransferOwnershipFlag: false,
-        canChangePermissionsFlag: false,
+        revealCards: ALLOWED,
+        gameFlow: ALLOWED,
+        issueManagement: ALLOWED,
+        roomSettings: ALLOWED,
+        removeTarget: () => DENIED,
+        promoteTarget: () => DENIED,
+        demoteTarget: () => DENIED,
+        transfer: DENIED,
+        changePermissions: DENIED,
         permissions: DEFAULT_PERMISSIONS,
       };
     }
@@ -65,47 +66,33 @@ export function usePermissions(
     const currentUser = roomData.users.find((u) => u._id === currentUserId);
     const role: MemberRole = currentUser?.role ?? "participant";
     const permissions = getEffectivePermissions(roomData.room);
-    const isOwnerAbsent = roomData.isOwnerAbsent;
+    const ownerAbsent = roomData.isOwnerAbsent;
+    const ctx = { actorRole: role, permissions, ownerAbsent };
 
-    // For permission checks, if owner is absent AND level is "owner", block the action
-    const canDoAction = (level: PermissionLevel): boolean => {
-      if (level === "owner" && isOwnerAbsent) return false;
-      return roleSatisfiesLevel(role, level);
-    };
+    const category = (c: PermissionCategory): Decision =>
+      evaluate({ kind: "category", category: c, level: permissions[c] }, ctx);
 
     return {
       role,
       isOwner: role === "owner",
       isFacilitator: role === "facilitator",
-      isOwnerAbsent,
-      canRevealCards: canDoAction(permissions.revealCards),
-      canControlGameFlow: canDoAction(permissions.gameFlow),
-      canManageIssues: canDoAction(permissions.issueManagement),
-      canChangeRoomSettings: canDoAction(permissions.roomSettings),
-      canRemoveTarget: (targetRole: MemberRole) =>
-        canRemoveMember(role, targetRole),
-      canPromoteTarget: (targetRole: MemberRole) =>
-        targetRole === "participant" && canPromoteToFacilitator(role),
-      canDemoteFacilitatorFlag: canDemoteFacilitator(role),
-      canTransferOwnershipFlag: canTransferOwnership(role),
-      canChangePermissionsFlag: canChangePermissions(role),
+      isOwnerAbsent: ownerAbsent,
+      revealCards: category("revealCards"),
+      gameFlow: category("gameFlow"),
+      issueManagement: category("issueManagement"),
+      roomSettings: category("roomSettings"),
+      removeTarget: (targetRole) =>
+        evaluate({ kind: "relationship", verb: "remove", targetRole }, ctx),
+      promoteTarget: (targetRole) =>
+        evaluate({ kind: "relationship", verb: "promote", targetRole }, ctx),
+      demoteTarget: (targetRole) =>
+        evaluate({ kind: "relationship", verb: "demote", targetRole }, ctx),
+      transfer: evaluate({ kind: "relationship", verb: "transfer" }, ctx),
+      changePermissions: evaluate(
+        { kind: "relationship", verb: "changePerms" },
+        ctx
+      ),
       permissions,
     };
   }, [roomData, currentUserId]);
-}
-
-/**
- * Returns a human-readable tooltip for why an action is disabled.
- */
-export function getPermissionDeniedTooltip(
-  level: PermissionLevel
-): string {
-  switch (level) {
-    case "owner":
-      return "Only the room owner can do this";
-    case "facilitators":
-      return "Only facilitators and the owner can do this";
-    default:
-      return "You don't have permission to do this";
-  }
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -4,7 +4,7 @@ import path from "path";
 export default defineConfig({
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "convex/**/*.test.ts"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Closes #197.

## What

Authorization now lives in **one pure module** reached through two thin adapters, replacing logic previously smeared across `requirePermission`, `canDoAction`, and five hand-composed predicates.

- **Permission decision** (`convex/permissions.ts`) — pure `evaluate(action, ctx): Decision` + `denialMessage(action, reason): string`. The single source of the role × level × target rule and its user-facing copy. No IO, no identity.
- **Permission guard** (`convex/model/auth.ts`) — `requireCan(ctx, roomId, spec, targetUserId?)` does the IO (loads room/memberships, computes owner absence, fetches the target), assembles the precise `Action`, calls `evaluate`, and throws the reason-derived message. Returns the loaded bundle so handlers stop re-fetching.
- **Frontend hook** (`src/hooks/usePermissions.ts`) — returns `Decision` objects from the same `evaluate`, dropping the duplicated lockdown branch and `getPermissionDeniedTooltip`.

All category and relationship call sites migrated (`rooms.ts`, `issues.ts`, `integrations.ts`, `roles.ts`, `users.ts`, `integrations/jira.ts`). Deleted: `requirePermission`, `roleSatisfiesLevel`, and the five `can*` predicates; `convex/model/permissions.ts` is now just the `isRoomOwnerAbsent` IO helper.

## Design

Lockdown (absent owner) is a **reason refinement, not a separate gate** — an absent owner already fails any owner-level role check, so `ownerAbsent` only flips the denial reason to `owner-absent`, never the outcome. See `docs/adr/0001-lockdown-is-a-denial-reason-not-a-gate.md` (included in this branch). Role check always precedes the target-rank check.

Identity rules (self-transfer, authoritative `ownerId`) intentionally stay in the calling handler, after the guard.

## Tests

Adds `convex/permissions.test.ts` — **38 tests**: full level × role × ownerAbsent truth table, per-verb target-rank vs insufficient-role precedence, lockdown refinement, and verb-specific denial copy. Broadens vitest `include` to `convex/**/*.test.ts`.

## Notes

- Denial copy is now unified through `denialMessage` (e.g. `"Only participants can be promoted to facilitator."`); all messages end with a period. The owner-absent lockdown string is preserved verbatim. No e2e spec asserts the old strings.
- Behaviour is preserved across all role/target/lockdown combinations; no permissiveness regression. One minor behaviour change: for `transfer`, target-membership existence is now checked before the role check (a non-owner passing a non-member target sees a different error) — acceptable since room members can already enumerate members.

## Verification

`npm run ts:check` clean · `npm run lint` clean · `npx vitest run` → 52 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)