### PR TITLE
refactor(canvas): extract pure buildCanvasNodes module from the canvas hook

### DIFF
--- a/src/components/room/hooks/buildCanvasNodes.test.ts
+++ b/src/components/room/hooks/buildCanvasNodes.test.ts
@@ -1,0 +1,603 @@
+/**
+ * buildCanvasNodes / buildCanvasEdges — the pure canvas derivation (#229).
+ *
+ * These tests call the builders with plain values and assert on the returned
+ * nodes and edges — never on how the module derived them, and never through
+ * React (prior art: the demo simulation tests). The expected values are the
+ * behavior the live canvas has always had; the extraction must be invisible
+ * in use.
+ */
+import { describe, it, expect } from "vitest";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { CanvasNode } from "@/convex/model/canvas";
+import type { SanitizedVote } from "@/convex/model/rooms";
+import type { RoomUserData } from "@/convex/model/users";
+import { RESOLVED_ALLOWED } from "@/convex/permissions";
+import { computeVotingCardRow } from "@/convex/canvasLayout";
+import { DEFAULT_SCALE } from "@/convex/scales";
+import {
+  DEMO_VIEWER_ID,
+  type CustomNodeType,
+  type VotingCardNodeType,
+} from "../types";
+import {
+  buildCanvasEdges,
+  buildCanvasNodes,
+  isNoteForIssue,
+  type CanvasEdgesInput,
+  type CanvasNodesInput,
+} from "./buildCanvasNodes";
+
+const ROOM_ID = "room-1" as Id<"rooms">;
+const ISSUE_ID = "issue-1" as Id<"issues">;
+
+function member(id: string, overrides?: Partial<RoomUserData>): RoomUserData {
+  return {
+    _id: id as Id<"users">,
+    name: `User ${id}`,
+    isSpectator: false,
+    role: "participant",
+    joinedAt: 0,
+    membershipId: `membership-${id}` as Id<"roomMemberships">,
+    ...overrides,
+  };
+}
+
+function playerCanvasNode(userId: string): CanvasNode {
+  return {
+    roomId: ROOM_ID,
+    nodeId: `player-${userId}`,
+    position: { x: 0, y: 0 },
+    lastUpdatedAt: 0,
+    type: "player",
+    data: { userId: userId as Id<"users"> },
+  };
+}
+
+function noteCanvasNode(
+  issueId: Id<"issues">,
+  nodeId = `note-${issueId}`,
+  content = "",
+): CanvasNode {
+  return {
+    roomId: ROOM_ID,
+    nodeId,
+    position: { x: 400, y: -200 },
+    lastUpdatedAt: 0,
+    type: "note",
+    data: { issueId, issueTitle: "Issue title", content },
+  };
+}
+
+function vote(userId: string, overrides?: Partial<SanitizedVote>): SanitizedVote {
+  return {
+    _id: `vote-${userId}` as Id<"votes">,
+    _creationTime: 0,
+    roomId: ROOM_ID,
+    userId: userId as Id<"users">,
+    hasVoted: true,
+    ...overrides,
+  };
+}
+
+function nodesInput(overrides?: Partial<CanvasNodesInput>): CanvasNodesInput {
+  return {
+    phase: "voting",
+    roomId: ROOM_ID,
+    room: {
+      name: "Sprint 42",
+      autoCompleteVoting: false,
+      autoRevealCountdownStartedAt: null,
+      votingScale: undefined,
+    },
+    members: [],
+    votes: [],
+    canvasNodes: [],
+    currentIssue: null,
+    viewerId: undefined,
+    selectedCardValue: null,
+    isDemoMode: false,
+    canRevealCards: RESOLVED_ALLOWED,
+    canControlGameFlow: RESOLVED_ALLOWED,
+    canChangeRoomSettings: RESOLVED_ALLOWED,
+    callbacks: {},
+    ...overrides,
+  };
+}
+
+function edgesInput(overrides?: Partial<CanvasEdgesInput>): CanvasEdgesInput {
+  return {
+    phase: "voting",
+    members: [],
+    canvasNodes: [],
+    currentIssue: null,
+    ...overrides,
+  };
+}
+
+describe("buildCanvasEdges", () => {
+  it("emits one session-to-player edge per member and the timer edge always", () => {
+    const edges = buildCanvasEdges(
+      edgesInput({
+        members: [member("u1"), member("u2")],
+        canvasNodes: [playerCanvasNode("u1"), playerCanvasNode("u2")],
+      }),
+    );
+
+    const playerEdges = edges.filter((e) => e.id.startsWith("session-to-player-"));
+    expect(playerEdges).toHaveLength(2);
+    expect(playerEdges[0]).toMatchObject({
+      id: "session-to-player-u1",
+      source: "session-current",
+      sourceHandle: "bottom",
+      target: "player-u1",
+      targetHandle: "top",
+      type: "default",
+    });
+    expect(playerEdges[1].target).toBe("player-u2");
+
+    expect(edges.filter((e) => e.id === "timer-to-session")).toHaveLength(1);
+    expect(edges.find((e) => e.id === "timer-to-session")).toMatchObject({
+      source: "timer",
+      target: "session-current",
+      type: "straight",
+    });
+  });
+
+  it("emits the session-to-results edge only when the round is revealed", () => {
+    const voting = buildCanvasEdges(edgesInput({ phase: "voting" }));
+    const countingDown = buildCanvasEdges(edgesInput({ phase: "countingDown" }));
+    const revealed = buildCanvasEdges(edgesInput({ phase: "revealed" }));
+
+    expect(voting.find((e) => e.id === "session-to-results")).toBeUndefined();
+    expect(countingDown.find((e) => e.id === "session-to-results")).toBeUndefined();
+    expect(revealed.find((e) => e.id === "session-to-results")).toMatchObject({
+      source: "session-current",
+      sourceHandle: "right",
+      target: "results",
+      targetHandle: "left",
+      type: "straight",
+    });
+  });
+
+  it("emits the session-to-note edge targeting the current issue's note node", () => {
+    const otherIssueId = "issue-2" as Id<"issues">;
+    const edges = buildCanvasEdges(
+      edgesInput({
+        canvasNodes: [
+          noteCanvasNode(otherIssueId, "note-other"),
+          noteCanvasNode(ISSUE_ID, "note-current"),
+        ],
+        currentIssue: { _id: ISSUE_ID },
+      }),
+    );
+
+    expect(edges.find((e) => e.id === "session-to-note")).toMatchObject({
+      source: "session-current",
+      target: "note-current",
+      type: "straight",
+    });
+  });
+
+  it("emits no note edge without a current issue or without a matching note", () => {
+    const noIssue = buildCanvasEdges(
+      edgesInput({ canvasNodes: [noteCanvasNode(ISSUE_ID)] }),
+    );
+    const noNote = buildCanvasEdges(
+      edgesInput({
+        canvasNodes: [noteCanvasNode("issue-2" as Id<"issues">)],
+        currentIssue: { _id: ISSUE_ID },
+      }),
+    );
+
+    expect(noIssue.find((e) => e.id === "session-to-note")).toBeUndefined();
+    expect(noNote.find((e) => e.id === "session-to-note")).toBeUndefined();
+  });
+});
+
+describe("buildCanvasNodes — player nodes", () => {
+  it("builds a player node per persisted player with its member's data", () => {
+    const alice = member("u1", { role: "owner" });
+    const lockedNode = { ...playerCanvasNode("u1"), isLocked: true };
+    const nodes = buildCanvasNodes(
+      nodesInput({
+        members: [alice],
+        votes: [vote("u1")],
+        canvasNodes: [lockedNode],
+        viewerId: "u1" as Id<"users">,
+      }),
+    ).filter((n) => n.type === "player");
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]).toMatchObject({
+      id: "player-u1",
+      type: "player",
+      position: { x: 0, y: 0 },
+      draggable: false,
+      data: {
+        user: alice,
+        isCurrentUser: true,
+        isCardPicked: true,
+        card: null,
+        phase: "voting",
+        role: "owner",
+      },
+    });
+  });
+
+  it("shows the vote's card label only when the round is revealed", () => {
+    const base = {
+      members: [member("u1")],
+      votes: [vote("u1", { cardLabel: "8" })],
+      canvasNodes: [playerCanvasNode("u1")],
+    };
+    const phases = ["voting", "countingDown", "revealed"] as const;
+    const [voting, countingDown, revealed] = phases.map(
+      (phase) => buildCanvasNodes(nodesInput({ ...base, phase }))[0],
+    );
+
+    expect(voting.data).toMatchObject({ card: null, phase: "voting" });
+    expect(countingDown.data).toMatchObject({ card: null, phase: "countingDown" });
+    expect(revealed.data).toMatchObject({ card: "8", phase: "revealed" });
+  });
+
+  it("skips a persisted player node whose member is gone", () => {
+    const nodes = buildCanvasNodes(
+      nodesInput({ members: [], canvasNodes: [playerCanvasNode("u-gone")] }),
+    );
+    expect(nodes).toHaveLength(0);
+  });
+});
+
+function sessionCanvasNode(): CanvasNode {
+  return {
+    roomId: ROOM_ID,
+    nodeId: "session-current",
+    position: { x: -140, y: -300 },
+    lastUpdatedAt: 0,
+    type: "session",
+    data: {},
+  };
+}
+
+describe("buildCanvasNodes — session node", () => {
+  it("derives counts from members and votes, excluding spectators", () => {
+    const nodes = buildCanvasNodes(
+      nodesInput({
+        members: [member("u1"), member("u2", { isSpectator: true }), member("u3")],
+        votes: [vote("u1"), vote("u3", { hasVoted: false })],
+        canvasNodes: [sessionCanvasNode()],
+        currentIssue: { _id: ISSUE_ID, title: "Checkout flow" },
+      }),
+    );
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]).toMatchObject({
+      id: "session-current",
+      type: "session",
+      data: {
+        sessionName: "Sprint 42",
+        participantCount: 2,
+        voteCount: 1,
+        hasVotes: true,
+        phase: "voting",
+        autoCompleteVoting: false,
+        autoRevealCountdownStartedAt: null,
+        currentIssue: { id: ISSUE_ID, title: "Checkout flow" },
+      },
+    });
+  });
+
+  it("passes resolved decisions through unaltered — allowed and denied alike", () => {
+    const denied = { allowed: false as const, message: "Only the owner can do that" };
+    const { data } = buildCanvasNodes(
+      nodesInput({
+        canvasNodes: [sessionCanvasNode()],
+        canRevealCards: denied,
+        canControlGameFlow: RESOLVED_ALLOWED,
+        canChangeRoomSettings: denied,
+      }),
+    )[0];
+
+    if (!("canRevealCards" in data)) throw new Error("expected session data");
+    expect(data.canRevealCards).toBe(denied);
+    expect(data.canControlGameFlow).toBe(RESOLVED_ALLOWED);
+    expect(data.canChangeRoomSettings).toBe(denied);
+  });
+
+  it("wires the session callbacks through by reference", () => {
+    const callbacks = {
+      onRevealCards: () => {},
+      onResetGame: () => {},
+      onToggleAutoComplete: () => {},
+      onCancelAutoReveal: () => {},
+      onOpenIssuesPanel: () => {},
+    };
+    const { data } = buildCanvasNodes(
+      nodesInput({ canvasNodes: [sessionCanvasNode()], callbacks }),
+    )[0];
+
+    if (!("canRevealCards" in data)) throw new Error("expected session data");
+    expect(data.onRevealCards).toBe(callbacks.onRevealCards);
+    expect(data.onResetGame).toBe(callbacks.onResetGame);
+    expect(data.onToggleAutoComplete).toBe(callbacks.onToggleAutoComplete);
+    expect(data.onCancelAutoReveal).toBe(callbacks.onCancelAutoReveal);
+    expect(data.onOpenIssuesPanel).toBe(callbacks.onOpenIssuesPanel);
+  });
+
+  it("falls back to the default session name and null current issue", () => {
+    const { data } = buildCanvasNodes(
+      nodesInput({
+        room: {
+          name: "",
+          autoCompleteVoting: true,
+          autoRevealCountdownStartedAt: 12345,
+        },
+        canvasNodes: [sessionCanvasNode()],
+      }),
+    )[0];
+
+    expect(data).toMatchObject({
+      sessionName: "Planning Session",
+      currentIssue: null,
+      autoCompleteVoting: true,
+      autoRevealCountdownStartedAt: 12345,
+    });
+  });
+});
+
+function resultsCanvasNode(): CanvasNode {
+  return {
+    roomId: ROOM_ID,
+    nodeId: "results",
+    position: { x: 400, y: -200 },
+    lastUpdatedAt: 0,
+    type: "results",
+    data: {},
+  };
+}
+
+describe("buildCanvasNodes — results node", () => {
+  it("appears only when the round is revealed, with cast votes only", () => {
+    const base = {
+      members: [member("u1"), member("u2")],
+      votes: [vote("u1", { cardLabel: "5" }), vote("u2", { hasVoted: false })],
+      canvasNodes: [resultsCanvasNode()],
+      room: {
+        name: "Sprint 42",
+        autoCompleteVoting: false,
+        autoRevealCountdownStartedAt: null,
+        votingScale: { cards: ["S", "M", "L"], isNumeric: false },
+      },
+    };
+
+    const hidden = buildCanvasNodes(nodesInput({ ...base, phase: "voting" }));
+    expect(hidden).toHaveLength(0);
+
+    const shown = buildCanvasNodes(nodesInput({ ...base, phase: "revealed" }));
+    expect(shown).toHaveLength(1);
+    expect(shown[0]).toMatchObject({ id: "results", type: "results" });
+    if (!("isNumericScale" in shown[0].data)) throw new Error("expected results data");
+    expect(shown[0].data.isNumericScale).toBe(false);
+    expect(shown[0].data.votes).toEqual([base.votes[0]]);
+    expect(shown[0].data.users).toBe(base.members);
+  });
+
+  it("defaults to a numeric scale when the room has none", () => {
+    const nodes = buildCanvasNodes(
+      nodesInput({ phase: "revealed", canvasNodes: [resultsCanvasNode()] }),
+    );
+    if (!("isNumericScale" in nodes[0].data)) throw new Error("expected results data");
+    expect(nodes[0].data.isNumericScale).toBe(true);
+  });
+});
+
+describe("buildCanvasNodes — note node", () => {
+  it("shows only the note belonging to the current issue", () => {
+    const nodes = buildCanvasNodes(
+      nodesInput({
+        canvasNodes: [
+          noteCanvasNode("issue-2" as Id<"issues">, "note-other"),
+          noteCanvasNode(ISSUE_ID, "note-current", "some content"),
+        ],
+        currentIssue: { _id: ISSUE_ID, title: "Checkout flow" },
+      }),
+    );
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]).toMatchObject({
+      id: "note-current",
+      type: "note",
+      data: { issueId: ISSUE_ID, issueTitle: "Issue title", content: "some content" },
+    });
+  });
+
+  it("hides every note when there is no current issue", () => {
+    const nodes = buildCanvasNodes(
+      nodesInput({ canvasNodes: [noteCanvasNode(ISSUE_ID)], currentIssue: null }),
+    );
+    expect(nodes).toHaveLength(0);
+  });
+
+  it("gives the note closures that capture its own node id and content state", () => {
+    const updates: [string, string][] = [];
+    const deletions: [string, boolean][] = [];
+    const build = (content: string) =>
+      buildCanvasNodes(
+        nodesInput({
+          canvasNodes: [noteCanvasNode(ISSUE_ID, "note-current", content)],
+          currentIssue: { _id: ISSUE_ID, title: "Checkout flow" },
+          callbacks: {
+            onUpdateNoteContent: (nodeId, next) => updates.push([nodeId, next]),
+            onDeleteNote: (nodeId, hasContent) => deletions.push([nodeId, hasContent]),
+          },
+        }),
+      )[0];
+
+    const withContent = build("draft").data;
+    if (!("onUpdateContent" in withContent)) throw new Error("expected note data");
+    withContent.onUpdateContent("edited");
+    withContent.onDelete?.();
+
+    const empty = build("").data;
+    if (!("onUpdateContent" in empty)) throw new Error("expected note data");
+    empty.onDelete?.();
+
+    expect(updates).toEqual([["note-current", "edited"]]);
+    expect(deletions).toEqual([
+      ["note-current", true],
+      ["note-current", false],
+    ]);
+  });
+});
+
+describe("buildCanvasNodes — timer node", () => {
+  it("passes the persisted timer state through with sync identifiers", () => {
+    const timerNode: CanvasNode = {
+      roomId: ROOM_ID,
+      nodeId: "timer",
+      position: { x: -500, y: -250 },
+      lastUpdatedAt: 0,
+      type: "timer",
+      data: {
+        startedAt: 111,
+        pausedAt: null,
+        elapsedSeconds: 42,
+        lastUpdatedBy: "u1" as Id<"users">,
+        lastAction: "start",
+      },
+    };
+    const nodes = buildCanvasNodes(
+      nodesInput({ canvasNodes: [timerNode], viewerId: "u2" as Id<"users"> }),
+    ).filter((n) => n.type === "timer");
+
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]).toMatchObject({
+      id: "timer",
+      type: "timer",
+      data: {
+        startedAt: 111,
+        pausedAt: null,
+        elapsedSeconds: 42,
+        isRunning: false,
+        lastUpdatedBy: "u1",
+        lastAction: "start",
+        roomId: ROOM_ID,
+        userId: "u2",
+        nodeId: "timer",
+      },
+    });
+  });
+});
+
+function votingCards(nodes: CustomNodeType[]): VotingCardNodeType[] {
+  return nodes.filter((n): n is VotingCardNodeType => n.type === "votingCard");
+}
+
+describe("buildCanvasNodes — voting-card row", () => {
+  const scale = { cards: ["1", "2", "3"], isNumeric: true };
+  const roomWithScale = {
+    name: "Sprint 42",
+    autoCompleteVoting: false,
+    autoRevealCountdownStartedAt: null,
+    votingScale: scale,
+  };
+  const viewer = "u1" as Id<"users">;
+
+  it("renders one selectable card per scale value for a participant viewer", () => {
+    const onCardSelect = () => {};
+    const nodes = buildCanvasNodes(
+      nodesInput({
+        room: roomWithScale,
+        members: [member("u1")],
+        viewerId: viewer,
+        selectedCardValue: "2",
+        callbacks: { onCardSelect },
+      }),
+    );
+
+    const cards = votingCards(nodes);
+    expect(cards.map((n) => n.id)).toEqual([
+      "card-u1-0",
+      "card-u1-1",
+      "card-u1-2",
+    ]);
+    expect(cards.map((n) => n.position)).toEqual(computeVotingCardRow(3));
+    expect(cards.map((n) => n.data.card.value)).toEqual(["1", "2", "3"]);
+    expect(cards.map((n) => n.data.isSelected)).toEqual([false, true, false]);
+    expect(cards.map((n) => n.selected)).toEqual([false, true, false]);
+    expect(cards.every((n) => n.draggable === false)).toBe(true);
+    expect(cards.every((n) => n.data.isSelectable)).toBe(true);
+    expect(cards.every((n) => n.data.onCardSelect === onCardSelect)).toBe(true);
+    expect(cards.every((n) => n.data.userId === viewer)).toBe(true);
+    expect(cards.every((n) => n.data.roomId === ROOM_ID)).toBe(true);
+  });
+
+  it("uses the default scale when the room has none", () => {
+    const nodes = buildCanvasNodes(nodesInput({ viewerId: viewer }));
+    const cards = votingCards(nodes);
+    expect(cards.map((n) => n.data.card.value)).toEqual([...DEFAULT_SCALE.cards]);
+    expect(cards.map((n) => n.position)).toEqual(
+      computeVotingCardRow(DEFAULT_SCALE.cards.length),
+    );
+  });
+
+  it("never shows the row to a spectator, nor to an anonymous non-demo viewer", () => {
+    const spectator = buildCanvasNodes(
+      nodesInput({
+        room: roomWithScale,
+        members: [member("u1", { isSpectator: true })],
+        viewerId: viewer,
+      }),
+    );
+    const anonymous = buildCanvasNodes(nodesInput({ room: roomWithScale }));
+
+    expect(spectator).toHaveLength(0);
+    expect(anonymous).toHaveLength(0);
+  });
+
+  it("shows the row in demo mode under the demo viewer id, never selectable", () => {
+    const onCardSelect = () => {};
+    const nodes = buildCanvasNodes(
+      nodesInput({
+        room: roomWithScale,
+        isDemoMode: true,
+        callbacks: { onCardSelect },
+      }),
+    );
+
+    const cards = votingCards(nodes);
+    expect(cards.map((n) => n.id)).toEqual([
+      `card-${DEMO_VIEWER_ID}-0`,
+      `card-${DEMO_VIEWER_ID}-1`,
+      `card-${DEMO_VIEWER_ID}-2`,
+    ]);
+    expect(cards.every((n) => n.data.isSelectable === false)).toBe(true);
+    expect(cards.every((n) => n.data.onCardSelect === undefined)).toBe(true);
+    expect(cards.every((n) => n.data.userId === DEMO_VIEWER_ID)).toBe(true);
+  });
+
+  it("suppresses selectability once the round is revealed", () => {
+    const nodes = buildCanvasNodes(
+      nodesInput({
+        room: roomWithScale,
+        members: [member("u1")],
+        viewerId: viewer,
+        phase: "revealed",
+      }),
+    );
+    const cards = votingCards(nodes);
+    expect(cards).toHaveLength(3);
+    expect(cards.every((n) => n.data.isSelectable === false)).toBe(true);
+  });
+});
+
+describe("isNoteForIssue", () => {
+  it("matches only note nodes carrying the given issue id", () => {
+    const note = noteCanvasNode(ISSUE_ID);
+    expect(isNoteForIssue(note, ISSUE_ID)).toBe(true);
+    expect(isNoteForIssue(note, "issue-2" as Id<"issues">)).toBe(false);
+    expect(isNoteForIssue(note, undefined)).toBe(false);
+    expect(isNoteForIssue(playerCanvasNode("u1"), ISSUE_ID)).toBe(false);
+  });
+});

