### PR TITLE
feat(permissions): single-source denial copy via resolved decisions

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -26,6 +26,10 @@ _Avoid_: middleware, interceptor, auth wrapper
 Why a **Decision** was `allowed: false` — `insufficient-role`, `owner-absent`, or `target-rank` (acting on a target whose role forbids it). One reason maps to one message via a shared pure function used by both backend throws and frontend tooltips.
 _Avoid_: error code, status
 
+**Resolved decision**:
+A **Decision** whose **denial reason** has been resolved to its user-facing message: `{ allowed: true }` or `{ allowed: false, message }`. Produced by the pure `resolve(action, ctx)` — the one combiner of `evaluate` and `denialMessage` — so the copy is derived in exactly one place and a caller (a frontend control, a backend throw) reads the message without reconstructing the **Action** or re-deriving the reason. The bare **Decision** carries the reason for classification; the **resolved decision** carries the rendered copy for display. A control disables on `!allowed` and shows `message` as its denial tooltip; it never embeds its own copy.
+_Avoid_: gate (an outcome-changing branch, per [ADR-0001](docs/adr/0001-lockdown-is-a-denial-reason-not-a-gate.md)); resolved permission; can-do
+
 ### Roles & permissions
 
 **Role**:

--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -16,8 +16,7 @@ import { ActionCtx } from "../_generated/server";
 import { encryptToken, decryptToken } from "../lib/encryption";
 import {
   Action,
-  evaluate,
-  denialMessage,
+  resolve,
   getEffectivePermissions,
   getEffectiveRole,
 } from "../permissions";
