### PR TITLE
fix(security): security audit — 12 fixes (webhook auth, authz gaps, XSS, injection, headers)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,8 +29,9 @@ NEXT_PUBLIC_SITE_URL=http://localhost:3000
 # JIRA_CLIENT_ID=your-atlassian-client-id
 # JIRA_CLIENT_SECRET=your-atlassian-client-secret
 
-# Optional webhook secret header check. If enabled, your edge/proxy should
-# inject x-hub-secret on requests to /webhooks/jira.
+# Required shared secret for the Jira webhook endpoint (/webhooks/jira).
+# Deliveries without a matching secret are rejected, and webhook registration
+# embeds it in the callback URL (Jira cannot send custom headers).
 # JIRA_WEBHOOK_SECRET=your-shared-secret
 
 # Convex server-side encryption key (set via `npx convex env set`)

--- a/convex/canvas.ts
+++ b/convex/canvas.ts
@@ -69,7 +69,10 @@ export const removePlayerNode = mutation({
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    await requireRoomMember(ctx, args.roomId);
+    const { user } = await requireRoomMember(ctx, args.roomId);
+    if (user._id !== args.userId) {
+      throw new Error("Cannot act as another user");
+    }
     await Canvas.removePlayerNode(ctx, args);
   },
 });

--- a/convex/canvas.ts
+++ b/convex/canvas.ts
@@ -121,12 +121,14 @@ export const updateNoteContent = mutation({
 });
 
 // Get note content for an issue (for export)
+// Requires room membership: note contents are private to the room.
 export const getNoteContentForIssue = query({
   args: {
     roomId: v.id("rooms"),
     issueId: v.id("issues"),
   },
   handler: async (ctx, args) => {
+    await requireRoomMember(ctx, args.roomId);
     return await Canvas.getNoteContentForIssue(ctx, args);
   },
 });

--- a/convex/constants.ts
+++ b/convex/constants.ts
@@ -6,3 +6,11 @@
  * Duration for auto-reveal countdown in milliseconds
  */
 export const COUNTDOWN_DURATION_MS = 3000; // 3 seconds
+
+/**
+ * Abuse-prevention caps for participant-writable content. Chosen well above
+ * any legitimate planning-poker usage so real rooms never hit them.
+ */
+export const MAX_ROOM_NAME_LENGTH = 100;
+export const MAX_ISSUE_TITLE_LENGTH = 500;
+export const MAX_ISSUES_PER_ROOM = 500;

--- a/convex/http.ts
+++ b/convex/http.ts
@@ -7,21 +7,46 @@ const http = httpRouter();
 
 authComponent.registerRoutes(http, createAuth);
 