--- a/src/components/room/hooks/buildCanvasNodes.ts
+++ b/src/components/room/hooks/buildCanvasNodes.ts
@@ -1,0 +1,369 @@
+/**
+ * buildCanvasNodes / buildCanvasEdges — the pure canvas derivation (#229).
+ *
+ * The ONE place the whiteboard's node and edge lists are derived from room
+ * state: every node type, the voting-card row, phase-dependent visibility, and
+ * decision-driven control disabling. Plain functions — no React, no Convex, no
+ * demo context — so the phase-by-node-type matrix is unit-testable, and the
+ * demo and live canvases are two callers of one implementation.
+ *
+ * Callers learn two builder interfaces (nodes, edges) plus one shared
+ * note-for-issue predicate; the per-node-type helpers stay private. The
+ * `useCanvasNodes` hook is the adapter that selects the data source
+ * (Convex vs demo context), derives the phase, and memoizes.
+ */
+import type { Edge } from "@xyflow/react";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { CanvasNode } from "@/convex/model/canvas";
+import type { SanitizedVote } from "@/convex/model/rooms";
+import type { RoomUserData } from "@/convex/model/users";
+import type { ResolvedDecision } from "@/convex/permissions";
+import type { Phase } from "@/convex/phase";
+import { computeVotingCardRow } from "@/convex/canvasLayout";
+import { DEFAULT_SCALE } from "@/convex/scales";
+import { DEMO_VIEWER_ID, type CustomNodeType } from "../types";
+
+/** The room fields the nodes builder reads — a view, not the whole document. */
+export interface CanvasRoomView {
+  name: string;
+  autoCompleteVoting: boolean;
+  /**
+   * Raw countdown-start timestamp, passed through solely as node data for the
+   * session node's ticking display — never a phase branch (that is `phase`'s
+   * job, derived once in the adapter via `phaseOf`).
+   */
+  autoRevealCountdownStartedAt: number | null;
+  votingScale?: { cards: string[]; isNumeric: boolean };
+}
+
+/** The canvas-triggered handlers written into node data at construction time. */
+export interface CanvasNodeCallbacks {
+  onRevealCards?: () => void;
+  onResetGame?: () => void;
+  onCardSelect?: (cardValue: string) => void;
+  onToggleAutoComplete?: () => void;
+  onCancelAutoReveal?: () => void;
+  onOpenIssuesPanel?: () => void;
+  onUpdateNoteContent?: (nodeId: string, content: string) => void;
+  onDeleteNote?: (nodeId: string, hasContent: boolean) => void;
+}
+
+/**
+ * Input to {@link buildCanvasNodes}. The adapter assembles this fresh per
+ * memo run from individual fields; the module never branches on raw round
+ * fields — `phase` is the only lifecycle signal.
+ */
+export interface CanvasNodesInput {
+  phase: Phase;
+  roomId: Id<"rooms">;
+  room: CanvasRoomView;
+  members: RoomUserData[];
+  votes: SanitizedVote[];
+  canvasNodes: CanvasNode[];
+  currentIssue: { _id: Id<"issues">; title: string } | null;
+  /** The viewing user; undefined for anonymous demo viewers. */
+  viewerId?: Id<"users">;
+  selectedCardValue: string | null;
+  isDemoMode: boolean;
+  canRevealCards: ResolvedDecision;
+  canControlGameFlow: ResolvedDecision;
+  canChangeRoomSettings: ResolvedDecision;
+  callbacks: CanvasNodeCallbacks;
+}
+
+/**
+ * Input to {@link buildCanvasEdges} — deliberately a strict subset of the
+ * nodes input: phase, members, canvas nodes, and the current issue are the
+ * only fields the edge rules ever read, so the adapter's edges memo can stop
+ * recomputing on unrelated room-data changes.
+ */
+export interface CanvasEdgesInput {
+  phase: Phase;
+  members: RoomUserData[];
+  canvasNodes: CanvasNode[];
+  currentIssue: { _id: Id<"issues"> } | null;
+}
+
+// --- Nodes builder -----------------------------------------------------------
+
+/**
+ * Derives the full node list from one room snapshot: each persisted canvas
+ * node hydrated with live data, plus the client-generated voting-card row.
+ */
+export function buildCanvasNodes(input: CanvasNodesInput): CustomNodeType[] {
+  const allNodes: CustomNodeType[] = [];
+
+  input.canvasNodes.forEach((node) => {
+    if (node.type === "player") {
+      const playerNode = buildPlayerNode(node, input);
+      if (playerNode) allNodes.push(playerNode);
+    } else if (node.type === "timer") {
+      allNodes.push(buildTimerNode(node, input));
+    } else if (node.type === "session") {
+      allNodes.push(buildSessionNode(node, input));
+    } else if (node.type === "results" && input.phase === "revealed") {
+      allNodes.push(buildResultsNode(node, input));
+    } else if (isNoteForIssue(node, input.currentIssue?._id)) {
+      allNodes.push(buildNoteNode(node, input));
+    }
+  });
+
+  allNodes.push(...buildVotingCardRow(input));
+
+  return allNodes;
+}
+
+/**
+ * The client-generated voting-card row: shown to non-spectator members, and to
+ * the anonymous demo viewer (where the cards are display-only — never
+ * selectable, no select handler).
+ */
+function buildVotingCardRow(input: CanvasNodesInput): CustomNodeType[] {
+  const shouldShowVotingCards = input.viewerId
+    ? !input.members.find((u) => u._id === input.viewerId)?.isSpectator
+    : input.isDemoMode;
+  if (!shouldShowVotingCards) return [];
+
+  const cards = input.room.votingScale?.cards ?? DEFAULT_SCALE.cards;
+  const cardPositions = computeVotingCardRow(cards.length);
+  const effectiveUserId = input.viewerId ?? DEMO_VIEWER_ID;
+
+  return cards.map((cardValue, index) => ({
+    id: `card-${effectiveUserId}-${index}`,
+    type: "votingCard",
+    position: cardPositions[index],
+    data: {
+      card: { value: cardValue },
+      userId: effectiveUserId,
+      roomId: input.roomId,
+      isSelectable: input.phase !== "revealed" && !input.isDemoMode,
+      isSelected: cardValue === input.selectedCardValue,
+      onCardSelect: input.isDemoMode ? undefined : input.callbacks.onCardSelect,
+    },
+    selected: cardValue === input.selectedCardValue,
+    draggable: false,
+  }));
+}
+
+function buildPlayerNode(
+  node: CanvasNode & { type: "player" },
+  input: CanvasNodesInput,
+): CustomNodeType | null {
+  const userId = node.data.userId;
+  const user = input.members.find((u) => u._id === userId);
+  if (!user) return null;
+
+  const userVote = input.votes.find((v) => v.userId === userId);
+
+  return {
+    id: node.nodeId,
+    type: "player",
+    position: node.position,
+    data: {
+      user,
+      isCurrentUser: userId === input.viewerId,
+      isCardPicked: userVote?.hasVoted || false,
+      card: input.phase === "revealed" ? userVote?.cardLabel || null : null,
+      phase: input.phase,
+      role: user.role ?? "participant",
+    },
+    draggable: !node.isLocked,
+  };
+}
+
+function buildTimerNode(
+  node: CanvasNode & { type: "timer" },
+  input: CanvasNodesInput,
+): CustomNodeType {
+  return {
+    id: node.nodeId,
+    type: "timer",
+    position: node.position,
+    data: {
+      ...node.data,
+      isRunning: node.data.isRunning ?? false,
+      roomId: input.roomId,
+      userId: input.viewerId,
+      nodeId: node.nodeId,
+    },
+    draggable: !node.isLocked,
+  };
+}
+
+function buildSessionNode(
+  node: CanvasNode & { type: "session" },
+  input: CanvasNodesInput,
+): CustomNodeType {
+  const { room, members, votes, currentIssue, callbacks } = input;
+  return {
+    id: node.nodeId,
+    type: "session",
+    position: node.position,
+    data: {
+      sessionName: room.name || "Planning Session",
+      participantCount: members.filter((u) => !u.isSpectator).length,
+      voteCount: votes.filter((v) => v.hasVoted).length,
+      phase: input.phase,
+      hasVotes: votes.some((v) => v.hasVoted),
+      autoCompleteVoting: room.autoCompleteVoting,
+      autoRevealCountdownStartedAt: room.autoRevealCountdownStartedAt,
+      currentIssue: currentIssue
+        ? { id: currentIssue._id, title: currentIssue.title }
+        : null,
+      canRevealCards: input.canRevealCards,
+      canControlGameFlow: input.canControlGameFlow,
+      canChangeRoomSettings: input.canChangeRoomSettings,
+      onRevealCards: callbacks.onRevealCards,
+      onResetGame: callbacks.onResetGame,
+      onToggleAutoComplete: callbacks.onToggleAutoComplete,
+      onCancelAutoReveal: callbacks.onCancelAutoReveal,
+      onOpenIssuesPanel: callbacks.onOpenIssuesPanel,
+    },
+    draggable: !node.isLocked,
+  };
+}
+
+function buildResultsNode(
+  node: CanvasNode & { type: "results" },
+  input: CanvasNodesInput,
+): CustomNodeType {
+  return {
+    id: node.nodeId,
+    type: "results",
+    position: node.position,
+    data: {
+      votes: input.votes.filter((v) => v.hasVoted),
+      users: input.members,
+      isNumericScale: input.room.votingScale?.isNumeric ?? true,
+    },
+    draggable: !node.isLocked,
+  };
+}
+
+function buildNoteNode(
+  node: CanvasNode & { type: "note" },
+  input: CanvasNodesInput,
+): CustomNodeType {
+  const { callbacks } = input;
+  const noteContent = node.data.content || "";
+  // The only per-node closures in the derivation: they must capture this
+  // node's identifier. Never part of a memo dependency array.
+  const nodeId = node.nodeId;
+  return {
+    id: nodeId,
+    type: "note",
+    position: node.position,
+    data: {
+      issueId: node.data.issueId,
+      issueTitle: node.data.issueTitle || input.currentIssue?.title || "",
+      content: noteContent,
+      lastUpdatedBy: node.data.lastUpdatedBy,
+      lastUpdatedAt: node.data.lastUpdatedAt,
+      onUpdateContent: (content: string) => {
+        callbacks.onUpdateNoteContent?.(nodeId, content);
+      },
+      onDelete: () => {
+        callbacks.onDeleteNote?.(nodeId, !!noteContent);
+      },
+    },
+    draggable: !node.isLocked,
+  };
+}
+
+/**
+ * The ONE implementation of "is this persisted node the note for that issue?"
+ * — shared by the nodes builder, the edges builder, and the adapter's
+ * `hasNoteForCurrentIssue`, so the three former copies cannot drift.
+ */
+export function isNoteForIssue(
+  node: CanvasNode,
+  issueId: Id<"issues"> | undefined,
+): node is CanvasNode & { type: "note" } {
+  return (
+    node.type === "note" && issueId !== undefined && node.data.issueId === issueId
+  );
+}
+
+/** Derives the edge list: which connectors exist and where they attach. */
+export function buildCanvasEdges(input: CanvasEdgesInput): Edge[] {
+  const { members } = input;
+  const allEdges: Edge[] = [];
+
+  // Session to Players edges (subtle, consistent with timer edge)
+  members.forEach((user) => {
+    allEdges.push({
+      id: `session-to-player-${user._id}`,
+      source: "session-current",
+      sourceHandle: "bottom",
+      target: `player-${user._id}`,
+      targetHandle: "top",
+      type: "default",
+      animated: false,
+      style: {
+        stroke: "#64748b",
+        strokeWidth: 2,
+        strokeOpacity: 0.6,
+      },
+    });
+  });
+
+  // Session to Results edge (once the round is revealed)
+  if (input.phase === "revealed") {
+    allEdges.push({
+      id: "session-to-results",
+      source: "session-current",
+      sourceHandle: "right",
+      target: "results",
+      targetHandle: "left",
+      type: "straight",
+      animated: false,
+      style: {
+        stroke: "#10b981",
+        strokeWidth: 2,
+        strokeDasharray: "5,5",
+        strokeOpacity: 0.6,
+      },
+    });
+  }
+
+  // Timer to Session edge
+  allEdges.push({
+    id: "timer-to-session",
+    source: "timer",
+    sourceHandle: "right",
+    target: "session-current",
+    targetHandle: "left",
+    type: "straight",
+    animated: false,
+    style: {
+      stroke: "#64748b",
+      strokeWidth: 2,
+      strokeDasharray: "5,5",
+      strokeOpacity: 0.6,
+    },
+  });
+
+  // Session to Note edge (when current issue has a note)
+  const noteNode = input.canvasNodes.find((n) =>
+    isNoteForIssue(n, input.currentIssue?._id),
+  );
+  if (noteNode) {
+    allEdges.push({
+      id: "session-to-note",
+      source: "session-current",
+      sourceHandle: "right",
+      target: noteNode.nodeId,
+      targetHandle: "left",
+      type: "straight",
+      animated: false,
+      style: {
+        stroke: "#f59e0b", // Amber color matching note node
+        strokeWidth: 2,
+        strokeDasharray: "5,5",
+        strokeOpacity: 0.6,
+      },
+    });
+  }
+
+  return allEdges;
+}

