### PR TITLE
refactor(demo): route the demo signal through the provider seam; drop the isDemoMode prop-drill (#214)

### DIFF
--- a/src/app/demo/demo-content.tsx
+++ b/src/app/demo/demo-content.tsx
@@ -29,7 +29,7 @@ function DemoCanvas({ isEmbedded }: { isEmbedded: boolean }) {
 
   return (
     <div className="relative h-screen bg-white dark:bg-black">
-      <RoomCanvas roomData={demo.roomData} isDemoMode={true} isEmbedded={isEmbedded} />
+      <RoomCanvas roomData={demo.roomData} isEmbedded={isEmbedded} />
     </div>
   );
 }

--- a/src/components/room/canvas-navigation.tsx
+++ b/src/components/room/canvas-navigation.tsx
@@ -45,6 +45,7 @@ import {
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
 import { copyTextToClipboard } from "@/utils/copy-text-to-clipboard";
 import { UserPresenceAvatars } from "./user-presence-avatars";
+import { useIsDemoMode } from "./demo/DemoSimulationProvider";
 
 // `document.fullscreenEnabled` is a client-only capability. Reading it through
 // useSyncExternalStore — with a `false` server snapshot — keeps SSR and the
@@ -66,7 +67,6 @@ interface CanvasNavigationProps {
   onIssuesPanelChange: (open: boolean) => void;
   isSettingsOpen: boolean;
   onSettingsPanelChange: (open: boolean) => void;
-  isDemoMode?: boolean;
 }
 
 export const CanvasNavigation: FC<CanvasNavigationProps> = ({
@@ -78,8 +78,9 @@ export const CanvasNavigation: FC<CanvasNavigationProps> = ({
   onIssuesPanelChange,
   isSettingsOpen,
   onSettingsPanelChange,
-  isDemoMode = false,
 }) => {
+  // The demo signal comes from the provider seam (#214), not a threaded prop.
+  const isDemoMode = useIsDemoMode();
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const router = useRouter();
 

--- a/src/components/room/canvas-navigation.tsx
+++ b/src/components/room/canvas-navigation.tsx
@@ -79,7 +79,6 @@ export const CanvasNavigation: FC<CanvasNavigationProps> = ({
   isSettingsOpen,
   onSettingsPanelChange,
 }) => {
-  // The demo signal comes from the provider seam (#214), not a threaded prop.
   const isDemoMode = useIsDemoMode();
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const router = useRouter();

--- a/src/components/room/demo/DemoSimulationProvider.tsx
+++ b/src/components/room/demo/DemoSimulationProvider.tsx
@@ -58,6 +58,20 @@ export function useDemoSimulation(): DemoSimulationContextValue | null {
   return useContext(DemoSimulationContext);
 }
 
+/**
+ * The single source for "are we in the demo?" (#214). Derives the answer from
+ * the provider seam — the same fact the data-bypass branches on — so the signal
+ * never travels a parallel `isDemoMode` prop channel that could disagree.
+ *
+ * Load-bearing invariant: `DemoSimulationProvider` is mounted iff the page is
+ * the demo simulation. Real-room pages must not mount it, which is what makes
+ * this return `false` in live rooms and `true` under `/demo`. Any consumer
+ * rendered inside the provider gets the correct signal for free.
+ */
+export function useIsDemoMode(): boolean {
+  return !!useDemoSimulation();
+}
+
 const CURRENT_ISSUE = {
   _id: DEMO_CURRENT_ISSUE._id,
   title: DEMO_CURRENT_ISSUE.title,

--- a/src/components/room/demo/zero-reads.test.ts
+++ b/src/components/room/demo/zero-reads.test.ts
@@ -8,10 +8,18 @@
  * `useQuery` is passed `"skip"`, and `usePresence` is never called at all.
  * Directly protects user stories 12/14/17 (ADR-0003).
  *
+ * Single-channel sourcing (#214): the demo signal travels only through the
+ * provider seam — the hooks take no `isDemoMode` prop and derive it from
+ * context. So this guard renders them with NO `isDemoMode` prop and asserts the
+ * bypass purely from being inside the provider; a companion case renders the
+ * same hooks OUTSIDE the provider and asserts they behave as a real room (every
+ * subscription opens). Together they pin that the signal and the Convex-bypass
+ * branch on the same fact.
+ *
  * It renders with `react-dom/server` (no DOM/jsdom needed): hooks run during
  * render, which is exactly when `useQuery`/`usePresence` are invoked.
  */
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach } from "vitest";
 
 // Hoisted capture buffers — referenced inside the (hoisted) vi.mock factories.
 const spy = vi.hoisted(() => ({
@@ -38,6 +46,8 @@ import { createElement, type ReactNode } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { getFunctionName } from "convex/server";
 import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { RoomWithRelatedData } from "@/convex/model/rooms";
 import {
   DemoSimulationProvider,
   useDemoSimulation,
@@ -48,57 +58,101 @@ import { useTimerSync } from "../hooks/use-timer-sync";
 import { useRoomPresence } from "@/hooks/useRoomPresence";
 import { DEMO_VIEWER_ID } from "../types";
 
+// Every subscription reachable from the demo canvas. In demo mode all must be
+// bypassed; in a real room all must open.
+const SUBSCRIPTIONS = [
+  getFunctionName(api.canvas.getCanvasNodes),
+  getFunctionName(api.issues.getCurrent),
+  getFunctionName(api.issues.list),
+  getFunctionName(api.issues.getForEnhancedExport),
+  getFunctionName(api.timer.getTimerState),
+];
+
+// Names + args of the captured subscription calls (ignoring queries we don't
+// guard here, e.g. the integration queries owned by their own sites).
+function capturedSubscriptions(): { name: string; args: unknown }[] {
+  return spy.queries
+    .map((c) => ({
+      name: getFunctionName(c.query as Parameters<typeof getFunctionName>[0]),
+      args: c.args,
+    }))
+    .filter((c) => SUBSCRIPTIONS.includes(c.name));
+}
+
 // Calls every always-mounted Convex-subscribing hook reachable from the demo
 // canvas. The other demo-reachable subscriptions are guarded at their own site,
 // so they are deliberately outside this Probe's scope (audited 2026-05-24):
 //   - RoomCanvas/PlayerNode/StoryNode read `roomData` (a prop) — api.rooms.get
 //     is never called in demo mode.
-//   - issues-panel skips its integration queries in demo (`isDemoMode ? "skip"`).
+//   - issues-panel skips its integration queries in demo (derives the signal
+//     from `useIsDemoMode()`).
 //   - integration-settings (getConnections/getRoomMapping, both un-skipped) only
 //     mounts behind `{!isDemoMode && …}` in room-settings-panel.
 // If one of those gates regresses this Probe won't catch it — re-audit on change.
-function Probe(): ReactNode {
-  const demo = useDemoSimulation();
-  if (!demo) throw new Error("Probe must render inside DemoSimulationProvider");
-  const roomId = demo.roomData.room._id;
-
+function useProbeHooks(roomId: Id<"rooms">, roomData: RoomWithRelatedData): void {
+  // The hooks take no `isDemoMode` prop: they read the demo signal from the
+  // provider seam, so what differs between the two cases is only whether the
+  // provider is mounted around them.
   useCanvasNodes({
     roomId,
-    roomData: demo.roomData,
+    roomData,
     currentUserId: undefined,
     selectedCardValue: null,
-    isDemoMode: true,
   });
-  useIssues({ roomId, isDemoMode: true });
-  useRoomPresence(roomId, DEMO_VIEWER_ID, demo.roomData.users);
+  useIssues({ roomId });
+  useRoomPresence(roomId, DEMO_VIEWER_ID, roomData.users);
   useTimerSync({ roomId, nodeId: "timer", userId: undefined });
+}
 
+function DemoProbe(): ReactNode {
+  const demo = useDemoSimulation();
+  if (!demo) throw new Error("DemoProbe must render inside DemoSimulationProvider");
+  useProbeHooks(demo.roomData.room._id, demo.roomData);
   return null;
 }
 
-describe("zero-reads guard: /demo opens no Convex subscriptions", () => {
-  it("skips every demo/canvas/issues/timer query and never subscribes to presence", () => {
+// A real room: no provider mounted, so `useDemoSimulation()` is null and the
+// hooks must subscribe. The exact data is irrelevant — the queries fire during
+// render regardless — so a minimal room shape is enough.
+function RealRoomProbe(): ReactNode {
+  const roomId = "real-room-id" as Id<"rooms">;
+  const roomData = {
+    room: { _id: roomId, name: "Real Room", isGameOver: false },
+    users: [],
+    votes: [],
+    isOwnerAbsent: false,
+  } as unknown as RoomWithRelatedData;
+  useProbeHooks(roomId, roomData);
+  return null;
+}
+
+describe("zero-reads guard: the demo signal is sourced from the provider seam", () => {
+  beforeEach(() => {
+    spy.queries.length = 0;
+    spy.presenceCalled = false;
+  });
+
+  it("skips every demo/canvas/issues/timer query and never subscribes to presence inside the provider", () => {
     renderToStaticMarkup(
-      createElement(DemoSimulationProvider, null, createElement(Probe)),
+      createElement(DemoSimulationProvider, null, createElement(DemoProbe)),
     );
 
     // Every subscription reachable from the demo canvas must be bypassed.
-    const forbidden = new Set([
-      getFunctionName(api.canvas.getCanvasNodes),
-      getFunctionName(api.issues.getCurrent),
-      getFunctionName(api.issues.list),
-      getFunctionName(api.issues.getForEnhancedExport),
-      getFunctionName(api.timer.getTimerState),
-    ]);
-
-    const leaked = spy.queries
-      .map((c) => ({
-        name: getFunctionName(c.query as Parameters<typeof getFunctionName>[0]),
-        args: c.args,
-      }))
-      .filter((c) => forbidden.has(c.name) && c.args !== "skip");
-
+    const leaked = capturedSubscriptions().filter((c) => c.args !== "skip");
     expect(leaked).toEqual([]);
     expect(spy.presenceCalled).toBe(false);
+  });
+
+  it("opens every subscription and subscribes to presence outside the provider (real room)", () => {
+    renderToStaticMarkup(createElement(RealRoomProbe));
+
+    const opened = capturedSubscriptions();
+    // Each guarded subscription opened at least once with real args (not skip).
+    for (const name of SUBSCRIPTIONS) {
+      const calls = opened.filter((c) => c.name === name);
+      expect(calls.length).toBeGreaterThan(0);
+      expect(calls.every((c) => c.args !== "skip")).toBe(true);
+    }
+    expect(spy.presenceCalled).toBe(true);
   });
 });

--- a/src/components/room/demo/zero-reads.test.ts
+++ b/src/components/room/demo/zero-reads.test.ts
@@ -112,8 +112,10 @@ function DemoProbe(): ReactNode {
 }
 
 // A real room: no provider mounted, so `useDemoSimulation()` is null and the
-// hooks must subscribe. The exact data is irrelevant — the queries fire during
-// render regardless — so a minimal room shape is enough.
+// hooks must subscribe. The exact data is irrelevant — `useQuery` fires
+// synchronously during `renderToStaticMarkup`, before any data round-trip — so
+// the double-cast to a minimal room shape is safe: nothing ever reads the
+// fields we omitted.
 function RealRoomProbe(): ReactNode {
   const roomId = "real-room-id" as Id<"rooms">;
   const roomData = {

--- a/src/components/room/hooks/useCanvasNodes.ts
+++ b/src/components/room/hooks/useCanvasNodes.ts
@@ -25,7 +25,6 @@ interface UseCanvasNodesProps {
   roomData: RoomWithRelatedData;
   currentUserId?: string;
   selectedCardValue: string | null;
-  isDemoMode?: boolean;
   canRevealCards?: ResolvedDecision;
   canControlGameFlow?: ResolvedDecision;
   canChangeRoomSettings?: ResolvedDecision;
@@ -51,7 +50,6 @@ export function useCanvasNodes({
   roomData,
   currentUserId,
   selectedCardValue,
-  isDemoMode = false,
   canRevealCards = RESOLVED_ALLOWED,
   canControlGameFlow = RESOLVED_ALLOWED,
   canChangeRoomSettings = RESOLVED_ALLOWED,
@@ -67,7 +65,10 @@ export function useCanvasNodes({
   // In the Demo simulation, the persisted nodes and the current issue come from
   // context — never from Convex (zero reads, ADR-0003). Real rooms subscribe as
   // before. `"skip"` keeps the hook call unconditional (rules of hooks).
+  // The demo signal is derived from the same context that supplies the bypass
+  // data (#214), so the two can never disagree.
   const demo = useDemoSimulation();
+  const isDemoMode = !!demo;
 
   const canvasNodesQuery = useQuery(
     api.canvas.getCanvasNodes,

--- a/src/components/room/hooks/useIssues.ts
+++ b/src/components/room/hooks/useIssues.ts
@@ -9,7 +9,6 @@ import { useDemoSimulation } from "../demo/DemoSimulationProvider";
 
 interface UseIssuesProps {
   roomId: Id<"rooms">;
-  isDemoMode?: boolean;
 }
 
 interface UseIssuesReturn {
@@ -27,9 +26,10 @@ interface UseIssuesReturn {
   exportData: EnhancedExportableIssue[] | undefined;
 }
 
-export function useIssues({ roomId, isDemoMode = false }: UseIssuesProps): UseIssuesReturn {
+export function useIssues({ roomId }: UseIssuesProps): UseIssuesReturn {
   // In the Demo simulation, the issues list and current issue come from context
   // — never from Convex (zero reads, ADR-0003). Real rooms subscribe as before.
+  // The demo signal is derived from that same context (#214), not a prop.
   const demo = useDemoSimulation();
 
   // Queries (skipped in demo mode; data is served from context below)
@@ -40,7 +40,7 @@ export function useIssues({ roomId, isDemoMode = false }: UseIssuesProps): UseIs
   );
   const exportData = useQuery(
     api.issues.getForEnhancedExport,
-    demo || isDemoMode ? "skip" : { roomId },
+    demo ? "skip" : { roomId },
   );
 
   const issues = demo ? demo.issues : (issuesQuery ?? []);

--- a/src/components/room/issue-item.tsx
+++ b/src/components/room/issue-item.tsx
@@ -46,7 +46,6 @@ export const IssueItem: FC<IssueItemProps> = ({
   canControlGameFlow: canControlGameFlowDecision = RESOLVED_ALLOWED,
   issueLink,
 }) => {
-  // The demo signal comes from the provider seam (#214), not a threaded prop.
   const isDemoMode = useIsDemoMode();
   // Resolved decisions in, booleans out for the existing gating logic; the
   // denial copy comes from the resolved decision's message (single source).

--- a/src/components/room/issue-item.tsx
+++ b/src/components/room/issue-item.tsx
@@ -14,6 +14,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
 import { type ResolvedDecision, RESOLVED_ALLOWED } from "@/convex/permissions";
+import { useIsDemoMode } from "./demo/DemoSimulationProvider";
 
 interface IssueLink {
   _id: string;
@@ -29,7 +30,6 @@ interface IssueItemProps {
   onUpdateTitle: (issueId: Id<"issues">, title: string) => void;
   onUpdateEstimate: (issueId: Id<"issues">, estimate: string) => void;
   onDelete: (issueId: Id<"issues">) => void;
-  isDemoMode?: boolean;
   canManageIssues?: ResolvedDecision;
   canControlGameFlow?: ResolvedDecision;
   issueLink?: IssueLink;
@@ -42,11 +42,12 @@ export const IssueItem: FC<IssueItemProps> = ({
   onUpdateTitle,
   onUpdateEstimate,
   onDelete,
-  isDemoMode = false,
   canManageIssues: canManageIssuesDecision = RESOLVED_ALLOWED,
   canControlGameFlow: canControlGameFlowDecision = RESOLVED_ALLOWED,
   issueLink,
 }) => {
+  // The demo signal comes from the provider seam (#214), not a threaded prop.
+  const isDemoMode = useIsDemoMode();
   // Resolved decisions in, booleans out for the existing gating logic; the
   // denial copy comes from the resolved decision's message (single source).
   const canManageIssues = canManageIssuesDecision.allowed;

--- a/src/components/room/issues-panel.tsx
+++ b/src/components/room/issues-panel.tsx
@@ -24,6 +24,7 @@ import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { useIssues } from "./hooks/useIssues";
+import { useIsDemoMode } from "./demo/DemoSimulationProvider";
 import { IssueItem } from "./issue-item";
 import { JiraImportModal } from "./jira-import-modal";
 import { exportIssuesToCSV } from "@/utils/export-issues-csv";
@@ -36,7 +37,6 @@ interface IssuesPanelProps {
   roomName: string;
   isOpen: boolean;
   onClose: () => void;
-  isDemoMode?: boolean;
   canManageIssues?: ResolvedDecision;
   canControlGameFlow?: ResolvedDecision;
 }
@@ -46,10 +46,12 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
   roomName,
   isOpen,
   onClose,
-  isDemoMode = false,
   canManageIssues: canManageIssuesDecision = RESOLVED_ALLOWED,
   canControlGameFlow: canControlGameFlowDecision = RESOLVED_ALLOWED,
 }) => {
+  // The demo signal comes from the provider seam (#214), not a threaded prop;
+  // it gates the integration queries below and the child issue rows.
+  const isDemoMode = useIsDemoMode();
   // Resolved decisions in; booleans for gating and a message for denial copy.
   const canManageIssues = canManageIssuesDecision.allowed;
   const manageIssuesDenial = canManageIssuesDecision.allowed
@@ -77,7 +79,7 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
     updateEstimate,
     deleteIssue,
     exportData,
-  } = useIssues({ roomId, isDemoMode });
+  } = useIssues({ roomId });
 
   const handleAddIssue = async () => {
     if (!newIssueTitle.trim()) return;
@@ -394,7 +396,6 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
                         onUpdateTitle={handleUpdateTitle}
                         onUpdateEstimate={handleUpdateEstimate}
                         onDelete={handleDeleteIssue}
-                        isDemoMode={isDemoMode}
                         canManageIssues={canManageIssuesDecision}
                         canControlGameFlow={canControlGameFlowDecision}
                         issueLink={issueLinksMap?.[issue._id] ?? undefined}

--- a/src/components/room/issues-panel.tsx
+++ b/src/components/room/issues-panel.tsx
@@ -49,8 +49,6 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
   canManageIssues: canManageIssuesDecision = RESOLVED_ALLOWED,
   canControlGameFlow: canControlGameFlowDecision = RESOLVED_ALLOWED,
 }) => {
-  // The demo signal comes from the provider seam (#214), not a threaded prop;
-  // it gates the integration queries below and the child issue rows.
   const isDemoMode = useIsDemoMode();
   // Resolved decisions in; booleans for gating and a message for denial copy.
   const canManageIssues = canManageIssuesDecision.allowed;

--- a/src/components/room/node-picker-toolbar.tsx
+++ b/src/components/room/node-picker-toolbar.tsx
@@ -24,8 +24,6 @@ export function NodePickerToolbar({
   hasNoteForCurrentIssue,
   onCreateNote,
 }: NodePickerToolbarProps): ReactElement | null {
-  // The demo never creates notes, so the toolbar self-guards via the provider
-  // seam (#214) rather than a threaded prop.
   const isDemoMode = useIsDemoMode();
 
   // Only show toolbar when there's an issue selected and no note exists

--- a/src/components/room/node-picker-toolbar.tsx
+++ b/src/components/room/node-picker-toolbar.tsx
@@ -11,20 +11,23 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { Id } from "@/convex/_generated/dataModel";
+import { useIsDemoMode } from "./demo/DemoSimulationProvider";
 
 interface NodePickerToolbarProps {
   currentIssueId: Id<"issues"> | null;
   hasNoteForCurrentIssue: boolean;
   onCreateNote: () => void;
-  isDemoMode?: boolean;
 }
 
 export function NodePickerToolbar({
   currentIssueId,
   hasNoteForCurrentIssue,
   onCreateNote,
-  isDemoMode = false,
 }: NodePickerToolbarProps): ReactElement | null {
+  // The demo never creates notes, so the toolbar self-guards via the provider
+  // seam (#214) rather than a threaded prop.
+  const isDemoMode = useIsDemoMode();
+
   // Only show toolbar when there's an issue selected and no note exists
   if (!currentIssueId || hasNoteForCurrentIssue || isDemoMode) {
     return null;

--- a/src/components/room/room-canvas.tsx
+++ b/src/components/room/room-canvas.tsx
@@ -22,6 +22,7 @@ import { CanvasNavigation } from "./canvas-navigation";
 import { RoomSettingsPanel } from "./room-settings-panel";
 import { IssuesPanel } from "./issues-panel";
 import { DemoExplainer } from "./demo-explainer";
+import { useIsDemoMode } from "./demo/DemoSimulationProvider";
 import { useCanvasNodes } from "./hooks/useCanvasNodes";
 import { useCanvasActions } from "./hooks/useCanvasActions";
 import { useCardSelection } from "./hooks/useCardSelection";
@@ -55,7 +56,6 @@ import {
 interface RoomCanvasProps {
   roomData: RoomWithRelatedData;
   currentUserId?: Id<"users">;
-  isDemoMode?: boolean;
   isEmbedded?: boolean;
 }
 
@@ -70,7 +70,11 @@ const nodeTypes: NodeTypes = {
   timer: TimerNode,
 } as const;
 
-function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedded = false }: RoomCanvasProps): ReactElement {
+function RoomCanvasInner({ roomData, currentUserId, isEmbedded = false }: RoomCanvasProps): ReactElement {
+  // The demo signal is derived once from the provider seam (#214), matching how
+  // the children and hooks below now obtain it; the demo route mounts the
+  // provider and is the sole place that decides demo-vs-real.
+  const isDemoMode = useIsDemoMode();
   const [nodes, setNodes, onNodesChange] = useNodesState<CustomNodeType>([]);
   const [edges, setEdges, onEdgesChange] = useEdgesState<Edge>([]);
   const { fitView } = useReactFlow();
@@ -127,7 +131,6 @@ function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedd
     roomData,
     currentUserId,
     selectedCardValue,
-    isDemoMode,
     canRevealCards: permissions.revealCards,
     canControlGameFlow: permissions.gameFlow,
     canChangeRoomSettings: permissions.roomSettings,
@@ -261,7 +264,6 @@ function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedd
             onIssuesPanelChange={(open) => (open ? openIssues() : closeAll())}
             isSettingsOpen={isSettingsOpen}
             onSettingsPanelChange={(open) => (open ? openSettings() : closeAll())}
-            isDemoMode={isDemoMode}
           />
         )}
         <ReactFlow
@@ -299,14 +301,12 @@ function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedd
           className="*:stroke-gray-300 dark:*:stroke-surface-3"
         />
       </ReactFlow>
-      {!isDemoMode && (
-        <NodePickerToolbar
-          currentIssueId={currentIssue?._id ?? null}
-          hasNoteForCurrentIssue={hasNoteForCurrentIssue}
-          onCreateNote={() => currentIssue && actions.createNote(currentIssue._id)}
-          isDemoMode={isDemoMode}
-        />
-      )}
+      {/* The toolbar self-guards in demo via the provider seam (#214). */}
+      <NodePickerToolbar
+        currentIssueId={currentIssue?._id ?? null}
+        hasNoteForCurrentIssue={hasNoteForCurrentIssue}
+        onCreateNote={() => currentIssue && actions.createNote(currentIssue._id)}
+      />
 
       {/* Demo explainer - only shown in demo mode, not when embedded */}
       {isDemoMode && !isEmbedded && <DemoExplainer />}
@@ -360,7 +360,6 @@ function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedd
         currentUserId={isDemoMode ? undefined : (currentUserId as Id<"users">)}
         isOpen={isSettingsOpen}
         onClose={closeAll}
-        isDemoMode={isDemoMode}
       />
 
       {/* Issues Panel */}
@@ -369,7 +368,6 @@ function RoomCanvasInner({ roomData, currentUserId, isDemoMode = false, isEmbedd
         roomName={roomData.room.name}
         isOpen={isIssuesPanelOpen}
         onClose={closeAll}
-        isDemoMode={isDemoMode}
         canManageIssues={permissions.issueManagement}
         canControlGameFlow={permissions.gameFlow}
       />

--- a/src/components/room/room-canvas.tsx
+++ b/src/components/room/room-canvas.tsx
@@ -301,7 +301,6 @@ function RoomCanvasInner({ roomData, currentUserId, isEmbedded = false }: RoomCa
           className="*:stroke-gray-300 dark:*:stroke-surface-3"
         />
       </ReactFlow>
-      {/* The toolbar self-guards in demo via the provider seam (#214). */}
       <NodePickerToolbar
         currentIssueId={currentIssue?._id ?? null}
         hasNoteForCurrentIssue={hasNoteForCurrentIssue}

--- a/src/components/room/room-settings-panel.tsx
+++ b/src/components/room/room-settings-panel.tsx
@@ -110,7 +110,6 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
   isOpen,
   onClose,
 }) => {
-  // The demo signal comes from the provider seam (#214), not a threaded prop.
   const isDemoMode = useIsDemoMode();
   const { toast } = useToast();
   const { theme, setTheme } = useTheme();

--- a/src/components/room/room-settings-panel.tsx
+++ b/src/components/room/room-settings-panel.tsx
@@ -66,13 +66,13 @@ import { UserAvatar } from "@/components/user-menu/user-avatar";
 import { formatLastSeen } from "./user-presence-avatars";
 
 import { useRoomPresence } from "@/hooks/useRoomPresence";
+import { useIsDemoMode } from "./demo/DemoSimulationProvider";
 
 interface RoomSettingsPanelProps {
   roomData: RoomWithRelatedData;
   currentUserId?: Id<"users">;
   isOpen: boolean;
   onClose: () => void;
-  isDemoMode?: boolean;
 }
 
 const PERMISSION_CONFIG: Record<PermissionCategory, { label: string; description: string; tooltip: string }> = {
@@ -109,8 +109,9 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
   currentUserId,
   isOpen,
   onClose,
-  isDemoMode = false,
 }) => {
+  // The demo signal comes from the provider seam (#214), not a threaded prop.
+  const isDemoMode = useIsDemoMode();
   const { toast } = useToast();
   const { theme, setTheme } = useTheme();
 


### PR DESCRIPTION
Closes #214.

## Problem

ADR-0003 made `DemoSimulationProvider` the seam where `/demo` becomes a client-side simulation. But "are we in the demo?" also traveled a second channel — an `isDemoMode` boolean prop-drilled through ~8 components and 2 hooks. Two of those hooks (`useCanvasNodes`, `useIssues`) took the prop *and* already called `useDemoSimulation()`, carrying the same fact twice. Two channels for one fact can disagree, and every new demo-aware component had to remember to thread the prop or silently behave as a real room.

## Solution

Make the provider seam the single channel.

- **New single source** — `useIsDemoMode()` in `DemoSimulationProvider.tsx`: `() => !!useDemoSimulation()`. Its docstring states the load-bearing invariant: *the provider is mounted iff the page is the demo simulation.*
- **Hooks stop double-carrying** — `useCanvasNodes` / `useIssues` drop the `isDemoMode` param and derive `isDemoMode = !!demo` from the context they already read.
- **Components drop the prop, read the hook** — `canvas-navigation`, `issues-panel`, `issue-item`, `node-picker-toolbar`, `room-settings-panel`. `node-picker-toolbar` now self-guards, so its `{!isDemoMode && …}` wrapper in `room-canvas` was removed.
- **`room-canvas`** derives `isDemoMode` once at the top of its inner component and stops threading it down; **`demo-content`** stops passing `isDemoMode={true}` to `RoomCanvas` (still mounts the provider + passes `isEmbedded`).

The `/demo` route is now the sole demo decision site. A new demo-aware component gets the correct signal merely by rendering inside the provider.

## Left as-is (per scope)

`useTimerSync`, `useRoomPresence` (already derive from the provider), `useCanvasActions`' internal derivation (owned by #212), and `isEmbedded`. **No backend, schema, or Convex change.**

## Testing

Extended `demo/zero-reads.test.ts` into two cases that branch only on whether the provider is mounted — no `isDemoMode` prop anywhere:

- *inside* the provider → every guarded subscription is `"skip"` and presence is never called;
- *outside* the provider (real room) → every guarded subscription opens with real args and presence subscribes.

This pins ADR-0003's zero-reads guarantee under the new single-channel sourcing.

- `npm test` → 166 passed
- `npm run ts:check` → clean
- `npm run lint` → 0 errors (only pre-existing `.filter()` warnings in `convex/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)