+// Constant-time string comparison via fixed-length digests, so neither the
+// length nor the matching prefix of the secret leaks through timing.
+async function timingSafeEqual(a: string, b: string): Promise<boolean> {
+  const encoder = new TextEncoder();
+  const [hashA, hashB] = await Promise.all([
+    crypto.subtle.digest("SHA-256", encoder.encode(a)),
+    crypto.subtle.digest("SHA-256", encoder.encode(b)),
+  ]);
+  const viewA = new Uint8Array(hashA);
+  const viewB = new Uint8Array(hashB);
+  let diff = 0;
+  for (let i = 0; i < viewA.length; i++) {
+    diff |= viewA[i] ^ viewB[i];
+  }
+  return diff === 0;
+}
+
 // Jira webhook endpoint — receives issue updates from Jira Cloud
 http.route({
   path: "/webhooks/jira",
   method: "POST",
   handler: httpAction(async (ctx, request) => {
     try {
-      // Optional shared-secret check via header.
-      // We intentionally avoid query-param secrets because URLs are commonly logged.
+      // Shared-secret check. Jira Cloud webhooks cannot send custom headers,
+      // so the registration embeds the secret in the webhook URL as a query
+      // param (high-entropy, HTTPS-only); the header is accepted as well.
+      // Fail closed: without a configured secret no delivery is trusted.
       const webhookSecret = process.env.JIRA_WEBHOOK_SECRET;
-      if (webhookSecret) {
-        const token = request.headers.get("x-hub-secret");
-        if (!token || token !== webhookSecret) {
-          console.warn("Jira webhook rejected: invalid secret");
-          return new Response("Forbidden", { status: 403 });
-        }
+      if (!webhookSecret) {
+        console.error(
+          "Jira webhook rejected: JIRA_WEBHOOK_SECRET is not configured"
+        );
+        return new Response("Forbidden", { status: 403 });
+      }
+      const token =
+        request.headers.get("x-hub-secret") ??
+        new URL(request.url).searchParams.get("secret");
+      if (!token || !(await timingSafeEqual(token, webhookSecret))) {
+        console.warn("Jira webhook rejected: invalid secret");
+        return new Response("Forbidden", { status: 403 });
       }
 
       const payload = await request.json();

--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -756,7 +756,16 @@ export const registerWebhook = internalAction({
     if (!connection) throw new Error("Connection not found");
 
     const client = await buildJiraClient(ctx, connection);
-    const webhookUrl = `${process.env.CONVEX_SITE_URL}/webhooks/jira`;
+    // Jira Cloud webhooks cannot send custom headers, so the shared secret
+    // travels in the registered URL. The endpoint rejects deliveries without
+    // it, so registration must not proceed when the secret is missing.
+    const webhookSecret = process.env.JIRA_WEBHOOK_SECRET;
+    if (!webhookSecret) {
+      throw new Error(
+        "JIRA_WEBHOOK_SECRET must be configured to register a Jira webhook"
+      );
+    }
+    const webhookUrl = `${process.env.CONVEX_SITE_URL}/webhooks/jira?secret=${encodeURIComponent(webhookSecret)}`;
 
     try {
       if (mapping.jiraWebhookId) {

--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -22,6 +22,8 @@ import {
 } from "../permissions";
 import { isRoomOwnerAbsent } from "../model/permissions";
 import { JiraClient } from "./jiraClient";
+import { validateIssueTitle } from "../model/issues";
+import { MAX_ISSUES_PER_ROOM } from "../constants";
 
 function getTokenEncryptionKey(): string {
   const key = process.env.TOKEN_ENCRYPTION_KEY;
@@ -250,6 +252,10 @@ export const createIssueWithLink = internalMutation({
       .withIndex("by_room", (q) => q.eq("roomId", args.roomId))
       .collect();
 
+    if (roomIssues.length >= MAX_ISSUES_PER_ROOM) {
+      throw new Error(`Rooms are limited to ${MAX_ISSUES_PER_ROOM} issues`);
+    }
+
     for (const issue of roomIssues) {
       const link = await ctx.db
         .query("issueLinks")
@@ -284,7 +290,7 @@ export const createIssueWithLink = internalMutation({
     const issueId = await ctx.db.insert("issues", {
       roomId: args.roomId,
       sequentialId: currentNumber,
-      title: args.title,
+      title: validateIssueTitle(args.title),
       status: "pending",
       createdAt: Date.now(),
       order: maxOrder + 1,

--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -236,6 +236,13 @@ export const createIssueWithLink = internalMutation({
     externalUrl: v.string(),
   },
   handler: async (ctx, args) => {
+    // externalUrl is rendered as an anchor href in the room UI — only allow
+    // real web URLs so a malicious integration connection can't inject a
+    // javascript: link.
+    if (!args.externalUrl.startsWith("https://")) {
+      throw new Error("externalUrl must be an https:// URL");
+    }
+
     // Dedup per-room: same Jira issue can exist in multiple rooms,
     // but not twice in the same room.
     const roomIssues = await ctx.db
@@ -457,6 +464,22 @@ export const connectJira = action({
   handler: async (ctx, args) => {
     const identity = await ctx.auth.getUserIdentity();
     if (!identity) throw new Error("Not authenticated");
+
+    // The siteUrl is stored and later concatenated into issue browse links
+    // rendered as anchor hrefs. This action is public, so a client could
+    // bypass the OAuth callback and store a javascript: URL — validate it.
+    let parsedSiteUrl: URL;
+    try {
+      parsedSiteUrl = new URL(args.siteUrl);
+    } catch {
+      throw new Error("Invalid Jira site URL");
+    }
+    if (
+      parsedSiteUrl.protocol !== "https:" ||
+      !parsedSiteUrl.hostname.endsWith(".atlassian.net")
+    ) {
+      throw new Error("Jira site URL must be an https://*.atlassian.net URL");
+    }
 
     // Resolve user from auth identity
     const user: Doc<"users"> | null = await ctx.runQuery(

--- a/convex/issues.ts
+++ b/convex/issues.ts
@@ -25,11 +25,13 @@ export const getCurrent = query({
 });
 
 /**
- * Get issues formatted for export
+ * Get issues formatted for export.
+ * Requires room membership: the export includes discussion-note contents.
  */
 export const getForExport = query({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
+    await requireRoomMember(ctx, args.roomId);
     return await Issues.getIssuesForExport(ctx, args.roomId);
   },
 });

--- a/convex/model/issues.ts
+++ b/convex/model/issues.ts
@@ -1,8 +1,29 @@
 import { QueryCtx, MutationCtx } from "../_generated/server";
 import { Id, Doc } from "../_generated/dataModel";
 import * as VotingRound from "./votingRound";
+import {
+  MAX_ISSUE_TITLE_LENGTH,
+  MAX_ISSUES_PER_ROOM,
+} from "../constants";
 
 export type IssueStatus = "pending" | "voting" | "completed";
+
+/**
+ * Validates an issue title (trims, enforces non-empty and a length cap).
+ * Jira-imported titles ("KEY - summary") fit comfortably under the cap.
+ */
+export function validateIssueTitle(title: string): string {
+  const trimmed = title.trim();
+  if (!trimmed) {
+    throw new Error("Issue title is required");
+  }
+  if (trimmed.length > MAX_ISSUE_TITLE_LENGTH) {
+    throw new Error(
+      `Issue title must be ${MAX_ISSUE_TITLE_LENGTH} characters or less`
+    );
+  }
+  return trimmed;
+}
 
 export interface VoteStats {
   average: number | null;
@@ -105,6 +126,9 @@ export async function createIssue(
     .query("issues")
     .withIndex("by_room", (q) => q.eq("roomId", args.roomId))
     .collect();
+  if (issues.length >= MAX_ISSUES_PER_ROOM) {
+    throw new Error(`Rooms are limited to ${MAX_ISSUES_PER_ROOM} issues`);
+  }
   const maxOrder = issues.length > 0 ? Math.max(...issues.map((i) => i.order)) : 0;
 
   // Update room's next issue number
@@ -117,7 +141,7 @@ export async function createIssue(
   return await ctx.db.insert("issues", {
     roomId: args.roomId,
     sequentialId: nextNumber,
-    title: args.title,
+    title: validateIssueTitle(args.title),
     status: "pending",
     createdAt: Date.now(),
     order: maxOrder + 1,
@@ -134,7 +158,7 @@ export async function updateIssueTitle(
   const issue = await ctx.db.get(args.issueId);
   if (!issue) throw new Error("Issue not found");
 
-  await ctx.db.patch(args.issueId, { title: args.title });
+  await ctx.db.patch(args.issueId, { title: validateIssueTitle(args.title) });
 
   // Update room activity
   await ctx.db.patch(issue.roomId, { lastActivityAt: Date.now() });

--- a/convex/model/issues.ts
+++ b/convex/model/issues.ts
@@ -291,6 +291,19 @@ export async function reorderIssues(
   ctx: MutationCtx,
   args: { roomId: Id<"rooms">; issueIds: Id<"issues">[] }
 ): Promise<void> {
+  // Authorization was checked against args.roomId, so every reordered issue
+  // must belong to that room — otherwise issue IDs from another room could be
+  // smuggled into the array to scramble its ordering.
+  const issues = await Promise.all(
+    args.issueIds.map((issueId) => ctx.db.get(issueId))
+  );
+  for (const issue of issues) {
+    if (!issue) throw new Error("Issue not found");
+    if (issue.roomId !== args.roomId) {
+      throw new Error("Issue does not belong to this room");
+    }
+  }
+
   // Update order for each issue
   await Promise.all(
     args.issueIds.map((issueId, index) =>

--- a/convex/model/rooms.ts
+++ b/convex/model/rooms.ts
@@ -3,6 +3,7 @@ import { Id, Doc } from "../_generated/dataModel";
 import * as Canvas from "./canvas";
 import * as Users from "./users";
 import { VOTING_SCALES, VotingScaleType } from "../scales";
+import { MAX_ROOM_NAME_LENGTH } from "../constants";
 import { isRoomOwnerAbsent } from "./permissions";
 
 export interface CreateRoomArgs {
@@ -14,6 +15,26 @@ export interface CreateRoomArgs {
     cards?: string[]; // Required only for custom type
   };
 }
+
+/**
+ * Validates a room name (trims, enforces non-empty and a length cap).
+ */
+export function validateRoomName(name: string): string {
+  const trimmed = name.trim();
+  if (!trimmed) {
+    throw new Error("Room name is required");
+  }
+  if (trimmed.length > MAX_ROOM_NAME_LENGTH) {
+    throw new Error(`Room name must be ${MAX_ROOM_NAME_LENGTH} characters or less`);
+  }
+  return trimmed;
+}
+
+// Custom scale rules — mirror validateCustomScale in src/lib/voting-scales.ts
+// so direct Convex clients can't bypass them with oversized card arrays.
+const CUSTOM_SCALE_MIN_CARDS = 3;
+const CUSTOM_SCALE_MAX_CARDS = 20;
+const CUSTOM_SCALE_MAX_CARD_LENGTH = 10;
 
 export interface SanitizedVote extends Doc<"votes"> {
   hasVoted: boolean;
@@ -45,9 +66,27 @@ function resolveVotingScale(scaleConfig?: CreateRoomArgs["votingScale"]) {
     if (!scaleConfig.cards || scaleConfig.cards.length === 0) {
       throw new Error("Custom scale requires cards array");
     }
+    const cards = scaleConfig.cards;
+    if (cards.length < CUSTOM_SCALE_MIN_CARDS) {
+      throw new Error(`Minimum ${CUSTOM_SCALE_MIN_CARDS} cards required`);
+    }
+    if (cards.length > CUSTOM_SCALE_MAX_CARDS) {
+      throw new Error(`Maximum ${CUSTOM_SCALE_MAX_CARDS} cards allowed`);
+    }
+    if (new Set(cards).size !== cards.length) {
+      throw new Error("Duplicate card values not allowed");
+    }
+    if (cards.some((c) => c.trim() === "")) {
+      throw new Error("Empty card values not allowed");
+    }
+    if (cards.some((c) => c.length > CUSTOM_SCALE_MAX_CARD_LENGTH)) {
+      throw new Error(
+        `Card values must be ${CUSTOM_SCALE_MAX_CARD_LENGTH} characters or less`
+      );
+    }
     return {
       type: "custom" as const,
-      cards: scaleConfig.cards,
+      cards,
       isNumeric: false, // Custom scales default to non-numeric
     };
   }
@@ -71,7 +110,7 @@ export async function createRoom(
   const votingScale = resolveVotingScale(args.votingScale);
 
   const roomId = await ctx.db.insert("rooms", {
-    name: args.name,
+    name: validateRoomName(args.name),
     roomType: "canvas", // Always canvas now
     autoCompleteVoting: args.autoCompleteVoting ?? false,
     isGameOver: false,

--- a/convex/model/users.ts
+++ b/convex/model/users.ts
@@ -10,6 +10,12 @@ export interface JoinRoomArgs {
   name: string;
   isSpectator?: boolean;
   authUserId: string;
+  /**
+   * When false, an existing user's display name is left untouched. The
+   * unauthenticated post-sign-in race path passes false so that a caller
+   * without a verified identity can never rename someone else's account.
+   */
+  allowRename?: boolean;
 }
 
 export interface EditUserArgs {
@@ -36,7 +42,7 @@ export interface RoomUserData {
  */
 export async function findOrCreateGlobalUser(
   ctx: MutationCtx,
-  args: { authUserId: string; name: string }
+  args: { authUserId: string; name: string; allowRename?: boolean }
 ): Promise<Id<"users">> {
   // Check for existing global user
   const existingUser = await ctx.db
@@ -45,8 +51,8 @@ export async function findOrCreateGlobalUser(
     .first();
 
   if (existingUser) {
-    // Update name if changed
-    if (existingUser.name !== args.name) {
+    // Update name if changed (unless the caller's identity is unverified)
+    if (args.allowRename !== false && existingUser.name !== args.name) {
       await ctx.db.patch(existingUser._id, { name: args.name });
     }
     return existingUser._id;
@@ -127,6 +133,7 @@ export async function joinRoom(
   const userId = await findOrCreateGlobalUser(ctx, {
     authUserId: args.authUserId,
     name: args.name,
+    allowRename: args.allowRename,
   });
 
   // Check if membership already exists for this room

--- a/convex/model/votingRound.ts
+++ b/convex/model/votingRound.ts
@@ -6,7 +6,7 @@ import * as Issues from "./issues";
 import * as Canvas from "./canvas";
 import * as Votes from "./votes";
 import { summarize } from "../summarize";
-import { SPECIAL_CARDS, VotingScale } from "../scales";
+import { SPECIAL_CARDS, DEFAULT_SCALE, VotingScale } from "../scales";
 import { COUNTDOWN_DURATION_MS } from "../constants";
 
 /**
@@ -427,6 +427,19 @@ export async function castVote(ctx: MutationCtx, args: CastVoteArgs): Promise<vo
     throw new Error("Spectators cannot vote");
   }
 
+  // Validate the card against the room's voting scale and re-derive its numeric
+  // value server-side. pickCard is public, so an unchecked label/value would
+  // flow into vote stats, exports, and auto-pushed Jira estimates.
+  const room = await ctx.db.get(args.roomId);
+  if (!room) throw new Error("Room not found");
+  const scale = room.votingScale ?? DEFAULT_SCALE;
+  const scaleCards: readonly string[] = scale.cards;
+  if (!scaleCards.includes(args.cardLabel)) {
+    throw new Error("Card is not in this room's voting scale");
+  }
+  const parsedValue = scale.isNumeric ? Number.parseFloat(args.cardLabel) : 0;
+  const cardValue = Number.isFinite(parsedValue) ? parsedValue : 0;
+
   await Rooms.updateRoomActivity(ctx, args.roomId);
 
   const existing = await ctx.db
@@ -439,7 +452,7 @@ export async function castVote(ctx: MutationCtx, args: CastVoteArgs): Promise<vo
   if (existing) {
     await ctx.db.patch(existing._id, {
       cardLabel: args.cardLabel,
-      cardValue: args.cardValue,
+      cardValue,
       cardIcon: args.cardIcon,
     });
   } else {
@@ -447,7 +460,7 @@ export async function castVote(ctx: MutationCtx, args: CastVoteArgs): Promise<vo
       roomId: args.roomId,
       userId: args.userId,
       cardLabel: args.cardLabel,
-      cardValue: args.cardValue,
+      cardValue,
       cardIcon: args.cardIcon,
     });
   }

--- a/convex/presence.ts
+++ b/convex/presence.ts
@@ -1,7 +1,9 @@
 import { mutation, query } from "./_generated/server";
 import { components } from "./_generated/api";
+import { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { Presence } from "@convex-dev/presence";
+import { requireRoomMember } from "./model/auth";
 
 export const presence = new Presence(components.presence);
 
@@ -13,6 +15,14 @@ export const heartbeat = mutation({
     interval: v.number(),
   },
   handler: async (ctx, { roomId, userId, sessionId, interval }) => {
+    // The presence component accepts bare strings, so verify the caller is
+    // actually this room member before heartbeating as them — otherwise any
+    // client could spoof another user's online status or inject phantom
+    // presence into arbitrary rooms.
+    const { user } = await requireRoomMember(ctx, roomId as Id<"rooms">);
+    if (user._id !== userId) {
+      throw new Error("Cannot heartbeat as another user");
+    }
     return await presence.heartbeat(ctx, roomId, userId, sessionId, interval);
   },
 });

--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -123,7 +123,7 @@ export const rename = mutation({
   handler: async (ctx, args) => {
     await requireCan(ctx, args.roomId, { kind: "category", category: "roomSettings" });
     await ctx.db.patch(args.roomId, {
-      name: args.name,
+      name: Rooms.validateRoomName(args.name),
       lastActivityAt: Date.now(),
     });
   },

--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -6,6 +6,7 @@ import {
   requireAuth,
   requireAuthUser,
   requireCan,
+  requireRoomMember,
 } from "./model/auth";
 
 // Create a new room
@@ -66,7 +67,9 @@ export const getUserRooms = query({
 export const updateActivity = mutation({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
-    await requireAuth(ctx);
+    // Membership, not just auth: otherwise any signed-in user could keep
+    // arbitrary rooms alive forever, defeating the inactivity cleanup cron.
+    await requireRoomMember(ctx, args.roomId);
     await Rooms.updateRoomActivity(ctx, args.roomId);
   },
 });

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -64,10 +64,33 @@ export const join = mutation({
     authUserId: v.string(), // Kept for post-sign-in race condition
   },
   handler: async (ctx, args) => {
-    // If auth is available, verify the caller owns this authUserId
+    // Verify the caller owns this authUserId. When the session token hasn't
+    // propagated to Convex yet (post-sign-in race), an unauthenticated caller
+    // may only create a brand-new user record or rejoin a room they already
+    // belong to — anything else would let someone rename another user's
+    // account or forge a membership in their name.
     const identity = await ctx.auth.getUserIdentity();
-    if (identity && identity.subject !== args.authUserId) {
-      throw new Error("Auth identity mismatch");
+    let allowRename = true;
+    if (identity) {
+      if (identity.subject !== args.authUserId) {
+        throw new Error("Auth identity mismatch");
+      }
+    } else {
+      allowRename = false;
+      const existingUser = await Users.getGlobalUserByAuthUserId(
+        ctx,
+        args.authUserId
+      );
+      if (existingUser) {
+        const membership = await Users.getMembership(
+          ctx,
+          args.roomId,
+          existingUser._id
+        );
+        if (!membership) {
+          throw new Error("Authentication required");
+        }
+      }
     }
 
     return await Users.joinRoom(ctx, {
@@ -75,6 +98,7 @@ export const join = mutation({
       name: validateName(args.name),
       isSpectator: args.isSpectator,
       authUserId: args.authUserId,
+      allowRename,
     });
   },
 });
@@ -191,10 +215,24 @@ export const ensureGlobalUser = mutation({
     name: v.string(),
   },
   handler: async (ctx, args) => {
-    // If auth is available, verify the caller owns this authUserId
+    // Verify the caller owns this authUserId. When the session token hasn't
+    // propagated to Convex yet (post-sign-in race), an unauthenticated caller
+    // may only create a brand-new user record — never rename an existing one.
     const identity = await ctx.auth.getUserIdentity();
-    if (identity && identity.subject !== args.authUserId) {
-      throw new Error("Auth identity mismatch");
+    if (identity) {
+      if (identity.subject !== args.authUserId) {
+        throw new Error("Auth identity mismatch");
+      }
+    } else {
+      const existingUser = await Users.getGlobalUserByAuthUserId(
+        ctx,
+        args.authUserId
+      );
+      if (existingUser) {
+        // Record already exists and there's no identity to prove ownership:
+        // no-op rather than apply an unverified name change.
+        return;
+      }
     }
 
     await Users.findOrCreateGlobalUser(ctx, {

--- a/convex/votes.ts
+++ b/convex/votes.ts
@@ -8,6 +8,8 @@ export const pickCard = mutation({
     roomId: v.id("rooms"),
     userId: v.id("users"),
     cardLabel: v.string(),
+    // Accepted but ignored: the numeric value is re-derived server-side from
+    // cardLabel in castVote. Kept in the API for client compatibility.
     cardValue: v.number(),
     cardIcon: v.optional(v.string()),
   },

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,37 @@
 import type { NextConfig } from "next";
 
+// Baseline security headers for every route. The CSP only restricts framing:
+// locking down script-src/style-src properly requires nonce support across
+// all pages, which is a separate piece of work.
+const securityHeaders = [
+  // Clickjacking protection (frame-ancestors for modern browsers,
+  // X-Frame-Options as legacy fallback). The homepage demo iframe is
+  // same-origin, so 'self' preserves it.
+  { key: "Content-Security-Policy", value: "frame-ancestors 'self'" },
+  { key: "X-Frame-Options", value: "SAMEORIGIN" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  // The app is HTTPS-only in production; browsers ignore HSTS over HTTP,
+  // so local development is unaffected.
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=63072000; includeSubDomains",
+  },
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=()",
+  },
+];
+
 const nextConfig: NextConfig = {
+  async headers() {
+    return [
+      {
+        source: "/:path*",
+        headers: securityHeaders,
+      },
+    ];
+  },
   images: {
     remotePatterns: [
       {

--- a/src/components/dashboard/jira-connection-card.tsx
+++ b/src/components/dashboard/jira-connection-card.tsx
@@ -63,7 +63,7 @@ export function JiraConnectionCard({ connection }: JiraConnectionCardProps) {
               </p>
               {connection && (
                 <div className="flex items-center gap-3 mt-2 text-xs text-muted-foreground">
-                  {connection.siteUrl && (
+                  {connection.siteUrl && connection.siteUrl.startsWith("https://") && (
                     <a
                       href={connection.siteUrl}
                       target="_blank"

--- a/src/components/room/issue-item.tsx
+++ b/src/components/room/issue-item.tsx
@@ -165,7 +165,7 @@ export const IssueItem: FC<IssueItemProps> = ({
                 {issue.title}
               </span>
             )}
-            {issueLink && (
+            {issueLink && issueLink.externalUrl.startsWith("https://") && (
               <a
                 href={issueLink.externalUrl}
                 target="_blank"

--- a/src/utils/export-issues-csv.test.ts
+++ b/src/utils/export-issues-csv.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+import type { EnhancedExportableIssue } from "@/convex/model/issues";
+import { issuesToCSV } from "./export-issues-csv";
+
+function makeIssue(
+  overrides: Partial<EnhancedExportableIssue> = {}
+): EnhancedExportableIssue {
+  return {
+    title: "Plain issue",
+    finalEstimate: "5",
+    status: "completed",
+    votedAt: "2026-01-01T00:00:00.000Z",
+    average: 5,
+    median: 5,
+    agreement: 100,
+    voteCount: 3,
+    notes: null,
+    timeToConsensusMs: null,
+    timeToConsensusFormatted: null,
+    votingRounds: 1,
+    individualVotes: null,
+    externalUrl: null,
+    externalId: null,
+    ...overrides,
+  };
+}
+
+describe("issuesToCSV", () => {
+  it("renders a header and a data row for a normal issue", () => {
+    const csv = issuesToCSV([makeIssue()]);
+    const lines = csv.split("\n");
+    expect(lines[0]).toContain("Title");
+    expect(lines[1]).toContain("Plain issue");
+  });
+
+  it("neutralizes formula-leading characters in user-controlled fields", () => {
+    const csv = issuesToCSV([
+      makeIssue({
+        title: '=HYPERLINK("https://evil.example","Click")',
+        notes: "@SUM(1+1)",
+        individualVotes: [{ userName: "=2+5", vote: "3", deltaFromConsensus: null }],
+      }),
+    ]);
+    const row = csv.split("\n")[1];
+    expect(row).toContain("'=HYPERLINK");
+    expect(row).toContain("'@SUM");
+    expect(row).toContain("'=2+5: 3");
+    expect(row).not.toMatch(/(^|,)"?=/);
+  });
+
+  it("neutralizes leading plus, minus, tab, and carriage return", () => {
+    const csv = issuesToCSV([
+      makeIssue({ title: "+1+1", notes: "-10+20", externalId: "\t=cmd" }),
+    ]);
+    const row = csv.split("\n")[1];
+    expect(row).toContain("'+1+1");
+    expect(row).toContain("'-10+20");
+    expect(row).toContain("'\t=cmd");
+  });
+
+  it("leaves ordinary values untouched", () => {
+    const csv = issuesToCSV([
+      makeIssue({ title: "Estimate login page", finalEstimate: "3" }),
+    ]);
+    const row = csv.split("\n")[1];
+    expect(row.startsWith("Estimate login page")).toBe(true);
+    expect(row).not.toContain("'");
+  });
+});

--- a/src/utils/export-issues-csv.ts
+++ b/src/utils/export-issues-csv.ts
@@ -2,11 +2,19 @@ import type { EnhancedExportableIssue } from "@/convex/model/issues";
 import { downloadFile } from "./download-file";
 
 /**
- * Escapes a CSV field value (handles commas, quotes, newlines)
+ * Escapes a CSV field value (handles commas, quotes, newlines).
+ * Also neutralizes spreadsheet formula injection: values that begin with
+ * =, +, -, @, tab, or CR are prefixed with a single quote so Excel and
+ * LibreOffice render them as text instead of evaluating them (OWASP CSV
+ * injection guidance). Issue titles, voter names, and notes are
+ * participant-controlled.
  */
 function escapeCSVField(value: string | number | null): string {
   if (value === null || value === undefined) return "";
-  const stringValue = String(value);
+  let stringValue = String(value);
+  if (/^[=+\-@\t\r]/.test(stringValue)) {
+    stringValue = `'${stringValue}`;
+  }
   // If contains comma, quote, or newline, wrap in quotes and escape existing quotes
   if (
     stringValue.includes(",") ||


### PR DESCRIPTION
## Security audit fixes

Full-repo security audit (Convex backend authorization, Next.js frontend, HTTP/webhook/auth surface, room access model, dependencies). `npm audit` is clean — all findings are code-level. One commit per fix; build (`next build`), `tsc --noEmit`, and the full vitest suite (212 tests) pass after every commit. Lint clean.

### Fixed

| # | Issue | Severity | Location | What changed |
|---|-------|----------|----------|--------------|
| 1 | Jira webhook endpoint unauthenticated: secret check skipped when `JIRA_WEBHOOK_SECRET` unset, and the header-based check could never work (Jira Cloud can't send custom headers) — anyone could forge issue rename/delete events | **High** | `convex/http.ts:14`, `convex/integrations/jira.ts:786` | Fail closed when the secret is unset; secret now embedded in the registered webhook URL (`?secret=`) at registration time; timing-safe digest comparison; `.env.example` updated |
| 2 | `users.join` / `users.ensureGlobalUser` trusted a client-supplied `authUserId` when no auth identity was present — unauthenticated rename of any user's profile and forged room memberships (incl. owner) | Medium | `convex/users.ts:59`, `convex/users.ts:210`, `convex/model/users.ts:43` | Unauthenticated callers (post-sign-in race path) may only create a brand-new user record or rejoin a room they're already in; renames require a verified identity |
| 3 | Stored XSS: public `connectJira` action stored client-supplied `siteUrl` verbatim → `javascript:` URL flowed into issue `externalUrl` rendered as an anchor href in shared rooms | Medium | `convex/integrations/jira.ts:458`, `convex/integrations/jira.ts:243`, `src/components/room/issue-item.tsx:168`, `src/components/dashboard/jira-connection-card.tsx:66` | `connectJira` requires `https://*.atlassian.net`; `createIssueWithLink` rejects non-https URLs (defense-in-depth); both render sites only anchor `https://` URLs |
| 4 | `votes.pickCard` never validated the card against the room's voting scale — rogue values corrupted vote stats/exports and were auto-pushed to Jira as story points | Medium | `convex/model/votingRound.ts:414` | `castVote` rejects labels outside the room's scale and re-derives the numeric value server-side from the label |
| 5 | No security headers anywhere — clickjacking exposure on dashboard/auth pages | Medium | `next.config.ts` | `frame-ancestors 'self'` + `X-Frame-Options`, `nosniff`, `Referrer-Policy`, HSTS, `Permissions-Policy`. Full script-src CSP needs nonce plumbing — follow-up |
| 6 | CSV formula injection: participant-controlled titles/voter names/notes exported verbatim; `=HYPERLINK(...)` evaluates when opened in Excel/LibreOffice | Medium | `src/utils/export-issues-csv.ts:7` | Values starting with `= + - @` tab/CR are `'`-prefixed per OWASP guidance; unit tests added |
| 7 | DB-bloat DoS: unbounded room names, issue titles, custom scale cards, and no per-room issue cap | Medium | `convex/model/rooms.ts`, `convex/model/issues.ts:93`, `convex/integrations/jira.ts:243`, `convex/constants.ts` | Room names ≤100, issue titles ≤500, 500 issues/room (manual + import paths), custom scales validated server-side (3–20 unique cards, ≤10 chars) |
| 8 | `issues.getForExport` and `canvas.getNoteContentForIssue` returned issue data + discussion-note contents to any unauthenticated client holding a room link | Low | `convex/issues.ts:30`, `convex/canvas.ts:124` | Both now require room membership (consistent with `getForEnhancedExport`; no frontend/pre-join callers) |
| 9 | `presence.heartbeat` accepted bare roomId/userId strings — spoof anyone's online status in any room | Low | `convex/presence.ts:8` | Heartbeat requires an authenticated room member heartbeating as their own user ID |
| 10 | `rooms.updateActivity` required auth but not membership — keep arbitrary rooms alive forever, defeating the cleanup cron | Low | `convex/rooms.ts:66` | Now requires room membership (no frontend callers of the public mutation) |
| 11 | `issues.reorder` authorized against `roomId` but patched any issue IDs in the array — cross-room reordering | Low | `convex/model/issues.ts:290` | Every issue in the array is verified to belong to the authorized room |
| 12 | `canvas.removePlayerNode` missing the self-check all sibling mutations have — any member could delete another member's player node | Low | `convex/canvas.ts:66` | Added the same self-check; kick/leave paths use the internal model function and are unaffected |

### Checked and intentionally left (accepted risk)

- **Room reads by link** (`rooms.get`, `issues.list`, `timer.getTimerState`, `canvas.getCanvasNodes`): no auth — this is the documented zero-friction model (unguessable Convex IDs, `docs/room-permissions-ba.md`). Votes are correctly sanitized server-side pre-reveal. Only the export/note queries (#8) exceeded that model.
- **`trustedOrigins: https://*.vercel.app`** (`convex/auth.ts:61`): required for Vercel preview deployments. Exposure is limited today — auth is proxied same-origin with `SameSite=Lax` cookies and the auth component's CORS option is not enabled. Revisit if CORS is ever turned on.
- **Jira tokens at rest**: AES-256-GCM, per-message random IVs, env-var key — solid.
- **Admin/destructive functions** (`admin.ts`, `cleanup.ts`, `maintenance.ts`): all `internalMutation`, not client-callable.
- **Permission/role model** (`requireCan`, ownership transfer, promote/demote): verified sound — target roles resolved server-side.
- **No XSS via `dangerouslySetInnerHTML`/MDX** (static content only), **no open redirects** (`?from=` validated), **no hardcoded secrets**, **no dependency vulnerabilities**.

### Notes for reviewers

- Fix #1 changes operations: `JIRA_WEBHOOK_SECRET` must be set in the Convex deployment env, and existing Jira webhooks need re-registration (the `refreshJiraWebhooks` cron does this automatically) so the secret-bearing URL is picked up. Until then deliveries get 403 — that's the intended fail-closed behavior.
- Fix #2: in the post-sign-in race (session token not yet propagated), joining a room the user has *never* joined now requires waiting for the token (seconds); new-user and rejoin paths are unaffected.
