### PR TITLE
refactor(convex): resolve no-filter-in-query warnings and type canvas node data

### DIFF
--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -814,11 +814,8 @@ export const getAllJiraMappings = internalQuery({
   handler: async (ctx) => {
     return await ctx.db
       .query("integrationMappings")
-      .filter((q) =>
-        q.and(
-          q.eq(q.field("provider"), "jira"),
-          q.eq(q.field("autoPushEstimates"), true)
-        )
+      .withIndex("by_provider_autopush", (q) =>
+        q.eq("provider", "jira").eq("autoPushEstimates", true)
       )
       .collect();
   },

--- a/convex/model/canvas.ts
+++ b/convex/model/canvas.ts
@@ -26,17 +26,48 @@ export interface Position {
   y: number;
 }
 
-export interface CanvasNode {
+/**
+ * Persisted `data` payload for each canvas node `type`. The column is stored as
+ * `v.any()` in the schema (node shapes evolve independently of migrations), so
+ * this discriminated union is the read-side contract asserted by
+ * {@link getCanvasNodes} — it lets callers narrow `data` by `type`.
+ */
+export type CanvasNodeData =
+  | { type: "player"; data: { userId: Id<"users"> } }
+  | {
+      type: "timer";
+      data: {
+        startedAt: number | null;
+        pausedAt: number | null;
+        elapsedSeconds: number;
+        isRunning?: boolean;
+        lastUpdatedBy: Id<"users"> | null;
+        lastAction: "start" | "pause" | "reset" | null;
+      };
+    }
+  | {
+      type: "note";
+      data: {
+        issueId: Id<"issues">;
+        issueTitle: string;
+        content: string;
+        lastUpdatedBy?: string;
+        lastUpdatedAt?: number;
+      };
+    }
+  // session / results / story carry no persisted payload
+  | { type: "session"; data: Record<string, never> }
+  | { type: "results"; data: Record<string, never> }
+  | { type: "story"; data: Record<string, never> };
+
+export type CanvasNode = {
   roomId: Id<"rooms">;
   nodeId: string;
-  type: "player" | "timer" | "session" | "results" | "story" | "note";
   position: Position;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- TODO: Create proper type union for node data
-  data: any;
   isLocked?: boolean;
   lastUpdatedBy?: Id<"users">;
   lastUpdatedAt: number;
-}
+} & CanvasNodeData;
 
 interface NodePosition {
   nodeId: string;
@@ -215,10 +246,12 @@ export async function getCanvasNodes(
   ctx: QueryCtx,
   roomId: Id<"rooms">
 ): Promise<CanvasNode[]> {
-  return await ctx.db
+  const nodes = await ctx.db
     .query("canvasNodes")
     .withIndex("by_room", (q) => q.eq("roomId", roomId))
     .collect();
+  // `data` is persisted as `v.any()`; assert the per-`type` read contract.
+  return nodes as CanvasNode[];
 }
 
 /**

--- a/convex/model/canvas.ts
+++ b/convex/model/canvas.ts
@@ -51,7 +51,7 @@ export type CanvasNodeData =
         issueId: Id<"issues">;
         issueTitle: string;
         content: string;
-        lastUpdatedBy?: string;
+        lastUpdatedBy?: string; // display name (user.name), not an Id — see writes in this file
         lastUpdatedAt?: number;
       };
     }

--- a/convex/model/issues.ts
+++ b/convex/model/issues.ts
@@ -263,8 +263,7 @@ export async function getIssuesForExport(
   // Fetch all notes for room in a single query (avoid N+1)
   const noteNodes = await ctx.db
     .query("canvasNodes")
-    .withIndex("by_room", (q) => q.eq("roomId", roomId))
-    .filter((q) => q.eq(q.field("type"), "note"))
+    .withIndex("by_room_type", (q) => q.eq("roomId", roomId).eq("type", "note"))
     .collect();
 
   // Build lookup map: issueId -> note content

--- a/convex/model/users.ts
+++ b/convex/model/users.ts
@@ -503,10 +503,12 @@ export async function linkAnonymousToPermanent(
     for (const iv of anonIndividualVotes) {
       const existingIv = await ctx.db
         .query("individualVotes")
-        .withIndex("by_room_user", (q) =>
-          q.eq("roomId", iv.roomId).eq("userId", existingPermanent._id)
+        .withIndex("by_room_user_issue", (q) =>
+          q
+            .eq("roomId", iv.roomId)
+            .eq("userId", existingPermanent._id)
+            .eq("issueId", iv.issueId)
         )
-        .filter((q) => q.eq(q.field("issueId"), iv.issueId))
         .first();
 
       if (existingIv) {
@@ -552,7 +554,7 @@ export async function linkAnonymousToPermanent(
     // Transfer room ownership from anonymous user to permanent user
     const ownedRooms = await ctx.db
       .query("rooms")
-      .filter((q) => q.eq(q.field("ownerId"), user._id))
+      .withIndex("by_owner", (q) => q.eq("ownerId", user._id))
       .collect();
 
     for (const room of ownedRooms) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -54,7 +54,8 @@ export default defineSchema({
     ),
   })
     .index("by_activity", ["lastActivityAt"])
-    .index("by_created", ["createdAt"]), // For querying recent rooms
+    .index("by_created", ["createdAt"]) // For querying recent rooms
+    .index("by_owner", ["ownerId"]), // For transferring ownership on account linking
 
   issues: defineTable({
     roomId: v.id("rooms"),
@@ -174,7 +175,7 @@ export default defineSchema({
   })
     .index("by_issue", ["issueId"])
     .index("by_user", ["userId"])
-    .index("by_room_user", ["roomId", "userId"])
+    .index("by_room_user_issue", ["roomId", "userId", "issueId"])
     .index("by_room", ["roomId"]),
 
   // Integration connections (user-level OAuth tokens, encrypted)
@@ -223,7 +224,8 @@ export default defineSchema({
     createdAt: v.number(),
   })
     .index("by_room", ["roomId"])
-    .index("by_connection", ["connectionId"]),
+    .index("by_connection", ["connectionId"])
+    .index("by_provider_autopush", ["provider", "autoPushEstimates"]), // For webhook-refresh sweep
 
   // Bidirectional links between AgileKit issues and external issues
   issueLinks: defineTable({

--- a/src/components/room/hooks/useCanvasNodes.ts
+++ b/src/components/room/hooks/useCanvasNodes.ts
@@ -23,7 +23,7 @@ const VOTING_CARD_SPACING = 70;
 interface UseCanvasNodesProps {
   roomId: Id<"rooms">;
   roomData: RoomWithRelatedData;
-  currentUserId?: string;
+  currentUserId?: Id<"users">;
   selectedCardValue: string | null;
   canRevealCards?: ResolvedDecision;
   canControlGameFlow?: ResolvedDecision;
@@ -133,6 +133,7 @@ export function useCanvasNodes({
           position: node.position,
           data: {
             ...node.data,
+            isRunning: node.data.isRunning ?? false,
             roomId,
             userId: currentUserId,
             nodeId: node.nodeId,


### PR DESCRIPTION
## What

Resolves every Convex-related lint issue in the repo: the four `@convex-dev/no-filter-in-query` warnings and the one disabled `@typescript-eslint/no-explicit-any` rule in convex code. All fixes follow `convex/_generated/ai/guidelines.md` ("Do NOT use `filter` in queries — define an index and use `withIndex`").

## `.filter()` → `withIndex` (4 warnings)

| Location | Fix |
|---|---|
| `integrations/jira.ts` `getAllJiraMappings` | new index `integrationMappings.by_provider_autopush` |
| `model/issues.ts` `getIssuesForExport` | use **existing** `canvasNodes.by_room_type` (filter was redundant) |
| `model/users.ts` (account linking) | `individualVotes.by_room_user` → `by_room_user_issue` (old 2-field index was used only here) |
| `model/users.ts` (account linking) | new index `rooms.by_owner` |

## Removed `no-explicit-any` on `CanvasNode.data`

Replaced `data: any` with a **discriminated union** keyed by node `type`. The schema column stays `v.any()` by design (node shapes evolve without migrations), so `getCanvasNodes` asserts the read contract via one documented cast.

This *strengthened* existing code: `useCanvasNodes` already narrowed on `node.type` then read `node.data.userId`/`.issueId`, type-unsafe under `any`. Tightening surfaced two latent mismatches, both fixed:
- hook prop `currentUserId?: string` → `Id<"users">` (its only caller, `room-canvas.tsx`, already passes `Id<"users">`)
- timer node `isRunning` set explicitly (`node.data.isRunning ?? false`), since persisted timer data omits it at init

## Migration / risk

No data migration — index changes rebuild on the next `npx convex dev` / deploy. The schema `data` validator is unchanged.

## Verification

- `npx eslint convex/` → **0 warnings** (was 4)
- `npm run lint` (full repo) → clean
- `npm run ts:check` → clean
- `npx vitest run --project convex` → **106/106 pass** (`convex-test` throws on unknown index names, confirming renames are wired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)