--- a/src/components/room/hooks/useCanvasNodes.test.tsx
+++ b/src/components/room/hooks/useCanvasNodes.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * useCanvasNodes — adapter-level identity guard (#229, user story 9).
+ *
+ * The derivation itself is covered by the pure buildCanvasNodes tests; here we
+ * pin the ONE contract the adapter adds on top: referential stability of the
+ * returned `nodes` and `edges` arrays across re-renders, including unrelated
+ * prop churn. This is the render-loop regression guard at the hook layer
+ * (prior art: the canvas actions hook tests).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { RoomWithRelatedData } from "@/convex/model/rooms";
+
+// Hoisted stable query results shared with the (hoisted) vi.mock factory: the
+// adapter must see referentially stable subscription data so any identity
+// churn the test observes is the adapter's own doing.
+const stable = vi.hoisted(() => ({
+  canvasNodes: [
+    {
+      roomId: "room-1",
+      nodeId: "session-current",
+      position: { x: 0, y: -300 },
+      lastUpdatedAt: 0,
+      type: "session",
+      data: {},
+    },
+    {
+      roomId: "room-1",
+      nodeId: "player-user-1",
+      position: { x: 0, y: 0 },
+      lastUpdatedAt: 0,
+      type: "player",
+      data: { userId: "user-1" },
+    },
+  ],
+  currentIssue: { _id: "issue-1", title: "Checkout flow" },
+}));
+
+vi.mock("convex/react", async () => {
+  const { getFunctionName } = await import("convex/server");
+  return {
+    useQuery: (query: Parameters<typeof getFunctionName>[0]) => {
+      const name = getFunctionName(query);
+      if (name === "canvas:getCanvasNodes") return stable.canvasNodes;
+      if (name === "issues:getCurrent") return stable.currentIssue;
+      return undefined;
+    },
+  };
+});
+
+import { useCanvasNodes } from "./useCanvasNodes";
+
+const ROOM_ID = "room-1" as Id<"rooms">;
+const USER_ID = "user-1" as Id<"users">;
+
+const ROOM_DATA: RoomWithRelatedData = {
+  room: {
+    _id: ROOM_ID,
+    _creationTime: 0,
+    name: "Sprint 42",
+    autoCompleteVoting: false,
+    isGameOver: false,
+    createdAt: 0,
+    lastActivityAt: 0,
+  },
+  users: [
+    {
+      _id: USER_ID,
+      name: "Alice",
+      isSpectator: false,
+      role: "participant",
+      joinedAt: 0,
+      membershipId: "membership-1" as Id<"roomMemberships">,
+    },
+  ],
+  votes: [],
+  isOwnerAbsent: false,
+};
+
+// Frozen-identity handlers, as the canvas-actions module guarantees in prod.
+const HANDLERS = {
+  onRevealCards: () => {},
+  onResetGame: () => {},
+  onCardSelect: () => {},
+  onToggleAutoComplete: () => {},
+  onCancelAutoReveal: () => {},
+  onOpenIssuesPanel: () => {},
+  onUpdateNoteContent: () => {},
+  onDeleteNote: () => {},
+};
+
+/**
+ * A fresh props object per render, with stable field identities — the shape
+ * of a real parent re-render.
+ */
+function baseProps(): Parameters<typeof useCanvasNodes>[0] {
+  return {
+    roomId: ROOM_ID,
+    roomData: ROOM_DATA,
+    currentUserId: USER_ID,
+    selectedCardValue: null as string | null,
+    ...HANDLERS,
+  };
+}
+
+describe("useCanvasNodes — referential stability", () => {
+  it("keeps nodes and edges identities across a re-render with equal props", () => {
+    const { result, rerender } = renderHook(useCanvasNodes, {
+      initialProps: baseProps(),
+    });
+    const first = result.current;
+    expect(first.nodes.length).toBeGreaterThan(0);
+    expect(first.edges.length).toBeGreaterThan(0);
+
+    rerender(baseProps());
+
+    expect(result.current.nodes).toBe(first.nodes);
+    expect(result.current.edges).toBe(first.edges);
+  });
+
+  it("keeps the edges identity under nodes-only prop churn", () => {
+    const { result, rerender } = renderHook(useCanvasNodes, {
+      initialProps: baseProps(),
+    });
+    const first = result.current;
+
+    // Card selection and permission decisions feed only the nodes builder.
+    rerender({ ...baseProps(), selectedCardValue: "8" });
+    rerender({
+      ...baseProps(),
+      selectedCardValue: "8",
+      canRevealCards: { allowed: false as const, message: "Owner only" },
+    });
+
+    expect(result.current.nodes).not.toBe(first.nodes);
+    expect(result.current.edges).toBe(first.edges);
+  });
+
+  it("verifies the mocked subscriptions actually feed the derivation", () => {
+    const { result } = renderHook(useCanvasNodes, {
+      initialProps: baseProps(),
+    });
+
+    expect(result.current.currentIssue).toEqual({
+      _id: "issue-1",
+      title: "Checkout flow",
+    });
+    expect(result.current.nodes.some((n) => n.type === "session")).toBe(true);
+    expect(result.current.nodes.some((n) => n.type === "player")).toBe(true);
+  });
+});

--- a/src/components/room/hooks/useCanvasNodes.ts
+++ b/src/components/room/hooks/useCanvasNodes.ts
@@ -5,17 +5,19 @@ import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
 import { Edge } from "@xyflow/react";
 import { useMemo } from "react";
-import { DEMO_VIEWER_ID, type CustomNodeType } from "../types";
-import type { RoomWithRelatedData, SanitizedVote } from "@/convex/model/rooms";
-import type { RoomUserData } from "@/convex/model/users";
+import { type CustomNodeType } from "../types";
+import type { RoomWithRelatedData } from "@/convex/model/rooms";
 import {
   type ResolvedDecision,
   RESOLVED_ALLOWED,
 } from "@/convex/permissions";
 import { phaseOf, type Phase } from "@/convex/phase";
-import { DEFAULT_SCALE } from "@/convex/scales";
-import { computeVotingCardRow } from "@/convex/canvasLayout";
 import { useDemoSimulation } from "../demo/DemoSimulationProvider";
+import {
+  buildCanvasEdges,
+  buildCanvasNodes,
+  isNoteForIssue,
+} from "./buildCanvasNodes";
 
 interface UseCanvasNodesProps {
   roomId: Id<"rooms">;
@@ -42,6 +44,17 @@ interface UseCanvasNodesReturn {
   hasNoteForCurrentIssue: boolean;
 }
 
+/**
+ * The adapter over the pure canvas derivation (#229): selects the data source
+ * (Convex vs demo context), derives the phase once per room snapshot, and
+ * memoizes the two builder calls. All derivation policy lives in
+ * `buildCanvasNodes.ts` — this hook adds nothing but React glue.
+ *
+ * The input objects are assembled fresh inside each memo body, so the
+ * dependency arrays MUST list the individual fields, never the freshly built
+ * wrappers — the exhaustive-deps lint cannot catch that mistake; reviewers
+ * must.
+ */
 export function useCanvasNodes({
   roomId,
   roomData,
@@ -83,13 +96,18 @@ export function useCanvasNodes({
   const currentIssueTitle = demo
     ? demo.currentIssue.title
     : currentIssueQuery?.title;
+  const currentIssue = useMemo(
+    () =>
+      currentIssueId
+        ? { _id: currentIssueId, title: currentIssueTitle ?? "" }
+        : null,
+    [currentIssueId, currentIssueTitle],
+  );
 
   // Check if a note exists for the current issue
   const hasNoteForCurrentIssue = useMemo(() => {
-    if (!currentIssueId || !canvasNodes) return false;
-    return canvasNodes.some(
-      (n) => n.type === "note" && n.data.issueId === currentIssueId
-    );
+    if (!canvasNodes) return false;
+    return canvasNodes.some((n) => isNoteForIssue(n, currentIssueId));
   }, [currentIssueId, canvasNodes]);
 
   // The ONE client-side phase derivation (issue #227): node data and edges
@@ -100,150 +118,36 @@ export function useCanvasNodes({
     if (!canvasNodes || !roomData || !phase) return [];
 
     const { room, users, votes } = roomData;
-    const allNodes: CustomNodeType[] = [];
-
-    // Process each canvas node
-    canvasNodes.forEach((node) => {
-      if (node.type === "player") {
-        const userId = node.data.userId;
-        const user = users.find((u: RoomUserData) => u._id === userId);
-        if (!user) return;
-
-        const userVote = votes.find((v: SanitizedVote) => v.userId === userId);
-
-        const userRole = user.role ?? "participant";
-        const playerNode: CustomNodeType = {
-          id: node.nodeId,
-          type: "player",
-          position: node.position,
-          data: {
-            user,
-            isCurrentUser: userId === currentUserId,
-            isCardPicked: userVote?.hasVoted || false,
-            card: phase === "revealed" ? userVote?.cardLabel || null : null,
-            phase,
-            role: userRole,
-          },
-          draggable: !node.isLocked,
-        };
-        allNodes.push(playerNode);
-      } else if (node.type === "timer") {
-        const timerNode: CustomNodeType = {
-          id: node.nodeId,
-          type: "timer",
-          position: node.position,
-          data: {
-            ...node.data,
-            isRunning: node.data.isRunning ?? false,
-            roomId,
-            userId: currentUserId,
-            nodeId: node.nodeId,
-          },
-          draggable: !node.isLocked,
-        };
-        allNodes.push(timerNode);
-      } else if (node.type === "session") {
-        const sessionNode: CustomNodeType = {
-          id: node.nodeId,
-          type: "session",
-          position: node.position,
-          data: {
-            sessionName: room.name || "Planning Session",
-            participantCount: users.filter((u) => !u.isSpectator).length,
-            voteCount: votes.filter((v: SanitizedVote) => v.hasVoted).length,
-            phase,
-            hasVotes: votes.some((v: SanitizedVote) => v.hasVoted),
-            autoCompleteVoting: room.autoCompleteVoting,
-            autoRevealCountdownStartedAt: room.autoRevealCountdownStartedAt ?? null,
-            currentIssue: currentIssueId
-              ? { id: currentIssueId, title: currentIssueTitle ?? "" }
-              : null,
-            canRevealCards,
-            canControlGameFlow,
-            canChangeRoomSettings,
-            onRevealCards,
-            onResetGame,
-            onToggleAutoComplete,
-            onCancelAutoReveal,
-            onOpenIssuesPanel,
-          },
-          draggable: !node.isLocked,
-        };
-        allNodes.push(sessionNode);
-      } else if (node.type === "results" && phase === "revealed") {
-        const resultsNode: CustomNodeType = {
-          id: node.nodeId,
-          type: "results",
-          position: node.position,
-          data: {
-            votes: votes.filter((v: SanitizedVote) => v.hasVoted),
-            users: users,
-            isNumericScale: room.votingScale?.isNumeric ?? true,
-          },
-          draggable: !node.isLocked,
-        };
-        allNodes.push(resultsNode);
-      } else if (node.type === "note") {
-        // Only show note if it belongs to the current issue
-        const noteIssueId = node.data.issueId;
-        if (currentIssueId && noteIssueId === currentIssueId) {
-          const noteContent = node.data.content || "";
-          const nodeId = node.nodeId;
-          const noteNode: CustomNodeType = {
-            id: nodeId,
-            type: "note",
-            position: node.position,
-            data: {
-              issueId: noteIssueId,
-              issueTitle: node.data.issueTitle || currentIssueTitle || "",
-              content: noteContent,
-              lastUpdatedBy: node.data.lastUpdatedBy,
-              lastUpdatedAt: node.data.lastUpdatedAt,
-              onUpdateContent: (content: string) => {
-                onUpdateNoteContent?.(nodeId, content);
-              },
-              onDelete: () => {
-                onDeleteNote?.(nodeId, !!noteContent);
-              },
-            },
-            draggable: !node.isLocked,
-          };
-          allNodes.push(noteNode);
-        }
-      }
+    return buildCanvasNodes({
+      phase,
+      roomId,
+      room: {
+        name: room.name,
+        autoCompleteVoting: room.autoCompleteVoting,
+        autoRevealCountdownStartedAt: room.autoRevealCountdownStartedAt ?? null,
+        votingScale: room.votingScale,
+      },
+      members: users,
+      votes,
+      canvasNodes,
+      currentIssue,
+      viewerId: currentUserId,
+      selectedCardValue,
+      isDemoMode,
+      canRevealCards,
+      canControlGameFlow,
+      canChangeRoomSettings,
+      callbacks: {
+        onRevealCards,
+        onResetGame,
+        onCardSelect,
+        onToggleAutoComplete,
+        onCancelAutoReveal,
+        onOpenIssuesPanel,
+        onUpdateNoteContent,
+        onDeleteNote,
+      },
     });
-
-    // Generate voting cards client-side for non-spectator users or demo mode
-    const shouldShowVotingCards = currentUserId
-      ? !users.find((u: RoomUserData) => u._id === currentUserId)?.isSpectator
-      : isDemoMode;
-
-    if (shouldShowVotingCards) {
-      const cards = room.votingScale?.cards ?? DEFAULT_SCALE.cards;
-      const cardPositions = computeVotingCardRow(cards.length);
-      const effectiveUserId = currentUserId ?? DEMO_VIEWER_ID;
-
-      cards.forEach((cardValue, index) => {
-        const votingCardNode: CustomNodeType = {
-          id: `card-${effectiveUserId}-${index}`,
-          type: "votingCard",
-          position: cardPositions[index],
-          data: {
-            card: { value: cardValue },
-            userId: effectiveUserId,
-            roomId,
-            isSelectable: phase !== "revealed" && !isDemoMode,
-            isSelected: cardValue === selectedCardValue,
-            onCardSelect: isDemoMode ? undefined : onCardSelect,
-          },
-          selected: cardValue === selectedCardValue,
-          draggable: false,
-        };
-        allNodes.push(votingCardNode);
-      });
-    }
-
-    return allNodes;
     // Every handler arrives with a frozen identity from the canvas-actions
     // module (and the panel/confirmation hooks), so listing them as memo
     // dependencies is safe — they never churn and the node list never rebuilds.
@@ -254,8 +158,7 @@ export function useCanvasNodes({
     currentUserId,
     selectedCardValue,
     roomId,
-    currentIssueId,
-    currentIssueTitle,
+    currentIssue,
     isDemoMode,
     canRevealCards,
     canControlGameFlow,
@@ -270,97 +173,25 @@ export function useCanvasNodes({
     onDeleteNote,
   ]);
 
+  // The edges builder reads a strict subset of the nodes input, so this memo
+  // depends on `users` rather than all of `roomData` — edges stop recomputing
+  // on unrelated room-data changes.
+  const users = roomData?.users;
   const edges = useMemo(() => {
-    if (!canvasNodes || !roomData) return [];
+    if (!canvasNodes || !users || !phase) return [];
 
-    const { users } = roomData;
-    const allEdges: Edge[] = [];
-
-    // Session to Players edges (subtle, consistent with timer edge)
-    users.forEach((user: RoomUserData) => {
-      allEdges.push({
-        id: `session-to-player-${user._id}`,
-        source: "session-current",
-        sourceHandle: "bottom",
-        target: `player-${user._id}`,
-        targetHandle: "top",
-        type: "default",
-        animated: false,
-        style: {
-          stroke: "#64748b",
-          strokeWidth: 2,
-          strokeOpacity: 0.6,
-        },
-      });
+    return buildCanvasEdges({
+      phase,
+      members: users,
+      canvasNodes,
+      currentIssue: currentIssueId ? { _id: currentIssueId } : null,
     });
-
-    // Session to Results edge (once the round is revealed)
-    if (phase === "revealed") {
-      allEdges.push({
-        id: "session-to-results",
-        source: "session-current",
-        sourceHandle: "right",
-        target: "results",
-        targetHandle: "left",
-        type: "straight",
-        animated: false,
-        style: {
-          stroke: "#10b981",
-          strokeWidth: 2,
-          strokeDasharray: "5,5",
-          strokeOpacity: 0.6,
-        },
-      });
-    }
-
-    // Timer to Session edge
-    allEdges.push({
-      id: "timer-to-session",
-      source: "timer",
-      sourceHandle: "right",
-      target: "session-current",
-      targetHandle: "left",
-      type: "straight",
-      animated: false,
-      style: {
-        stroke: "#64748b",
-        strokeWidth: 2,
-        strokeDasharray: "5,5",
-        strokeOpacity: 0.6,
-      },
-    });
-
-    // Session to Note edge (when current issue has a note)
-    if (currentIssueId) {
-      const noteNode = canvasNodes.find(
-        (n) => n.type === "note" && n.data.issueId === currentIssueId
-      );
-      if (noteNode) {
-        allEdges.push({
-          id: "session-to-note",
-          source: "session-current",
-          sourceHandle: "right",
-          target: noteNode.nodeId,
-          targetHandle: "left",
-          type: "straight",
-          animated: false,
-          style: {
-            stroke: "#f59e0b", // Amber color matching note node
-            strokeWidth: 2,
-            strokeDasharray: "5,5",
-            strokeOpacity: 0.6,
-          },
-        });
-      }
-    }
-
-    return allEdges;
-  }, [canvasNodes, roomData, phase, currentIssueId]);
+  }, [canvasNodes, users, phase, currentIssueId]);
 
   return {
     nodes,
     edges,
-    currentIssue: currentIssueId ? { _id: currentIssueId, title: currentIssueTitle ?? "" } : null,
+    currentIssue,
     hasNoteForCurrentIssue,
   };
 }


### PR DESCRIPTION
Closes #229

## What

Extracts the entire canvas derivation — every node type, the voting-card row, phase-dependent visibility, decision-driven control disabling — out of `useCanvasNodes` into a pure module beside the hook:

- **`buildCanvasNodes.ts`** exports two public builders (`buildCanvasNodes`, `buildCanvasEdges`), the shared `isNoteForIssue` predicate, and the two input types. Per-node-type helpers stay private. The module has no React, no Convex, no demo context, and branches only on `phase` (never raw round fields); card-row geometry comes from the shared `canvasLayout` module.
- **`useCanvasNodes`** shrinks to an adapter: demo-vs-live source selection, the one `phaseOf` derivation, `currentIssue` stabilization, and memoization. Public props and return shape are unchanged — the canvas call site needs no edits.
- The edges memo now depends only on the strict subset the edge rules read (phase, members, canvas nodes, current issue).
- The note-for-issue lookup goes from three drifting copies to one implementation.

## Tests

- **New pure test file** (node project, 23 tests, written test-first): phase-by-node-type matrix, spectator and demo card-row visibility, selectability suppressed in demo mode and after reveal, card-row geometry asserted against `computeVotingCardRow` itself, resolved decisions passed through unaltered (allowed and denied), callback wiring asserted by reference, note closures invoked to prove they capture the right node, all four edge rules, and the predicate.
- **New jsdom adapter test** (3 tests): unrelated prop churn keeps the same `nodes`/`edges` array references — the render-loop regression guard at the hook layer.
- Demo zero-reads test passes unchanged; `room-canvas.tsx` untouched.

## Verification

- `tsc --noEmit`, ESLint clean
- Full unit suite: 208/208
- Full Playwright e2e suite: 83 passed, 1 skipped, 0 failed
- Two-axis review (standards + spec fidelity vs #229) found no hard violations and zero behavioral drift; its one cleanup suggestion (duplicated `currentIssue` literal in the adapter) is applied.