@@ -892,13 +891,13 @@ export const verifyRoomAccess = internalQuery({
       category: "issueManagement",
       level: permissions.issueManagement,
     };
-    const decision = evaluate(action, {
+    const decision = resolve(action, {
       actorRole: getEffectiveRole(membership),
       permissions,
       ownerAbsent: await isRoomOwnerAbsent(ctx, room),
     });
     if (!decision.allowed) {
-      throw new Error(denialMessage(action, decision.reason));
+      throw new Error(decision.message);
     }
 
     return { userId: user._id };

--- a/convex/model/auth.ts
+++ b/convex/model/auth.ts
@@ -3,8 +3,7 @@ import { Id, Doc } from "../_generated/dataModel";
 import {
   PermissionCategory,
   Action,
-  evaluate,
-  denialMessage,
+  resolve,
   requiresOwnerLevel,
   getEffectivePermissions,
   getEffectiveRole,
@@ -184,9 +183,9 @@ export async function requireCan(
     ? await isRoomOwnerAbsent(ctx, room)
     : false;
 
-  const decision = evaluate(action, { actorRole, permissions, ownerAbsent });
+  const decision = resolve(action, { actorRole, permissions, ownerAbsent });
   if (!decision.allowed) {
-    throw new Error(denialMessage(action, decision.reason));
+    throw new Error(decision.message);
   }
 
   return { identity, user, membership, room, target };

--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -207,9 +207,12 @@ export type ResolvedDecision =
 /**
  * The shared allowed value `resolve` returns on every allow. A module-level
  * singleton so an allow that stays an allow keeps a stable identity across
- * recomputes (protects downstream memoization).
+ * recomputes (protects downstream memoization). Frozen so a stray mutation
+ * can't corrupt the value every allow across the backend and browser shares.
  */
-export const RESOLVED_ALLOWED: ResolvedDecision = { allowed: true };
+export const RESOLVED_ALLOWED: ResolvedDecision = Object.freeze({
+  allowed: true,
+});
 
 /**
  * The single combiner of `evaluate` and `denialMessage`: resolves an action to

--- a/convex/permissions.ts
+++ b/convex/permissions.ts
@@ -194,6 +194,39 @@ export function denialMessage(action: Action, reason: DenialReason): string {
 }
 
 /**
+ * A Decision whose denial reason has already been resolved to its user-facing
+ * message. The allowed branch carries no message (and `message?: never` makes
+ * `message` narrow to `string` after an `!allowed` check, so callers need no
+ * fallback). The machine-readable reason is intentionally NOT exposed — callers
+ * needing it call `evaluate` directly.
+ */
+export type ResolvedDecision =
+  | { allowed: true; message?: never }
+  | { allowed: false; message: string };
+
+/**
+ * The shared allowed value `resolve` returns on every allow. A module-level
+ * singleton so an allow that stays an allow keeps a stable identity across
+ * recomputes (protects downstream memoization).
+ */
+export const RESOLVED_ALLOWED: ResolvedDecision = { allowed: true };
+
+/**
+ * The single combiner of `evaluate` and `denialMessage`: resolves an action to
+ * an allowed value or a denied value carrying its user-facing message. Pure —
+ * no IO, no React — so it runs unchanged in a Convex function and the browser.
+ * Shared by the backend guard's throw, the Jira push, and the frontend tooltip.
+ */
+export function resolve(
+  action: Action,
+  ctx: DecisionContext
+): ResolvedDecision {
+  const decision = evaluate(action, ctx);
+  if (decision.allowed) return RESOLVED_ALLOWED;
+  return { allowed: false, message: denialMessage(action, decision.reason) };
+}
+
+/**
  * Builds a Decision from a role check, refining the denial reason to
  * "owner-absent" when an owner-level requirement fails under lockdown.
  */

--- a/convex/resolve.test.ts
+++ b/convex/resolve.test.ts
@@ -24,6 +24,12 @@ function ctx(over: Partial<DecisionContext> = {}): DecisionContext {
   };
 }
 
+describe("RESOLVED_ALLOWED — shared immutable singleton", () => {
+  it("is frozen so a consumer cannot corrupt the process-wide allow value", () => {
+    expect(Object.isFrozen(RESOLVED_ALLOWED)).toBe(true);
+  });
+});
+
 describe("resolve — allow", () => {
   it("returns the shared RESOLVED_ALLOWED value when the action is allowed", () => {
     const action: Action = {

--- a/convex/resolve.test.ts
+++ b/convex/resolve.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolve,
+  denialMessage,
+  RESOLVED_ALLOWED,
+  type Action,
+  type DecisionContext,
+  type RoomPermissions,
+} from "./permissions";
+
+const allEveryone: RoomPermissions = {
+  revealCards: "everyone",
+  gameFlow: "everyone",
+  issueManagement: "everyone",
+  roomSettings: "everyone",
+};
+
+function ctx(over: Partial<DecisionContext> = {}): DecisionContext {
+  return {
+    actorRole: "participant",
+    permissions: allEveryone,
+    ownerAbsent: false,
+    ...over,
+  };
+}
+
+describe("resolve — allow", () => {
+  it("returns the shared RESOLVED_ALLOWED value when the action is allowed", () => {
+    const action: Action = {
+      kind: "category",
+      category: "revealCards",
+      level: "everyone",
+    };
+    expect(resolve(action, ctx())).toBe(RESOLVED_ALLOWED);
+  });
+});
+
+describe("resolve — deny", () => {
+  it("carries the insufficient-role message for a category denied by role", () => {
+    const action: Action = {
+      kind: "category",
+      category: "revealCards",
+      level: "facilitators",
+    };
+    expect(resolve(action, ctx({ actorRole: "participant" }))).toEqual({
+      allowed: false,
+      message: denialMessage(action, "insufficient-role"),
+    });
+  });
+
+  it("carries the owner-absent message for an owner-level category under lockdown", () => {
+    const action: Action = {
+      kind: "category",
+      category: "roomSettings",
+      level: "owner",
+    };
+    expect(
+      resolve(action, ctx({ actorRole: "facilitator", ownerAbsent: true }))
+    ).toEqual({
+      allowed: false,
+      message: denialMessage(action, "owner-absent"),
+    });
+  });
+
+  it("carries the target-rank message for a relationship action denied by target", () => {
+    const action: Action = {
+      kind: "relationship",
+      verb: "remove",
+      targetRole: "facilitator",
+    };
+    expect(resolve(action, ctx({ actorRole: "facilitator" }))).toEqual({
+      allowed: false,
+      message: denialMessage(action, "target-rank"),
+    });
+  });
+
+  it("always produces a non-empty message on deny", () => {
+    const action: Action = { kind: "relationship", verb: "transfer" };
+    const rd = resolve(action, ctx({ actorRole: "participant" }));
+    expect(rd.allowed).toBe(false);
+    if (!rd.allowed) expect(rd.message.length).toBeGreaterThan(0);
+  });
+});

--- a/src/components/room/hooks/useCanvasNodes.ts
+++ b/src/components/room/hooks/useCanvasNodes.ts
@@ -8,7 +8,11 @@ import { useMemo, useRef, useEffect } from "react";
 import { DEMO_VIEWER_ID, type CustomNodeType } from "../types";
 import type { RoomWithRelatedData, SanitizedVote } from "@/convex/model/rooms";
 import type { RoomUserData } from "@/convex/model/users";
-import type { MemberRole } from "@/convex/permissions";
+import {
+  type MemberRole,
+  type ResolvedDecision,
+  RESOLVED_ALLOWED,
+} from "@/convex/permissions";
 import { DEFAULT_SCALE } from "@/convex/scales";
 import { useDemoSimulation } from "../demo/DemoSimulationProvider";
 
@@ -23,9 +27,9 @@ interface UseCanvasNodesProps {
   currentUserId?: string;
   selectedCardValue: string | null;
   isDemoMode?: boolean;
-  canRevealCards?: boolean;
-  canControlGameFlow?: boolean;
-  canChangeRoomSettings?: boolean;
+  canRevealCards?: ResolvedDecision;
+  canControlGameFlow?: ResolvedDecision;
+  canChangeRoomSettings?: ResolvedDecision;
   canRemoveTarget?: (targetRole: MemberRole) => boolean;
   onRevealCards?: () => void;
   onResetGame?: () => void;
@@ -50,9 +54,9 @@ export function useCanvasNodes({
   currentUserId,
   selectedCardValue,
   isDemoMode = false,
-  canRevealCards = true,
-  canControlGameFlow = true,
-  canChangeRoomSettings = true,
+  canRevealCards = RESOLVED_ALLOWED,
+  canControlGameFlow = RESOLVED_ALLOWED,
+  canChangeRoomSettings = RESOLVED_ALLOWED,
   canRemoveTarget,
   onRevealCards,
   onResetGame,

--- a/src/components/room/issue-item.tsx
+++ b/src/components/room/issue-item.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
+import { type ResolvedDecision, RESOLVED_ALLOWED } from "@/convex/permissions";
 
 interface IssueLink {
   _id: string;
@@ -29,8 +30,8 @@ interface IssueItemProps {
   onUpdateEstimate: (issueId: Id<"issues">, estimate: string) => void;
   onDelete: (issueId: Id<"issues">) => void;
   isDemoMode?: boolean;
-  canManageIssues?: boolean;
-  canControlGameFlow?: boolean;
+  canManageIssues?: ResolvedDecision;
+  canControlGameFlow?: ResolvedDecision;
   issueLink?: IssueLink;
 }
 
@@ -42,10 +43,17 @@ export const IssueItem: FC<IssueItemProps> = ({
   onUpdateEstimate,
   onDelete,
   isDemoMode = false,
-  canManageIssues = true,
-  canControlGameFlow = true,
+  canManageIssues: canManageIssuesDecision = RESOLVED_ALLOWED,
+  canControlGameFlow: canControlGameFlowDecision = RESOLVED_ALLOWED,
   issueLink,
 }) => {
+  // Resolved decisions in, booleans out for the existing gating logic; the
+  // denial copy comes from the resolved decision's message (single source).
+  const canManageIssues = canManageIssuesDecision.allowed;
+  const canControlGameFlow = canControlGameFlowDecision.allowed;
+  const manageIssuesDenial = canManageIssuesDecision.allowed
+    ? undefined
+    : canManageIssuesDecision.message;
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [isEditingEstimate, setIsEditingEstimate] = useState(false);
   const [editedTitle, setEditedTitle] = useState(issue.title);
@@ -212,7 +220,7 @@ export const IssueItem: FC<IssueItemProps> = ({
               size="icon-sm"
               disabled={true}
               className="opacity-40 cursor-not-allowed text-gray-400"
-              title="You don't have permission to manage issues"
+              title={manageIssuesDenial}
             >
               <MoreHorizontal className="h-4 w-4" />
               <span className="sr-only">Issue actions unavailable</span>

--- a/src/components/room/issues-panel.tsx
+++ b/src/components/room/issues-panel.tsx
@@ -29,6 +29,7 @@ import { JiraImportModal } from "./jira-import-modal";
 import { exportIssuesToCSV } from "@/utils/export-issues-csv";
 import { exportIssuesToJSON } from "@/utils/export-issues-json";
 import type { Id } from "@/convex/_generated/dataModel";
+import { type ResolvedDecision, RESOLVED_ALLOWED } from "@/convex/permissions";
 
 interface IssuesPanelProps {
   roomId: Id<"rooms">;
@@ -36,8 +37,8 @@ interface IssuesPanelProps {
   isOpen: boolean;
   onClose: () => void;
   isDemoMode?: boolean;
-  canManageIssues?: boolean;
-  canControlGameFlow?: boolean;
+  canManageIssues?: ResolvedDecision;
+  canControlGameFlow?: ResolvedDecision;
 }
 
 export const IssuesPanel: FC<IssuesPanelProps> = ({
@@ -46,9 +47,14 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
   isOpen,
   onClose,
   isDemoMode = false,
-  canManageIssues = true,
-  canControlGameFlow = true,
+  canManageIssues: canManageIssuesDecision = RESOLVED_ALLOWED,
+  canControlGameFlow: canControlGameFlowDecision = RESOLVED_ALLOWED,
 }) => {
+  // Resolved decisions in; booleans for gating and a message for denial copy.
+  const canManageIssues = canManageIssuesDecision.allowed;
+  const manageIssuesDenial = canManageIssuesDecision.allowed
+    ? undefined
+    : canManageIssuesDecision.message;
   const { toast } = useToast();
 
   const [newIssueTitle, setNewIssueTitle] = useState("");
@@ -348,7 +354,7 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
                     placeholder="Add new issue..."
                     className="h-10 w-full pr-12 text-sm bg-white dark:bg-surface-2 border-gray-200/80 dark:border-border rounded-lg shadow-sm focus-visible:ring-1 focus-visible:ring-blue-500 focus-visible:border-blue-500 transition-all placeholder:text-gray-400"
                     disabled={isAddingIssue || !canManageIssues}
-                    title={!canManageIssues ? "You don't have permission to manage issues" : undefined}
+                    title={manageIssuesDenial}
                   />
                   {newIssueTitle.trim() && (
                     <div className="absolute inset-y-0 right-1 flex items-center">
@@ -389,8 +395,8 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
                         onUpdateEstimate={handleUpdateEstimate}
                         onDelete={handleDeleteIssue}
                         isDemoMode={isDemoMode}
-                        canManageIssues={canManageIssues}
-                        canControlGameFlow={canControlGameFlow}
+                        canManageIssues={canManageIssuesDecision}
+                        canControlGameFlow={canControlGameFlowDecision}
                         issueLink={issueLinksMap?.[issue._id] ?? undefined}
                       />
                     ))}

--- a/src/components/room/nodes/SessionNode.tsx
+++ b/src/components/room/nodes/SessionNode.tsx
@@ -13,6 +13,7 @@ import {
 
 import { cn } from "@/lib/utils";
 import { COUNTDOWN_DURATION_MS } from "@/convex/constants";
+import { permissionProps } from "@/hooks/usePermissions";
 
 import type { SessionNodeType } from "../types";
 
@@ -27,15 +28,23 @@ export const SessionNode = memo(
       autoCompleteVoting,
       autoRevealCountdownStartedAt,
       currentIssue,
-      canRevealCards,
-      canControlGameFlow,
-      canChangeRoomSettings,
+      canRevealCards: canRevealCardsDecision,
+      canControlGameFlow: canControlGameFlowDecision,
+      canChangeRoomSettings: canChangeRoomSettingsDecision,
       onRevealCards,
       onResetGame,
       onToggleAutoComplete,
       onCancelAutoReveal,
       onOpenIssuesPanel,
     } = data;
+
+    // Resolved decisions in; booleans drive each control's own onClick,
+    // className, and non-permission disabled state. The denial copy and the
+    // disabled-when-denied state are layered on via permissionProps, spread
+    // after each button's own attributes so they compose rather than replace.
+    const canRevealCards = canRevealCardsDecision.allowed;
+    const canControlGameFlow = canControlGameFlowDecision.allowed;
+    const canChangeRoomSettings = canChangeRoomSettingsDecision.allowed;
 
     const isActive = !isVotingComplete;
 
@@ -188,14 +197,12 @@ export const SessionNode = memo(
                   : "bg-gray-100 dark:bg-surface-1 text-gray-500 dark:text-gray-400 hover:bg-gray-200 dark:hover:bg-surface-3",
             )}
             aria-label={
-              !canChangeRoomSettings
-                ? "You don't have permission to change auto-reveal"
-                : autoCompleteVoting
-                  ? "Disable auto-reveal when all vote"
-                  : "Enable auto-reveal when all vote"
+              autoCompleteVoting
+                ? "Disable auto-reveal when all vote"
+                : "Enable auto-reveal when all vote"
             }
             aria-pressed={autoCompleteVoting}
-            title={!canChangeRoomSettings ? "You don't have permission to change this setting" : undefined}
+            {...permissionProps(canChangeRoomSettingsDecision)}
           >
             <Zap
               className={cn(
@@ -264,13 +271,11 @@ export const SessionNode = memo(
                     : "bg-emerald-500 hover:bg-emerald-600 active:bg-emerald-700 text-white shadow-sm hover:shadow-md",
                 )}
                 aria-label={
-                  !canControlGameFlow
-                    ? "You don't have permission to start a new round"
-                    : resetCooldown > 0
-                      ? `Please wait ${resetCooldown} seconds`
-                      : "Start a new voting round"
+                  resetCooldown > 0
+                    ? `Please wait ${resetCooldown} seconds`
+                    : "Start a new voting round"
                 }
-                title={!canControlGameFlow ? "You don't have permission to start a new round" : undefined}
+                {...permissionProps(canControlGameFlowDecision)}
               >
                 <RotateCcw
                   className={cn("h-5 w-5", resetCooldown > 0 && "animate-spin")}
@@ -292,11 +297,8 @@ export const SessionNode = memo(
                     ? "bg-amber-500 hover:bg-amber-600 active:bg-amber-700 text-white shadow-sm hover:shadow-md animate-pulse"
                     : "bg-gray-100 dark:bg-surface-2 text-gray-400 dark:text-gray-500 cursor-not-allowed",
                 )}
-                aria-label={
-                  canRevealCards
-                    ? `Auto-revealing in ${countdownSeconds} seconds. Tap to cancel.`
-                    : "You don't have permission to cancel auto-reveal"
-                }
+                aria-label={`Auto-revealing in ${countdownSeconds} seconds. Tap to cancel.`}
+                {...permissionProps(canRevealCardsDecision)}
               >
                 <span className="flex items-center gap-2">
                   <span className="font-mono text-lg font-bold tabular-nums">
@@ -318,13 +320,9 @@ export const SessionNode = memo(
                     : "bg-blue-500 hover:bg-blue-600 active:bg-blue-700 text-white shadow-sm hover:shadow-md",
                 )}
                 aria-label={
-                  !canRevealCards
-                    ? "You don't have permission to reveal votes"
-                    : hasVotes
-                      ? "Reveal all votes"
-                      : "Waiting for votes to reveal"
+                  hasVotes ? "Reveal all votes" : "Waiting for votes to reveal"
                 }
-                title={!canRevealCards ? "You don't have permission to reveal votes" : undefined}
+                {...permissionProps(canRevealCardsDecision)}
               >
                 <Play className="h-5 w-5" />
                 <span>

--- a/src/components/room/room-canvas.tsx
+++ b/src/components/room/room-canvas.tsx
@@ -331,9 +331,9 @@ function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedd
     currentUserId,
     selectedCardValue,
     isDemoMode,
-    canRevealCards: permissions.revealCards.allowed,
-    canControlGameFlow: permissions.gameFlow.allowed,
-    canChangeRoomSettings: permissions.roomSettings.allowed,
+    canRevealCards: permissions.revealCards,
+    canControlGameFlow: permissions.gameFlow,
+    canChangeRoomSettings: permissions.roomSettings,
     canRemoveTarget,
     onRevealCards: handleRevealCards,
     onResetGame: handleResetGame,
@@ -581,8 +581,8 @@ function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedd
         isOpen={isIssuesPanelOpen}
         onClose={() => setIsIssuesPanelOpen(false)}
         isDemoMode={isDemoMode}
-        canManageIssues={permissions.issueManagement.allowed}
-        canControlGameFlow={permissions.gameFlow.allowed}
+        canManageIssues={permissions.issueManagement}
+        canControlGameFlow={permissions.gameFlow}
       />
     </div>
   );

--- a/src/components/room/room-settings-panel.tsx
+++ b/src/components/room/room-settings-panel.tsx
@@ -55,7 +55,6 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { usePermissions } from "@/hooks/usePermissions";
-import { denialMessage } from "@/convex/permissions";
 import { IntegrationSettingsSection } from "./integration-settings";
 import { api } from "@/convex/_generated/api";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -282,17 +281,10 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
 
   const currentPermissions = getEffectivePermissions(roomData.room);
 
-  // Tooltip for the room-name controls, routed through the shared denial copy.
+  // Tooltip for the room-name controls, read straight from the resolved decision.
   const roomSettingsTooltip = perms.roomSettings.allowed
     ? undefined
-    : denialMessage(
-        {
-          kind: "category",
-          category: "roomSettings",
-          level: currentPermissions.roomSettings,
-        },
-        perms.roomSettings.reason
-      );
+    : perms.roomSettings.message;
 
   return (
     <>
@@ -584,7 +576,8 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                   sortedUsers.map((u) => {
                     const userRole = u.role ?? "participant";
                     const isMe = u._id === currentUserId;
-                    const canRemoveThis = perms.removeTarget(userRole).allowed;
+                    const removeDecision = perms.removeTarget(userRole);
+                    const canRemoveThis = removeDecision.allowed;
                     const canPromoteThis = perms.promoteTarget(userRole).allowed;
                     const canDemoteThis = perms.demoteTarget(userRole).allowed;
                     const canTransfer = perms.transfer.allowed;
@@ -720,7 +713,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                                   aria-label={
                                     canRemoveThis
                                       ? `Remove ${u.name}`
-                                      : "You don't have permission to remove this user"
+                                      : removeDecision.message
                                   }
                                 >
                                   <UserMinus className="h-4 w-4" />
@@ -728,9 +721,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                               } />
                               <TooltipContent>
                                 <p>
-                                  {canRemoveThis
-                                    ? "Remove user"
-                                    : "Only facilitators and the owner can remove members"}
+                                  {canRemoveThis ? "Remove user" : removeDecision.message}
                                 </p>
                               </TooltipContent>
                             </Tooltip>

--- a/src/components/room/types.ts
+++ b/src/components/room/types.ts
@@ -2,7 +2,7 @@ import { Node } from "@xyflow/react";
 import type { Id } from "@/convex/_generated/dataModel";
 import type { SanitizedVote } from "@/convex/model/rooms";
 import type { RoomUserData } from "@/convex/model/users";
-import type { MemberRole } from "@/convex/permissions";
+import type { MemberRole, ResolvedDecision } from "@/convex/permissions";
 
 // Demo mode constants
 export const DEMO_VIEWER_ID = "demo-viewer" as const;
@@ -40,9 +40,9 @@ export type SessionNodeData = {
     id: Id<"issues">;
     title: string;
   } | null;
-  canRevealCards: boolean;
-  canControlGameFlow: boolean;
-  canChangeRoomSettings: boolean;
+  canRevealCards: ResolvedDecision;
+  canControlGameFlow: ResolvedDecision;
+  canChangeRoomSettings: ResolvedDecision;
   onRevealCards?: () => void;
   onResetGame?: () => void;
   onToggleAutoComplete?: () => void;

--- a/src/hooks/permissionProps.test.ts
+++ b/src/hooks/permissionProps.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { permissionProps } from "./usePermissions";
+import { RESOLVED_ALLOWED } from "@/convex/permissions";
+
+describe("permissionProps — allowed", () => {
+  it("returns an empty overlay so the control keeps its own state and label", () => {
+    expect(permissionProps(RESOLVED_ALLOWED)).toEqual({});
+  });
+
+  it("does not emit disabled:false (would re-enable a cooldown/no-votes control)", () => {
+    expect(permissionProps(RESOLVED_ALLOWED)).not.toHaveProperty("disabled");
+  });
+});
+
+describe("permissionProps — denied", () => {
+  const message = "Only facilitators and the owner can do this.";
+
+  it("disables and labels the control with the denial message", () => {
+    expect(permissionProps({ allowed: false, message })).toEqual({
+      disabled: true,
+      title: message,
+      "aria-label": message,
+    });
+  });
+
+  it("uses the same message for title and aria-label", () => {
+    const overlay = permissionProps({ allowed: false, message });
+    expect(overlay).toHaveProperty("title", message);
+    expect(overlay).toHaveProperty("aria-label", message);
+  });
+});

--- a/src/hooks/usePermissions.test.ts
+++ b/src/hooks/usePermissions.test.ts
@@ -70,4 +70,39 @@ describe("computePermissions — optimistic defaults before data loads", () => {
     expect(result.transfer.allowed).toBe(false);
     expect(result.removeTarget("participant").allowed).toBe(false);
   });
+
+  it("carries each verb's own denial copy — owner-only verbs read the owner-only message", () => {
+    const result = computePermissions(null, undefined);
+    const ownerOnly = denialMessage(
+      { kind: "relationship", verb: "transfer" },
+      "insufficient-role"
+    );
+
+    expect(result.transfer).toEqual({ allowed: false, message: ownerOnly });
+    expect(result.changePermissions).toEqual({
+      allowed: false,
+      message: ownerOnly,
+    });
+    expect(result.demoteTarget("facilitator")).toEqual({
+      allowed: false,
+      message: ownerOnly,
+    });
+  });
+
+  it("carries the facilitator-level message for verbs allowed to facilitators", () => {
+    const result = computePermissions(null, undefined);
+    const facilitatorLevel = denialMessage(
+      { kind: "relationship", verb: "promote", targetRole: "participant" },
+      "insufficient-role"
+    );
+
+    expect(result.removeTarget("participant")).toEqual({
+      allowed: false,
+      message: facilitatorLevel,
+    });
+    expect(result.promoteTarget("participant")).toEqual({
+      allowed: false,
+      message: facilitatorLevel,
+    });
+  });
 });

--- a/src/hooks/usePermissions.test.ts
+++ b/src/hooks/usePermissions.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { computePermissions } from "./usePermissions";
+import type { RoomWithRelatedData } from "@/convex/model/rooms";
+import {
+  denialMessage,
+  RESOLVED_ALLOWED,
+  type MemberRole,
+  type RoomPermissions,
+} from "@/convex/permissions";
+
+const allEveryone: RoomPermissions = {
+  revealCards: "everyone",
+  gameFlow: "everyone",
+  issueManagement: "everyone",
+  roomSettings: "everyone",
+};
+
+/** Minimal RoomWithRelatedData fixture — only the fields the mapping reads. */
+function roomData(opts: {
+  role?: MemberRole;
+  permissions?: RoomPermissions;
+  isOwnerAbsent?: boolean;
+}): RoomWithRelatedData {
+  return {
+    room: { permissions: opts.permissions ?? allEveryone },
+    users: [{ _id: "u1", role: opts.role ?? "participant" }],
+    isOwnerAbsent: opts.isOwnerAbsent ?? false,
+  } as unknown as RoomWithRelatedData;
+}
+
+describe("computePermissions — resolved decisions", () => {
+  it("carries the resolved message for a category denied by role", () => {
+    const result = computePermissions(
+      roomData({ role: "participant", permissions: { ...allEveryone, revealCards: "facilitators" } }),
+      "u1"
+    );
+    expect(result.revealCards).toEqual({
+      allowed: false,
+      message: denialMessage(
+        { kind: "category", category: "revealCards", level: "facilitators" },
+        "insufficient-role"
+      ),
+    });
+  });
+
+  it("returns the shared RESOLVED_ALLOWED identity for an allowed category", () => {
+    const result = computePermissions(roomData({ role: "participant" }), "u1");
+    expect(result.gameFlow).toBe(RESOLVED_ALLOWED);
+  });
+
+  it("builds the right action per field (owner-level transfer denied for a facilitator)", () => {
+    const result = computePermissions(roomData({ role: "facilitator" }), "u1");
+    expect(result.transfer).toEqual({
+      allowed: false,
+      message: denialMessage(
+        { kind: "relationship", verb: "transfer" },
+        "insufficient-role"
+      ),
+    });
+  });
+});
+
+describe("computePermissions — optimistic defaults before data loads", () => {
+  it("opens categories and closes relationship actions", () => {
+    const result = computePermissions(null, undefined);
+    expect(result.revealCards).toBe(RESOLVED_ALLOWED);
+    expect(result.gameFlow).toBe(RESOLVED_ALLOWED);
+    expect(result.issueManagement).toBe(RESOLVED_ALLOWED);
+    expect(result.roomSettings).toBe(RESOLVED_ALLOWED);
+    expect(result.transfer.allowed).toBe(false);
+    expect(result.removeTarget("participant").allowed).toBe(false);
+  });
+});

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -6,11 +6,11 @@ import {
   type RoomPermissions,
   type ResolvedDecision,
   type PermissionCategory,
+  type DecisionContext,
   DEFAULT_PERMISSIONS,
   RESOLVED_ALLOWED,
   getEffectivePermissions,
   resolve,
-  denialMessage,
 } from "@/convex/permissions";
 
 /**
@@ -53,17 +53,18 @@ export interface UsePermissionsReturn {
 }
 
 /**
- * Fixed denied resolved decision for the optimistic-defaults branch's
- * relationship actions (before room data loads). Relationship controls are
- * hidden when denied, so the copy is rarely shown; it derives from
- * `denialMessage` rather than embedding a literal.
+ * Decision context for the optimistic-defaults branch (before room data loads):
+ * a participant actor with default permissions and no lockdown. Every
+ * relationship action is denied for a participant, and routing each verb
+ * through `resolve` with this context keeps the denial copy single-sourced —
+ * owner-only verbs (transfer/changePerms/demote) read "Only the owner…" and
+ * facilitator-level verbs (remove/promote) read "Only facilitators and the
+ * owner…", rather than one blanket message standing in for all five.
  */
-const RESOLVED_DENIED: ResolvedDecision = {
-  allowed: false,
-  message: denialMessage(
-    { kind: "relationship", verb: "promote", targetRole: "participant" },
-    "insufficient-role"
-  ),
+const OPTIMISTIC_CTX: DecisionContext = {
+  actorRole: "participant",
+  permissions: DEFAULT_PERMISSIONS,
+  ownerAbsent: false,
 };
 
 /**
@@ -87,11 +88,17 @@ export function computePermissions(
       gameFlow: RESOLVED_ALLOWED,
       issueManagement: RESOLVED_ALLOWED,
       roomSettings: RESOLVED_ALLOWED,
-      removeTarget: () => RESOLVED_DENIED,
-      promoteTarget: () => RESOLVED_DENIED,
-      demoteTarget: () => RESOLVED_DENIED,
-      transfer: RESOLVED_DENIED,
-      changePermissions: RESOLVED_DENIED,
+      removeTarget: (targetRole) =>
+        resolve({ kind: "relationship", verb: "remove", targetRole }, OPTIMISTIC_CTX),
+      promoteTarget: (targetRole) =>
+        resolve({ kind: "relationship", verb: "promote", targetRole }, OPTIMISTIC_CTX),
+      demoteTarget: (targetRole) =>
+        resolve({ kind: "relationship", verb: "demote", targetRole }, OPTIMISTIC_CTX),
+      transfer: resolve({ kind: "relationship", verb: "transfer" }, OPTIMISTIC_CTX),
+      changePermissions: resolve(
+        { kind: "relationship", verb: "changePerms" },
+        OPTIMISTIC_CTX
+      ),
       permissions: DEFAULT_PERMISSIONS,
     };
   }

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -4,95 +4,142 @@ import type { Id } from "@/convex/_generated/dataModel";
 import {
   type MemberRole,
   type RoomPermissions,
-  type Decision,
+  type ResolvedDecision,
   type PermissionCategory,
   DEFAULT_PERMISSIONS,
+  RESOLVED_ALLOWED,
   getEffectivePermissions,
-  evaluate,
+  resolve,
+  denialMessage,
 } from "@/convex/permissions";
+
+/**
+ * The denial overlay a control spreads on top of its own attributes. Allowed
+ * yields an empty overlay (the control keeps its own disabled state and label);
+ * denied forces `disabled` and overrides the accessible label with the denial
+ * copy. Always spread it AFTER the control's own attributes.
+ */
+export type PermissionOverlay =
+  | Record<string, never>
+  | { disabled: true; title: string; "aria-label": string };
+
+/**
+ * Maps a ResolvedDecision to the denial overlay a control composes by spreading
+ * it last. Pure. Owns denial-attribute wiring only — `className` and
+ * disabled-styling stay in each control because they vary presentationally.
+ */
+export function permissionProps(rd: ResolvedDecision): PermissionOverlay {
+  if (rd.allowed) return {};
+  return { disabled: true, title: rd.message, "aria-label": rd.message };
+}
 
 export interface UsePermissionsReturn {
   role: MemberRole;
   isOwner: boolean;
   isFacilitator: boolean;
   isOwnerAbsent: boolean;
-  /** Per-category permission decisions. Consumers read `.allowed` / `.reason`. */
-  revealCards: Decision;
-  gameFlow: Decision;
-  issueManagement: Decision;
-  roomSettings: Decision;
+  /** Per-category resolved decisions. Consumers read `.allowed` / `.message`. */
+  revealCards: ResolvedDecision;
+  gameFlow: ResolvedDecision;
+  issueManagement: ResolvedDecision;
+  roomSettings: ResolvedDecision;
   /** Per-target relationship decisions — the target's role refines the verdict. */
-  removeTarget: (targetRole: MemberRole) => Decision;
-  promoteTarget: (targetRole: MemberRole) => Decision;
-  demoteTarget: (targetRole: MemberRole) => Decision;
-  transfer: Decision;
-  changePermissions: Decision;
+  removeTarget: (targetRole: MemberRole) => ResolvedDecision;
+  promoteTarget: (targetRole: MemberRole) => ResolvedDecision;
+  demoteTarget: (targetRole: MemberRole) => ResolvedDecision;
+  transfer: ResolvedDecision;
+  changePermissions: ResolvedDecision;
   permissions: RoomPermissions;
 }
 
-const ALLOWED: Decision = { allowed: true };
-const DENIED: Decision = { allowed: false, reason: "insufficient-role" };
+/**
+ * Fixed denied resolved decision for the optimistic-defaults branch's
+ * relationship actions (before room data loads). Relationship controls are
+ * hidden when denied, so the copy is rarely shown; it derives from
+ * `denialMessage` rather than embedding a literal.
+ */
+const RESOLVED_DENIED: ResolvedDecision = {
+  allowed: false,
+  message: denialMessage(
+    { kind: "relationship", verb: "promote", targetRole: "participant" },
+    "insufficient-role"
+  ),
+};
 
 /**
- * Maps room data to permission Decisions through the shared `evaluate` decision.
- * Pure computation — no queries or mutations, and no duplicated lockdown logic.
+ * Maps room data to permission resolved decisions through the shared `resolve`
+ * combiner. Pure computation — no queries, mutations, React, or duplicated
+ * lockdown logic — so it is unit-testable directly without rendering.
+ */
+export function computePermissions(
+  roomData: RoomWithRelatedData | null | undefined,
+  currentUserId: Id<"users"> | string | undefined
+): UsePermissionsReturn {
+  if (!roomData || !currentUserId) {
+    // Optimistic defaults before data loads: configurable actions open,
+    // relationship actions closed (mirrors prior behaviour).
+    return {
+      role: "participant" as MemberRole,
+      isOwner: false,
+      isFacilitator: false,
+      isOwnerAbsent: false,
+      revealCards: RESOLVED_ALLOWED,
+      gameFlow: RESOLVED_ALLOWED,
+      issueManagement: RESOLVED_ALLOWED,
+      roomSettings: RESOLVED_ALLOWED,
+      removeTarget: () => RESOLVED_DENIED,
+      promoteTarget: () => RESOLVED_DENIED,
+      demoteTarget: () => RESOLVED_DENIED,
+      transfer: RESOLVED_DENIED,
+      changePermissions: RESOLVED_DENIED,
+      permissions: DEFAULT_PERMISSIONS,
+    };
+  }
+
+  const currentUser = roomData.users.find((u) => u._id === currentUserId);
+  const role: MemberRole = currentUser?.role ?? "participant";
+  const permissions = getEffectivePermissions(roomData.room);
+  const ownerAbsent = roomData.isOwnerAbsent;
+  const ctx = { actorRole: role, permissions, ownerAbsent };
+
+  const category = (c: PermissionCategory): ResolvedDecision =>
+    resolve({ kind: "category", category: c, level: permissions[c] }, ctx);
+
+  return {
+    role,
+    isOwner: role === "owner",
+    isFacilitator: role === "facilitator",
+    isOwnerAbsent: ownerAbsent,
+    revealCards: category("revealCards"),
+    gameFlow: category("gameFlow"),
+    issueManagement: category("issueManagement"),
+    roomSettings: category("roomSettings"),
+    removeTarget: (targetRole) =>
+      resolve({ kind: "relationship", verb: "remove", targetRole }, ctx),
+    promoteTarget: (targetRole) =>
+      resolve({ kind: "relationship", verb: "promote", targetRole }, ctx),
+    demoteTarget: (targetRole) =>
+      resolve({ kind: "relationship", verb: "demote", targetRole }, ctx),
+    transfer: resolve({ kind: "relationship", verb: "transfer" }, ctx),
+    changePermissions: resolve(
+      { kind: "relationship", verb: "changePerms" },
+      ctx
+    ),
+    permissions,
+  };
+}
+
+/**
+ * Thin `useMemo` wrapper over `computePermissions`, memoized on its inputs so
+ * every resolved decision keeps a stable identity across renders until
+ * `roomData`/`currentUserId` change — protecting the canvas memoization.
  */
 export function usePermissions(
   roomData: RoomWithRelatedData | null | undefined,
   currentUserId: Id<"users"> | string | undefined
 ): UsePermissionsReturn {
-  return useMemo(() => {
-    if (!roomData || !currentUserId) {
-      // Optimistic defaults before data loads: configurable actions open,
-      // relationship actions closed (mirrors prior behaviour).
-      return {
-        role: "participant" as MemberRole,
-        isOwner: false,
-        isFacilitator: false,
-        isOwnerAbsent: false,
-        revealCards: ALLOWED,
-        gameFlow: ALLOWED,
-        issueManagement: ALLOWED,
-        roomSettings: ALLOWED,
-        removeTarget: () => DENIED,
-        promoteTarget: () => DENIED,
-        demoteTarget: () => DENIED,
-        transfer: DENIED,
-        changePermissions: DENIED,
-        permissions: DEFAULT_PERMISSIONS,
-      };
-    }
-
-    const currentUser = roomData.users.find((u) => u._id === currentUserId);
-    const role: MemberRole = currentUser?.role ?? "participant";
-    const permissions = getEffectivePermissions(roomData.room);
-    const ownerAbsent = roomData.isOwnerAbsent;
-    const ctx = { actorRole: role, permissions, ownerAbsent };
-
-    const category = (c: PermissionCategory): Decision =>
-      evaluate({ kind: "category", category: c, level: permissions[c] }, ctx);
-
-    return {
-      role,
-      isOwner: role === "owner",
-      isFacilitator: role === "facilitator",
-      isOwnerAbsent: ownerAbsent,
-      revealCards: category("revealCards"),
-      gameFlow: category("gameFlow"),
-      issueManagement: category("issueManagement"),
-      roomSettings: category("roomSettings"),
-      removeTarget: (targetRole) =>
-        evaluate({ kind: "relationship", verb: "remove", targetRole }, ctx),
-      promoteTarget: (targetRole) =>
-        evaluate({ kind: "relationship", verb: "promote", targetRole }, ctx),
-      demoteTarget: (targetRole) =>
-        evaluate({ kind: "relationship", verb: "demote", targetRole }, ctx),
-      transfer: evaluate({ kind: "relationship", verb: "transfer" }, ctx),
-      changePermissions: evaluate(
-        { kind: "relationship", verb: "changePerms" },
-        ctx
-      ),
-      permissions,
-    };
-  }, [roomData, currentUserId]);
+  return useMemo(
+    () => computePermissions(roomData, currentUserId),
+    [roomData, currentUserId]
+  );
 }


### PR DESCRIPTION
Closes #210.

## Problem

Denial copy for gated controls was re-invented at each control (SessionNode carried 5 literal strings; issues-panel/issue-item/room-settings-panel had their own). `usePermissions` produced a `Decision`, but `room-canvas` flattened each to a bare `.allowed` boolean before it reached the controls — so the **denial reason** never arrived and controls couldn't derive the canonical copy. This silently broke the CONTEXT.md invariant: *one reason maps to one message via a shared pure function used by both backend throws and frontend tooltips.*

## Solution

Introduce a **resolved decision** — a `Decision` whose reason is already resolved to its user-facing message (`{ allowed: true } | { allowed: false, message }`) — produced by one new pure combiner `resolve(action, ctx)`, living beside `evaluate` and `denialMessage`. Net: denial copy is derived in exactly one place, shared by the backend throw, the Jira push, and every frontend tooltip.

## Changes

**Pure layer (TDD, red→green per behavior)**
- `convex/permissions.ts`: add `ResolvedDecision`, `RESOLVED_ALLOWED`, `resolve` — purely additive (`evaluate`/`denialMessage` unchanged).
- `usePermissions`: returns resolved decisions via an extracted pure `computePermissions` (hook is now a thin `useMemo`); adds `permissionProps` — a denial overlay (allowed → `{}`; denied → `{ disabled, title, "aria-label" }`) composed by spreading **after** a control's own attributes.

**Backend**
- `requireCan` (`model/auth.ts`) and `verifyRoomAccess` (`integrations/jira.ts`) route their throws through `resolve`. Action-building and the `requiresOwnerLevel`-gated owner-absence read are preserved (ADR-0001 intact — lockdown stays a reason refinement, never a gate).

**Wiring**
- `SessionNodeData` carries resolved decisions; `room-canvas` stops flattening to `.allowed`.
- `SessionNode`, `room-settings-panel`, `issues-panel`, `issue-item` drop hardcoded denial strings and read `message`. Non-permission disabled states (reset cooldown on New Round, no-votes on Reveal) are preserved by **composing** the overlay rather than replacing the control's own `disabled`.

## Accepted behavioral change

Denial tooltips shift from action-specific copy ("…to reveal votes") to the role-generic copy `denialMessage` already returns ("Only facilitators and the owner can do this"; the owner-absent lockdown banner). This is the single-source behavior the invariant asks for and gains correct lockdown wording. **Gating conditions are unchanged.** No schema, API, or migration changes.

## Note

The visible-disabled **remove** control renders denial copy through a Base UI `<Tooltip>` + `aria-label` (not a native `title`), so it reads `.message` directly instead of spreading `permissionProps` — same single-source outcome, avoiding a competing native tooltip. `permissionProps` is used for the native-`title` SessionNode buttons as intended.

## Testing

- New unit tests (TDD): `convex/resolve.test.ts`, `src/hooks/permissionProps.test.ts`, `src/hooks/usePermissions.test.ts`.
- `npm run ts:check` clean · `npm run lint` clean (only pre-existing Convex `no-filter-in-query` warnings) · **139 unit tests pass**.
- e2e: **18 room-settings gating** + **14 results-display** (reveal / new-round) tests pass — gating behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)