### PR TITLE
refactor: architecture deepening — 12 candidates from the architecture review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ convex/
 
 **Model layer** (`convex/model/*.ts`): Contains business logic, database operations, and helper functions.
 
-**Auth guards** (`convex/model/auth.ts`): Every mutation must enforce authorization. Use `requireRoomMember(ctx, roomId)` for room-scoped mutations (returns `{ user }` for identity checks). Use `requireAuth(ctx)` for global mutations. Never trust client-supplied `userId` without verifying `user._id === args.userId`. See [docs/authentication.md](docs/authentication.md) for full patterns.
+**Auth guards** (`convex/model/auth.ts`): Every mutation must enforce authorization. Use `requireCan(ctx, roomId, spec)` for permission-checked operations (`requireCanForUser` where the user is already resolved, e.g. action contexts), `requireActingUser(ctx, roomId, userId)` for room-scoped mutations that take a client-supplied `userId` (verifies authenticated + member + acting as that user), and `requireAuth(ctx)` for global mutations. Never re-implement these checks inline in handlers. See [docs/authentication.md](docs/authentication.md) for full patterns.
 
 Example usage in frontend:
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -19,8 +19,12 @@ What an actor is attempting. Either a **category action** (one of the four confi
 _Avoid_: operation, command, capability
 
 **Permission guard**:
-The backend adapter (`requireCan`) over the **permission decision**. It does the IO — reads the room, the actor's membership, the target's membership, and whether the owner is absent — assembles the **Action**, calls `evaluate`, and throws a reason-derived message on denial. Identity rules (self-transfer, authoritative `ownerId`) stay in the calling handler, not the guard.
+The backend adapter (`requireCan`) over the **permission decision**. It does the IO — reads the room, the actor's membership, the target's membership, and whether the owner is absent — assembles the **Action**, calls `evaluate`, and throws a reason-derived message on denial. Two entry points share the one IO assembly: `requireCan` (identity from `ctx.auth`, for queries/mutations) and `requireCanForUser` (an already-resolved user, for action contexts such as the Jira integration). Identity rules (self-transfer, authoritative `ownerId`) stay in the calling handler, not the guard.
 _Avoid_: middleware, interceptor, auth wrapper
+
+**Acting-user guard**:
+The backend adapter (`requireActingUser`) for "authenticated ∧ room member ∧ acting as this `userId`" — the one place that triple check lives. Handlers that take a client-supplied `userId` call it instead of re-checking membership and identity inline.
+_Avoid_: self-check, impersonation check
 
 **Denial reason**:
 Why a **Decision** was `allowed: false` — `insufficient-role`, `owner-absent`, or `target-rank` (acting on a target whose role forbids it). One reason maps to one message via a shared pure function used by both backend throws and frontend tooltips.
@@ -71,7 +75,7 @@ A control action that moves the **phase**: **start** (begin a round on a target)
 _Avoid_: event, command
 
 **Auto-reveal countdown**:
-The armed timer that reveals automatically once every non-spectator has voted, when the room's auto-complete setting is on. Its two room fields and the scheduled reveal are one unit — clearing the countdown must cancel the scheduled reveal. The scheduled reveal is *bound to the countdown that armed it* by a token: it reveals only while that token is still the room's live countdown, so a stale job (its countdown since cleared or replaced) is inert even if it fires. It is reconciled on every vote and on **dropping a voter**; a member who appears mid-countdown — joining, or ceasing to be a spectator — does not cancel it, so the scheduled reveal still fires. A member admitted mid-countdown is always a fresh non-voter — spectators are *voteless* (the round refuses their ballots) — so admission can only fail to complete the round, never silently complete it.
+The armed timer that reveals automatically once every non-spectator has voted, when the room's auto-complete setting is on. Its two room fields and the scheduled reveal are one unit — clearing the countdown must cancel the scheduled reveal. The scheduled reveal is *bound to the countdown that armed it* by a token: it reveals only while that token is still the room's live countdown, so a stale job (its countdown since cleared or replaced) is inert even if it fires. It is reconciled on every vote and on **dropping a voter**; a member who appears mid-countdown — joining, or ceasing to be a spectator — does not cancel it, so the scheduled reveal still fires. A member admitted mid-countdown is always a fresh non-voter — spectators are *voteless* (the round refuses their ballots) — so admission can only fail to complete the round, never silently complete it. The auto-complete setting itself is set through the round module (`setAutoComplete`): disabling cancels the countdown in the same step; enabling re-evaluates, arming immediately if every non-spectator has voted.
 _Avoid_: timer (reserve **timer** for the canvas TimerNode), auto-complete (that is the room setting that enables it)
 
 **Dropping a voter** (`dropVoter`):
@@ -81,6 +85,12 @@ _Avoid_: kick (the `remove` relationship action is one trigger, not the concept)
 **Demo simulation**:
 The looping illustration on `/demo`. It is **not a room and runs no voting round** — there is no `rooms` row, no membership, no persisted vote, and the backend never participates. Bots, issues, and **phase** transitions are computed entirely on the viewer's machine and discarded. It *imitates* a round's **phase** lifecycle and reuses the one pure results computation (`summarize`) so its revealed numbers match a real round's, but it lives deliberately outside the **voting round** module's authority. Paused while its tab is hidden (see [ADR-0003](docs/adr/0003-demo-is-a-client-simulation.md)).
 _Avoid_: demo room (there is no room), demo game, bot round
+
+### Integrations
+
+**Token vault**:
+The module (`convex/model/tokenVault.ts`) that owns the token-field contract for integration connections: key validation, encrypt-on-write, decrypt-on-read, and the token-expiry predicate. Plaintext is unrepresentable through its interface — writes accept plaintext and persist ciphertext; readers receive ciphertext rows and decrypt explicitly. Provider-agnostic; Jira is the only adapter today, GitHub (spec 07) is the planned second.
+_Avoid_: encryption utils (the pure primitive is `convex/lib/encryption.ts` — the vault is the policy owner, not a second crypto implementation)
 
 ## Flagged ambiguities
 

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -29,6 +29,7 @@ import type * as model_analytics from "../model/analytics.js";
 import type * as model_auth from "../model/auth.js";
 import type * as model_canvas from "../model/canvas.js";
 import type * as model_cleanup from "../model/cleanup.js";
+import type * as model_integrations from "../model/integrations.js";
 import type * as model_issues from "../model/issues.js";
 import type * as model_permissions from "../model/permissions.js";
 import type * as model_roles from "../model/roles.js";
@@ -79,6 +80,7 @@ declare const fullApi: ApiFromModules<{
   "model/auth": typeof model_auth;
   "model/canvas": typeof model_canvas;
   "model/cleanup": typeof model_cleanup;
+  "model/integrations": typeof model_integrations;
   "model/issues": typeof model_issues;
   "model/permissions": typeof model_permissions;
   "model/roles": typeof model_roles;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -10,6 +10,7 @@
 
 import type * as admin from "../admin.js";
 import type * as analytics from "../analytics.js";
+import type * as analyticsMath from "../analyticsMath.js";
 import type * as auth from "../auth.js";
 import type * as canvas from "../canvas.js";
 import type * as canvasLayout from "../canvasLayout.js";
@@ -31,6 +32,7 @@ import type * as model_cleanup from "../model/cleanup.js";
 import type * as model_issues from "../model/issues.js";
 import type * as model_permissions from "../model/permissions.js";
 import type * as model_roles from "../model/roles.js";
+import type * as model_roomAggregate from "../model/roomAggregate.js";
 import type * as model_rooms from "../model/rooms.js";
 import type * as model_timer from "../model/timer.js";
 import type * as model_users from "../model/users.js";
@@ -44,6 +46,7 @@ import type * as rooms from "../rooms.js";
 import type * as scales from "../scales.js";
 import type * as summarize from "../summarize.js";
 import type * as timer from "../timer.js";
+import type * as timerState from "../timerState.js";
 import type * as users from "../users.js";
 import type * as votes from "../votes.js";
 import type * as votingRound from "../votingRound.js";
@@ -57,6 +60,7 @@ import type {
 declare const fullApi: ApiFromModules<{
   admin: typeof admin;
   analytics: typeof analytics;
+  analyticsMath: typeof analyticsMath;
   auth: typeof auth;
   canvas: typeof canvas;
   canvasLayout: typeof canvasLayout;
@@ -78,6 +82,7 @@ declare const fullApi: ApiFromModules<{
   "model/issues": typeof model_issues;
   "model/permissions": typeof model_permissions;
   "model/roles": typeof model_roles;
+  "model/roomAggregate": typeof model_roomAggregate;
   "model/rooms": typeof model_rooms;
   "model/timer": typeof model_timer;
   "model/users": typeof model_users;
@@ -91,6 +96,7 @@ declare const fullApi: ApiFromModules<{
   scales: typeof scales;
   summarize: typeof summarize;
   timer: typeof timer;
+  timerState: typeof timerState;
   users: typeof users;
   votes: typeof votes;
   votingRound: typeof votingRound;

--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -36,6 +36,7 @@ import type * as model_roles from "../model/roles.js";
 import type * as model_roomAggregate from "../model/roomAggregate.js";
 import type * as model_rooms from "../model/rooms.js";
 import type * as model_timer from "../model/timer.js";
+import type * as model_tokenVault from "../model/tokenVault.js";
 import type * as model_users from "../model/users.js";
 import type * as model_votes from "../model/votes.js";
 import type * as model_votingRound from "../model/votingRound.js";
@@ -87,6 +88,7 @@ declare const fullApi: ApiFromModules<{
   "model/roomAggregate": typeof model_roomAggregate;
   "model/rooms": typeof model_rooms;
   "model/timer": typeof model_timer;
+  "model/tokenVault": typeof model_tokenVault;
   "model/users": typeof model_users;
   "model/votes": typeof model_votes;
   "model/votingRound": typeof model_votingRound;

--- a/convex/actingUser.test.ts
+++ b/convex/actingUser.test.ts
@@ -108,16 +108,6 @@ describe("acting-user guard (requireActingUser)", () => {
     ).rejects.toThrow("Not a member of this room");
   });
 
-  it("non-member cannot read timer state", async () => {
-    const t = convexTest(schema, modules);
-    const roomId = await seedRoom(t);
-    await addUser(t, "auth-outsider");
-    const asOutsider = t.withIdentity({ subject: "auth-outsider" });
-    await expect(
-      asOutsider.query(api.timer.getTimerState, { roomId, nodeId: "timer" })
-    ).rejects.toThrow("Not a member of this room");
-  });
-
   it("actor mismatch throws on updateNodePosition", async () => {
     const t = convexTest(schema, modules);
     const roomId = await seedRoom(t);

--- a/convex/actingUser.test.ts
+++ b/convex/actingUser.test.ts
@@ -1,0 +1,228 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import * as Canvas from "./model/canvas";
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+async function seedRoom(t: T): Promise<Id<"rooms">> {
+  return t.run((ctx) =>
+    ctx.db.insert("rooms", {
+      name: "R",
+      autoCompleteVoting: false,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    })
+  );
+}
+
+async function addMember(
+  t: T,
+  roomId: Id<"rooms">,
+  authUserId: string
+): Promise<Id<"users">> {
+  return t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      authUserId,
+      name: "U",
+      createdAt: Date.now(),
+    });
+    await ctx.db.insert("roomMemberships", {
+      roomId,
+      userId,
+      isSpectator: false,
+      joinedAt: Date.now(),
+    });
+    return userId;
+  });
+}
+
+async function addUser(t: T, authUserId: string): Promise<Id<"users">> {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      authUserId,
+      name: "U",
+      createdAt: Date.now(),
+    })
+  );
+}
+
+async function seedIssue(t: T, roomId: Id<"rooms">): Promise<Id<"issues">> {
+  return t.run((ctx) =>
+    ctx.db.insert("issues", {
+      roomId,
+      sequentialId: 1,
+      title: "Issue 1",
+      status: "voting",
+      createdAt: Date.now(),
+      order: 0,
+    })
+  );
+}
+
+async function seedNode(
+  t: T,
+  roomId: Id<"rooms">,
+  nodeId: string
+): Promise<void> {
+  await t.run((ctx) =>
+    ctx.db.insert("canvasNodes", {
+      roomId,
+      nodeId,
+      type: "session",
+      position: { x: 0, y: 0 },
+      data: {},
+      lastUpdatedAt: Date.now(),
+    })
+  );
+}
+
+describe("acting-user guard (requireActingUser)", () => {
+  it("probe: t.withIdentity satisfies ctx.auth.getUserIdentity in a registered handler", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addMember(t, roomId, "auth-a");
+    // getCanvasNodes now requires membership, so it only succeeds if the
+    // identity reaches ctx.auth.getUserIdentity() inside the registered query.
+    const asA = t.withIdentity({ subject: "auth-a" });
+    expect(await asA.query(api.canvas.getCanvasNodes, { roomId })).toEqual([]);
+    // Without an identity the same handler throws from requireAuth.
+    await expect(t.query(api.canvas.getCanvasNodes, { roomId })).rejects.toThrow(
+      "Not authenticated"
+    );
+  });
+
+  it("non-member cannot read canvas nodes", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addUser(t, "auth-outsider"); // user record, but no membership
+    const asOutsider = t.withIdentity({ subject: "auth-outsider" });
+    await expect(
+      asOutsider.query(api.canvas.getCanvasNodes, { roomId })
+    ).rejects.toThrow("Not a member of this room");
+  });
+
+  it("non-member cannot read timer state", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addUser(t, "auth-outsider");
+    const asOutsider = t.withIdentity({ subject: "auth-outsider" });
+    await expect(
+      asOutsider.query(api.timer.getTimerState, { roomId, nodeId: "timer" })
+    ).rejects.toThrow("Not a member of this room");
+  });
+
+  it("actor mismatch throws on updateNodePosition", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addMember(t, roomId, "auth-a");
+    const userB = await addMember(t, roomId, "auth-b");
+    const asA = t.withIdentity({ subject: "auth-a" });
+    await expect(
+      asA.mutation(api.canvas.updateNodePosition, {
+        roomId,
+        nodeId: "session-current",
+        position: { x: 1, y: 1 },
+        userId: userB,
+      })
+    ).rejects.toThrow("Cannot act as another user");
+  });
+
+  it("actor mismatch throws on pickCard", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addMember(t, roomId, "auth-a");
+    const userB = await addMember(t, roomId, "auth-b");
+    const asA = t.withIdentity({ subject: "auth-a" });
+    await expect(
+      asA.mutation(api.votes.pickCard, {
+        roomId,
+        userId: userB,
+        cardLabel: "5",
+        cardValue: 5,
+      })
+    ).rejects.toThrow("Cannot vote as another user");
+  });
+
+  it("member casts a vote through the registered handler", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userA = await addMember(t, roomId, "auth-a");
+    const asA = t.withIdentity({ subject: "auth-a" });
+    await asA.mutation(api.votes.pickCard, {
+      roomId,
+      userId: userA,
+      cardLabel: "5",
+      cardValue: 5,
+    });
+    const votes = await t.run((ctx) =>
+      ctx.db
+        .query("votes")
+        .withIndex("by_room_user", (q) =>
+          q.eq("roomId", roomId).eq("userId", userA)
+        )
+        .collect()
+    );
+    expect(votes).toHaveLength(1);
+    expect(votes[0].cardLabel).toBe("5");
+  });
+
+  it("member updates a node position through the registered handler", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userA = await addMember(t, roomId, "auth-a");
+    await seedNode(t, roomId, "session-current");
+    const asA = t.withIdentity({ subject: "auth-a" });
+    await asA.mutation(api.canvas.updateNodePosition, {
+      roomId,
+      nodeId: "session-current",
+      position: { x: 42, y: 7 },
+      userId: userA,
+    });
+    const node = await t.run((ctx) =>
+      ctx.db
+        .query("canvasNodes")
+        .withIndex("by_room_node", (q) =>
+          q.eq("roomId", roomId).eq("nodeId", "session-current")
+        )
+        .unique()
+    );
+    expect(node!.position).toEqual({ x: 42, y: 7 });
+    expect(node!.lastUpdatedBy).toBe(userA);
+  });
+
+  it("note CRUD is unchanged for a real member", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userA = await addMember(t, roomId, "auth-a");
+    const issueId = await seedIssue(t, roomId);
+    const asA = t.withIdentity({ subject: "auth-a" });
+    const nodeId = `note-${issueId}`;
+
+    await asA.mutation(api.canvas.createNote, { roomId, issueId, userId: userA });
+    await asA.mutation(api.canvas.updateNoteContent, {
+      roomId,
+      nodeId,
+      content: "acceptance criteria",
+      userId: userA,
+    });
+    expect(
+      await t.run((ctx) =>
+        Canvas.getNoteContentForIssue(ctx, { roomId, issueId })
+      )
+    ).toBe("acceptance criteria");
+
+    await asA.mutation(api.canvas.deleteNote, { roomId, nodeId, userId: userA });
+    expect(
+      await t.run((ctx) =>
+        Canvas.getNoteContentForIssue(ctx, { roomId, issueId })
+      )
+    ).toBeNull();
+  });
+});

--- a/convex/admin.ts
+++ b/convex/admin.ts
@@ -5,13 +5,18 @@
 
 import { internalMutation } from "./_generated/server";
 import { v } from "convex/values";
+import { ROOM_OWNED_TABLES } from "./model/roomAggregate";
 
 const DELETE_CONFIRMATION = "I understand this will delete all data permanently";
 
 /**
  * Permanently deletes ALL data from the database.
  *
- * Tables affected: rooms, issues, users, roomMemberships, votes, canvasNodes
+ * Tables affected: every room-owned table from the one inventory
+ * (convex/model/roomAggregate.ts — issues, roomMemberships, votes,
+ * canvasNodes, votingTimestamps, individualVotes, integrationMappings)
+ * plus issueLinks (room-owned via its issue), rooms, and the user-scoped /
+ * global tables (users, integrationConnections, webhookEvents).
  *
  * This action cannot be undone.
  *
@@ -35,15 +40,14 @@ export const dangerouslyDeleteAllData = internalMutation({
       );
     }
 
+    // Room-owned tables come from the one inventory; issueLinks are room-owned
+    // through their issues. The rest are user-scoped or global — this wipe's
+    // own concern, not the inventory's.
     const tables = [
-      "votes",
-      "canvasNodes",
-      "roomMemberships",
+      ...ROOM_OWNED_TABLES,
       "issueLinks",
-      "integrationMappings",
       "integrationConnections",
       "webhookEvents",
-      "issues",
       "rooms",
       "users",
     ] as const;

--- a/convex/analytics.test.ts
+++ b/convex/analytics.test.ts
@@ -1,0 +1,315 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import { api } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+// Deterministic UTC timestamps: IN lands inside RANGE, OUT outside it.
+const IN = Date.UTC(2026, 0, 10, 12); // 2026-01-10
+const OUT = Date.UTC(2026, 1, 10, 12); // 2026-02-10
+const RANGE = { from: Date.UTC(2026, 0, 1), to: Date.UTC(2026, 0, 31, 23, 59, 59) };
+
+async function seedUser(t: T, authUserId: string, name = "U"): Promise<Id<"users">> {
+  return t.run((ctx) =>
+    ctx.db.insert("users", { authUserId, name, createdAt: Date.now() })
+  );
+}
+
+async function seedRoom(t: T, name = "R"): Promise<Id<"rooms">> {
+  return t.run((ctx) =>
+    ctx.db.insert("rooms", {
+      name,
+      autoCompleteVoting: false,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    })
+  );
+}
+
+async function addMembership(
+  t: T,
+  roomId: Id<"rooms">,
+  userId: Id<"users">,
+  joinedAt: number
+): Promise<void> {
+  await t.run((ctx) =>
+    ctx.db.insert("roomMemberships", { roomId, userId, isSpectator: false, joinedAt })
+  );
+}
+
+async function seedIssue(
+  t: T,
+  roomId: Id<"rooms">,
+  opts: {
+    sequentialId: number;
+    status?: "pending" | "voting" | "completed";
+    votedAt?: number;
+    finalEstimate?: string;
+    voteStats?: { agreement: number; voteCount: number; timeToConsensusMs?: number };
+  }
+): Promise<Id<"issues">> {
+  return t.run((ctx) =>
+    ctx.db.insert("issues", {
+      roomId,
+      sequentialId: opts.sequentialId,
+      title: `Issue ${opts.sequentialId}`,
+      status: opts.status ?? "completed",
+      ...(opts.votedAt !== undefined ? { votedAt: opts.votedAt } : {}),
+      ...(opts.finalEstimate !== undefined ? { finalEstimate: opts.finalEstimate } : {}),
+      ...(opts.voteStats !== undefined ? { voteStats: opts.voteStats } : {}),
+      createdAt: Date.now(),
+      order: opts.sequentialId,
+    })
+  );
+}
+
+async function seedVote(
+  t: T,
+  opts: {
+    roomId: Id<"rooms">;
+    issueId: Id<"issues">;
+    userId: Id<"users">;
+    cardLabel: string;
+    consensusLabel?: string;
+    deltaSteps?: number;
+    votedAt: number;
+  }
+): Promise<void> {
+  await t.run((ctx) =>
+    ctx.db.insert("individualVotes", {
+      roomId: opts.roomId,
+      issueId: opts.issueId,
+      userId: opts.userId,
+      cardLabel: opts.cardLabel,
+      ...(opts.consensusLabel !== undefined ? { consensusLabel: opts.consensusLabel } : {}),
+      ...(opts.deltaSteps !== undefined ? { deltaSteps: opts.deltaSteps } : {}),
+      votedAt: opts.votedAt,
+    })
+  );
+}
+
+/** A user with one room holding a mix of completed issues in/out of RANGE. */
+async function seedMixedHistory(t: T) {
+  const userId = await seedUser(t, "auth-a");
+  const roomId = await seedRoom(t);
+  await addMembership(t, roomId, userId, IN);
+  const inRange = await seedIssue(t, roomId, {
+    sequentialId: 1,
+    votedAt: IN,
+    finalEstimate: "5",
+    voteStats: { agreement: 80, voteCount: 2 },
+  });
+  await seedIssue(t, roomId, { sequentialId: 2, votedAt: OUT, finalEstimate: "8" });
+  await seedIssue(t, roomId, { sequentialId: 3, finalEstimate: "13" }); // no votedAt
+  await seedIssue(t, roomId, { sequentialId: 4, status: "voting" });
+  return { userId, roomId, inRange };
+}
+
+describe("completedIssueHistory — range semantics through the registered queries", () => {
+  it("windows issues on issue.votedAt: in-range kept, out-of-range and votedAt-less dropped", async () => {
+    const t = convexTest(schema, modules);
+    await seedMixedHistory(t);
+    const asA = t.withIdentity({ subject: "auth-a" });
+
+    expect(await asA.query(api.analytics.getVelocityStats, { dateRange: RANGE })).toEqual([
+      { date: "2026-01-10", storyPoints: 5, issueCount: 1 },
+    ]);
+
+    // Without a range every completed issue is history (the votedAt-less one
+    // still can't be day-bucketed, so velocity skips it — same as before).
+    expect(await asA.query(api.analytics.getVelocityStats, {})).toEqual([
+      { date: "2026-01-10", storyPoints: 5, issueCount: 1 },
+      { date: "2026-02-10", storyPoints: 8, issueCount: 1 },
+    ]);
+  });
+
+  it("an unknown user short-circuits to defined empty results on every metric", async () => {
+    const t = convexTest(schema, modules);
+    const ghost = t.withIdentity({ subject: "auth-ghost" }); // no users row
+
+    expect(await ghost.query(api.analytics.getVelocityStats, {})).toEqual([]);
+    expect(await ghost.query(api.analytics.getAgreementTrend, {})).toEqual([]);
+    expect(await ghost.query(api.analytics.getVoteDistribution, {})).toEqual([]);
+    expect(await ghost.query(api.analytics.getSessions, {})).toEqual([]);
+    expect(await ghost.query(api.analytics.getParticipationStats, {})).toEqual({
+      totalSessions: 0,
+      totalIssuesVoted: 0,
+      totalVotesCast: 0,
+      averageVotesPerSession: 0,
+    });
+    expect(await ghost.query(api.analytics.getTimeToConsensus, {})).toEqual({
+      averageMs: null,
+      medianMs: null,
+      outliers: [],
+      trendBySession: [],
+    });
+    expect(await ghost.query(api.analytics.getVoterAlignment, {})).toEqual({
+      users: [],
+      scatterPoints: [],
+    });
+    expect(await ghost.query(api.analytics.getPredictability, {})).toEqual({
+      predictabilityScore: null,
+      sessions: [],
+      averageVelocityPerSession: 0,
+      velocityTrend: "stable",
+      averageAgreement: 0,
+      agreementTrend: "stable",
+    });
+    expect(await ghost.query(api.analytics.getSummary, {})).toEqual({
+      totalSessions: 0,
+      totalIssuesEstimated: 0,
+      totalStoryPoints: null,
+      averageAgreement: null,
+    });
+  });
+});
+
+describe("getVoteDistribution honors the date range (bug fix)", () => {
+  it("a range now excludes out-of-range AND votedAt-less issues", async () => {
+    const t = convexTest(schema, modules);
+    await seedMixedHistory(t);
+    const asA = t.withIdentity({ subject: "auth-a" });
+
+    // Old behavior: the votedAt-less "13" leaked into ranged results, and the
+    // out-of-range "8" was filtered — the copies disagreed. Now uniform:
+    // a range windows on issue.votedAt, so only "5" remains.
+    expect(
+      await asA.query(api.analytics.getVoteDistribution, { dateRange: RANGE })
+    ).toEqual([{ value: "5", count: 1, percentage: 100 }]);
+  });
+
+  it("without a range every completed issue is counted (unchanged)", async () => {
+    const t = convexTest(schema, modules);
+    await seedMixedHistory(t);
+    const asA = t.withIdentity({ subject: "auth-a" });
+
+    expect(await asA.query(api.analytics.getVoteDistribution, {})).toEqual([
+      { value: "5", count: 1, percentage: 33 },
+      { value: "8", count: 1, percentage: 33 },
+      { value: "13", count: 1, percentage: 33 },
+    ]);
+  });
+});
+
+describe("getParticipationStats counts real votes from individualVotes (bug fix)", () => {
+  async function seedParticipation(t: T) {
+    const userId = await seedUser(t, "auth-a");
+    const roomId = await seedRoom(t);
+    await addMembership(t, roomId, userId, IN);
+    const i1 = await seedIssue(t, roomId, { sequentialId: 1, votedAt: IN, finalEstimate: "5" });
+    const i2 = await seedIssue(t, roomId, { sequentialId: 2, votedAt: IN, finalEstimate: "8" });
+    // Five real vote snapshots in range across the two issues, one outside.
+    for (const [n, issueId] of [1, 2, 3].map((n) => [n, i1] as const)) {
+      await seedVote(t, { roomId, issueId, userId, cardLabel: String(n + 2), votedAt: IN });
+    }
+    await seedVote(t, { roomId, issueId: i2, userId, cardLabel: "5", votedAt: IN });
+    await seedVote(t, { roomId, issueId: i2, userId, cardLabel: "8", votedAt: IN });
+    await seedVote(t, { roomId, issueId: i2, userId, cardLabel: "8", votedAt: OUT });
+  }
+
+  it("totalVotesCast is the real snapshot count, not the completed-issue count", async () => {
+    const t = convexTest(schema, modules);
+    await seedParticipation(t);
+    const asA = t.withIdentity({ subject: "auth-a" });
+
+    // Old behavior: totalVotesCast === totalIssuesVoted (2) — knowingly fake.
+    expect(await asA.query(api.analytics.getParticipationStats, { dateRange: RANGE })).toEqual({
+      totalSessions: 1,
+      totalIssuesVoted: 2,
+      totalVotesCast: 5,
+      averageVotesPerSession: 5,
+    });
+
+    // Without a range the out-of-range snapshot counts too.
+    expect(await asA.query(api.analytics.getParticipationStats, {})).toEqual({
+      totalSessions: 1,
+      totalIssuesVoted: 2,
+      totalVotesCast: 6,
+      averageVotesPerSession: 6,
+    });
+  });
+
+  it("totalSessions windows on membership.joinedAt while activity windows on votedAt", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-a");
+    const roomId = await seedRoom(t);
+    await addMembership(t, roomId, userId, OUT); // joined outside the window
+    await seedIssue(t, roomId, { sequentialId: 1, votedAt: IN, finalEstimate: "5" });
+    const asA = t.withIdentity({ subject: "auth-a" });
+
+    // Documented split: the session count is membership-tenure (joinedAt),
+    // issue/vote activity is votedAt-windowed across all of the user's rooms.
+    expect(await asA.query(api.analytics.getParticipationStats, { dateRange: RANGE })).toEqual({
+      totalSessions: 0,
+      totalIssuesVoted: 1,
+      totalVotesCast: 0,
+      averageVotesPerSession: 0,
+    });
+  });
+});
+
+describe("getVoterAlignment through the aggregate", () => {
+  it("resolves names and windows votes on the vote's own votedAt", async () => {
+    const t = convexTest(schema, modules);
+    const viewer = await seedUser(t, "auth-a");
+    const ada = await seedUser(t, "auth-ada", "Ada");
+    const bob = await seedUser(t, "auth-bob", "Bob");
+    const roomId = await seedRoom(t);
+    await addMembership(t, roomId, viewer, IN);
+    const i1 = await seedIssue(t, roomId, { sequentialId: 1, votedAt: IN, finalEstimate: "5" });
+    await seedVote(t, { roomId, issueId: i1, userId: ada, cardLabel: "5", consensusLabel: "5", deltaSteps: 0, votedAt: IN });
+    await seedVote(t, { roomId, issueId: i1, userId: bob, cardLabel: "3", consensusLabel: "5", deltaSteps: -1, votedAt: IN });
+    await seedVote(t, { roomId, issueId: i1, userId: ada, cardLabel: "8", consensusLabel: "5", deltaSteps: 1, votedAt: OUT });
+
+    const asA = t.withIdentity({ subject: "auth-a" });
+    const ranged = await asA.query(api.analytics.getVoterAlignment, { dateRange: RANGE });
+    expect(ranged.users).toEqual([
+      { userId: ada, userName: "Ada", totalVotes: 1, agreesWithConsensus: 1, agreementRate: 100, averageDelta: 0, tendency: "aligned" },
+      { userId: bob, userName: "Bob", totalVotes: 1, agreesWithConsensus: 0, agreementRate: 0, averageDelta: -1, tendency: "under" },
+    ]);
+
+    // Without a range Ada's out-of-range vote joins her stats.
+    const unranged = await asA.query(api.analytics.getVoterAlignment, {});
+    expect(unranged.users.find((u) => u.userId === ada)).toMatchObject({
+      totalVotes: 2,
+      averageDelta: 0.5,
+    });
+  });
+});
+
+describe("getUserSessions keeps membership-tenure semantics", () => {
+  it("a range filters on joinedAt while per-session stats stay room-lifetime", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-a");
+    const roomA = await seedRoom(t, "A");
+    const roomB = await seedRoom(t, "B");
+    await addMembership(t, roomA, userId, IN);
+    await addMembership(t, roomB, userId, OUT);
+    // Room A's issues were voted OUTSIDE the range — a session row reports
+    // room-lifetime stats, so they still count for the in-window membership.
+    await seedIssue(t, roomA, { sequentialId: 1, votedAt: OUT, finalEstimate: "5", voteStats: { agreement: 80, voteCount: 2 } });
+    await seedIssue(t, roomA, { sequentialId: 2, votedAt: OUT, finalEstimate: "3" });
+    await seedIssue(t, roomB, { sequentialId: 1, votedAt: OUT, finalEstimate: "8" });
+    const asA = t.withIdentity({ subject: "auth-a" });
+
+    const ranged = await asA.query(api.analytics.getSessions, { dateRange: RANGE });
+    expect(ranged).toHaveLength(1);
+    expect(ranged[0]).toMatchObject({
+      roomName: "A",
+      joinedAt: IN,
+      issuesCompleted: 2,
+      totalStoryPoints: 8,
+      averageAgreement: 80,
+      participantCount: 1,
+    });
+
+    const unranged = await asA.query(api.analytics.getSessions, {});
+    expect(unranged.map((s) => s.roomName).sort()).toEqual(["A", "B"]);
+  });
+});

--- a/convex/analyticsMath.test.ts
+++ b/convex/analyticsMath.test.ts
@@ -1,0 +1,491 @@
+import { describe, it, expect } from "vitest";
+import {
+  agreementTrend,
+  velocityByDay,
+  voteDistribution,
+  participationStats,
+  timeToConsensus,
+  voterAlignment,
+  predictability,
+  dashboardSummary,
+  sessionIssueStats,
+  type HistoryIssue,
+  type HistoryVote,
+  type RoomIssue,
+  type RoomIssues,
+} from "./analyticsMath";
+
+// Deterministic UTC timestamps → stable ISO days.
+const DAY1 = Date.UTC(2026, 0, 10, 12); // "2026-01-10"
+const DAY2 = Date.UTC(2026, 0, 11, 12); // "2026-01-11"
+const DAY3 = Date.UTC(2026, 0, 12, 12); // "2026-01-12"
+
+function issue(over: Partial<HistoryIssue> = {}): HistoryIssue {
+  return { title: "Issue", votedAt: DAY1, ...over };
+}
+
+function entry(roomName: string, i: HistoryIssue, roomId = roomName): RoomIssue {
+  return { roomId, roomName, issue: i };
+}
+
+describe("agreementTrend", () => {
+  it("maps issues with an agreement to points sorted by timestamp", () => {
+    const points = agreementTrend([
+      entry("B", issue({ title: "later", votedAt: DAY2, voteStats: { agreement: 60 } })),
+      entry("A", issue({ title: "earlier", votedAt: DAY1, voteStats: { agreement: 80 } })),
+    ]);
+    expect(points).toEqual([
+      { date: "2026-01-10", timestamp: DAY1, agreement: 80, issueTitle: "earlier", roomName: "A" },
+      { date: "2026-01-11", timestamp: DAY2, agreement: 60, issueTitle: "later", roomName: "B" },
+    ]);
+  });
+
+  it("skips issues without a votedAt or an agreement", () => {
+    const points = agreementTrend([
+      entry("A", issue({ votedAt: undefined, voteStats: { agreement: 80 } })),
+      entry("A", issue({ voteStats: undefined })),
+    ]);
+    expect(points).toEqual([]);
+  });
+
+  it("returns a defined empty result for empty history", () => {
+    expect(agreementTrend([])).toEqual([]);
+  });
+});
+
+describe("velocityByDay", () => {
+  it("buckets story points and issue counts by day", () => {
+    const points = velocityByDay([
+      entry("A", issue({ finalEstimate: "5", votedAt: DAY1 })),
+      entry("B", issue({ finalEstimate: "3", votedAt: DAY1 })),
+      entry("A", issue({ finalEstimate: "8", votedAt: DAY2 })),
+    ]);
+    expect(points).toEqual([
+      { date: "2026-01-10", storyPoints: 8, issueCount: 2 },
+      { date: "2026-01-11", storyPoints: 8, issueCount: 1 },
+    ]);
+  });
+
+  it("skips non-numeric estimates, missing estimates, and missing votedAt", () => {
+    const points = velocityByDay([
+      entry("A", issue({ finalEstimate: "M" })), // non-numeric scale card
+      entry("A", issue({ finalEstimate: undefined })),
+      entry("A", issue({ finalEstimate: "5", votedAt: undefined })),
+    ]);
+    expect(points).toEqual([]);
+  });
+
+  it("returns a defined empty result for empty history", () => {
+    expect(velocityByDay([])).toEqual([]);
+  });
+});
+
+describe("voteDistribution", () => {
+  it("counts estimates with percentages, sorted by count descending", () => {
+    const dist = voteDistribution([
+      issue({ finalEstimate: "5" }),
+      issue({ finalEstimate: "5" }),
+      issue({ finalEstimate: "3" }),
+      issue({ finalEstimate: "M" }),
+      issue({ finalEstimate: undefined }),
+    ]);
+    expect(dist).toEqual([
+      { value: "5", count: 2, percentage: 50 },
+      { value: "3", count: 1, percentage: 25 },
+      { value: "M", count: 1, percentage: 25 },
+    ]);
+  });
+
+  it("counts whatever history it is given — the aggregate owns the window", () => {
+    // The old inline code leaked issues without a votedAt into RANGED results.
+    // Range filtering now happens once in completedIssueHistory, so a
+    // votedAt-less row simply never reaches this projection on a ranged call;
+    // on an unranged call it is legitimately part of the history and counted.
+    const dist = voteDistribution([issue({ finalEstimate: "5", votedAt: undefined })]);
+    expect(dist).toEqual([{ value: "5", count: 1, percentage: 100 }]);
+  });
+
+  it("returns a defined empty result for empty history", () => {
+    expect(voteDistribution([])).toEqual([]);
+  });
+});
+
+describe("participationStats", () => {
+  it("averages real votes cast per session, rounded", () => {
+    expect(participationStats({ totalSessions: 3, totalIssuesVoted: 3, totalVotesCast: 10 }))
+      .toEqual({ totalSessions: 3, totalIssuesVoted: 3, totalVotesCast: 10, averageVotesPerSession: 3 });
+  });
+
+  it("votes cast can exceed issues voted (several voters per issue)", () => {
+    // The fake old counter made these two equal by construction.
+    const stats = participationStats({ totalSessions: 1, totalIssuesVoted: 2, totalVotesCast: 5 });
+    expect(stats.totalVotesCast).toBe(5);
+    expect(stats.averageVotesPerSession).toBe(5);
+  });
+
+  it("returns zeros for empty history", () => {
+    expect(participationStats({ totalSessions: 0, totalIssuesVoted: 0, totalVotesCast: 0 }))
+      .toEqual({ totalSessions: 0, totalIssuesVoted: 0, totalVotesCast: 0, averageVotesPerSession: 0 });
+  });
+});
+
+describe("timeToConsensus", () => {
+  const withTime = (durationMs: number, over: Partial<HistoryIssue> = {}): HistoryIssue =>
+    issue({ votedAt: DAY1, voteStats: { agreement: 80, timeToConsensusMs: durationMs }, ...over });
+
+  it("computes rounded average and median", () => {
+    const stats = timeToConsensus([
+      entry("A", withTime(100)),
+      entry("A", withTime(200)),
+      entry("A", withTime(400)),
+    ]);
+    expect(stats.averageMs).toBe(233);
+    expect(stats.medianMs).toBe(200);
+  });
+
+  it("averages the two middle durations for an even count", () => {
+    const stats = timeToConsensus([entry("A", withTime(100)), entry("A", withTime(200))]);
+    expect(stats.medianMs).toBe(150);
+  });
+
+  it("flags outliers beyond 2x the average, sorted by duration, capped at 10", () => {
+    const entries = [
+      ...Array.from({ length: 50 }, () => entry("A", withTime(1))),
+      ...Array.from({ length: 11 }, () => entry("A", withTime(10))),
+    ];
+    const stats = timeToConsensus(entries);
+    // average ≈ 2.62 → 2x ≈ 5.25 → the eleven 10s are outliers, capped to 10.
+    expect(stats.outliers).toHaveLength(10);
+    expect(stats.outliers[0]).toMatchObject({ durationMs: 10, multiplierVsAverage: 3.8 });
+  });
+
+  it("groups the trend by room+date with rounded averages", () => {
+    const stats = timeToConsensus([
+      entry("A", withTime(100)),
+      entry("A", withTime(300)),
+      entry("B", withTime(50)),
+      entry("A", withTime(900, { votedAt: DAY2 })),
+    ]);
+    expect(stats.trendBySession).toEqual([
+      { date: "2026-01-10", roomName: "A", averageMs: 200 },
+      { date: "2026-01-10", roomName: "B", averageMs: 50 },
+      { date: "2026-01-11", roomName: "A", averageMs: 900 },
+    ]);
+  });
+
+  it("skips issues without a duration or votedAt", () => {
+    const stats = timeToConsensus([
+      entry("A", issue({ voteStats: { agreement: 80 } })),
+      entry("A", withTime(100, { votedAt: undefined })),
+    ]);
+    expect(stats).toEqual({ averageMs: null, medianMs: null, outliers: [], trendBySession: [] });
+  });
+
+  it("returns nulls and empty lists for empty history", () => {
+    expect(timeToConsensus([])).toEqual({
+      averageMs: null,
+      medianMs: null,
+      outliers: [],
+      trendBySession: [],
+    });
+  });
+});
+
+describe("voterAlignment", () => {
+  function vote(over: Partial<HistoryVote> = {}): HistoryVote {
+    return {
+      userId: "u1",
+      cardLabel: "5",
+      consensusLabel: "5",
+      deltaSteps: 0,
+      votedAt: DAY1,
+      ...over,
+    };
+  }
+
+  it("computes agreement rate, average delta, and consistency per user", () => {
+    const data = voterAlignment(
+      [
+        vote({ cardLabel: "5", consensusLabel: "5", deltaSteps: 0 }),
+        vote({ cardLabel: "3", consensusLabel: "5", deltaSteps: -1 }),
+        vote({ cardLabel: "8", consensusLabel: "5", deltaSteps: 1 }),
+      ],
+      { u1: "Ada" }
+    );
+    expect(data.users).toEqual([
+      {
+        userId: "u1",
+        userName: "Ada",
+        totalVotes: 3,
+        agreesWithConsensus: 1,
+        agreementRate: 33,
+        averageDelta: 0,
+        tendency: "aligned",
+      },
+    ]);
+    expect(data.scatterPoints).toEqual([{ userId: "u1", userName: "Ada", x: 0, y: 0.82 }]);
+  });
+
+  it("classifies under/over estimators by average delta beyond ±0.5", () => {
+    const data = voterAlignment(
+      [
+        vote({ userId: "low", deltaSteps: -2 }),
+        vote({ userId: "low", deltaSteps: -1 }),
+        vote({ userId: "high", deltaSteps: 2 }),
+        vote({ userId: "high", deltaSteps: 1 }),
+      ],
+      {}
+    );
+    expect(data.users.find((u) => u.userId === "low")).toMatchObject({
+      averageDelta: -1.5,
+      tendency: "under",
+    });
+    expect(data.users.find((u) => u.userId === "high")).toMatchObject({
+      averageDelta: 1.5,
+      tendency: "over",
+    });
+  });
+
+  it("marks users without delta data as unknown and excludes them from the scatter", () => {
+    const data = voterAlignment(
+      [
+        vote({ userId: "u1", deltaSteps: 1 }),
+        vote({ userId: "u2", deltaSteps: undefined, cardLabel: "M", consensusLabel: "M" }),
+      ],
+      { u1: "Ada", u2: "Bob" }
+    );
+    expect(data.users.find((u) => u.userId === "u2")).toMatchObject({
+      averageDelta: null,
+      tendency: "unknown",
+      agreementRate: 100,
+    });
+    expect(data.scatterPoints.map((p) => p.userId)).toEqual(["u1"]);
+  });
+
+  it("sorts users and scatter points by total votes descending", () => {
+    const data = voterAlignment(
+      [
+        vote({ userId: "u1", deltaSteps: 0 }),
+        vote({ userId: "u2", deltaSteps: 0 }),
+        vote({ userId: "u2", deltaSteps: 0 }),
+      ],
+      {}
+    );
+    expect(data.users.map((u) => u.userId)).toEqual(["u2", "u1"]);
+    expect(data.scatterPoints.map((p) => p.userId)).toEqual(["u2", "u1"]);
+  });
+
+  it("falls back to 'Unknown' for unresolved user names", () => {
+    const data = voterAlignment([vote({ userId: "ghost" })], {});
+    expect(data.users[0].userName).toBe("Unknown");
+  });
+
+  it("votes without a consensus label never count as agreeing", () => {
+    const data = voterAlignment([vote({ consensusLabel: undefined })], {});
+    expect(data.users[0].agreesWithConsensus).toBe(0);
+    expect(data.users[0].agreementRate).toBe(0);
+  });
+
+  it("returns a defined empty result for empty history", () => {
+    expect(voterAlignment([], {})).toEqual({ users: [], scatterPoints: [] });
+  });
+});
+
+describe("predictability", () => {
+  function room(roomName: string, issues: HistoryIssue[]): RoomIssues {
+    return { roomId: roomName, roomName, issues };
+  }
+
+  function scored(
+    estimate: string,
+    votedAt: number,
+    agreement?: number,
+    timeToConsensusMs?: number
+  ): HistoryIssue {
+    return issue({
+      finalEstimate: estimate,
+      votedAt,
+      voteStats:
+        agreement !== undefined || timeToConsensusMs !== undefined
+          ? {
+              agreement: agreement ?? 0,
+              ...(timeToConsensusMs !== undefined ? { timeToConsensusMs } : {}),
+            }
+          : undefined,
+    });
+  }
+
+  it("scores 88 for perfectly consistent velocity at 80% agreement", () => {
+    const data = predictability([
+      room("A", [scored("10", DAY1, 80)]),
+      room("B", [scored("10", DAY2, 80)]),
+      room("C", [scored("10", DAY3, 80)]),
+    ]);
+    // consistency = 1 - 0/10 = 1 → 80*0.6 + 100*0.4 = 88
+    expect(data.predictabilityScore).toBe(88);
+    expect(data.averageVelocityPerSession).toBe(10);
+    expect(data.velocityTrend).toBe("stable");
+    expect(data.averageAgreement).toBe(80);
+    expect(data.agreementTrend).toBe("stable");
+  });
+
+  it("returns a null score with fewer than 3 sessions with story points", () => {
+    const data = predictability([
+      room("A", [scored("10", DAY1, 80)]),
+      room("B", [scored("10", DAY2, 80)]),
+      room("C", [scored("M", DAY3, 80)]), // non-numeric scale → no points
+    ]);
+    expect(data.predictabilityScore).toBeNull();
+    expect(data.sessions).toHaveLength(3);
+    expect(data.sessions.find((s) => s.roomName === "C")).toMatchObject({
+      estimatedPoints: 0,
+      issueCount: 1,
+    });
+  });
+
+  it("clamps the score at 0 when velocity is wildly inconsistent", () => {
+    const data = predictability([
+      room("A", [scored("1", DAY1)]),
+      room("B", [scored("100", DAY2)]),
+      room("C", [scored("1", DAY3)]),
+    ]);
+    expect(data.predictabilityScore).toBe(0);
+  });
+
+  it("clamps the score at 100", () => {
+    const data = predictability([
+      room("A", [scored("10", DAY1, 100)]),
+      room("B", [scored("10", DAY2, 100)]),
+      room("C", [scored("10", DAY3, 100)]),
+    ]);
+    expect(data.predictabilityScore).toBe(100);
+  });
+
+  it("detects increasing and decreasing velocity trends (>10% half-over-half)", () => {
+    const increasing = predictability([
+      room("A", [scored("10", DAY1, 80)]),
+      room("B", [scored("10", DAY1, 80)]),
+      room("C", [scored("20", DAY3, 80)]),
+      room("D", [scored("20", DAY3, 80)]),
+    ]);
+    expect(increasing.velocityTrend).toBe("increasing");
+
+    const decreasing = predictability([
+      room("A", [scored("20", DAY1, 80)]),
+      room("B", [scored("20", DAY1, 80)]),
+      room("C", [scored("10", DAY3, 80)]),
+      room("D", [scored("10", DAY3, 80)]),
+    ]);
+    expect(decreasing.velocityTrend).toBe("decreasing");
+  });
+
+  it("detects improving and declining agreement trends (>5% half-over-half)", () => {
+    const improving = predictability([
+      room("A", [scored("10", DAY1, 60)]),
+      room("B", [scored("10", DAY2, 90)]),
+    ]);
+    expect(improving.agreementTrend).toBe("improving");
+
+    const declining = predictability([
+      room("A", [scored("10", DAY1, 90)]),
+      room("B", [scored("10", DAY2, 60)]),
+    ]);
+    expect(declining.agreementTrend).toBe("declining");
+  });
+
+  it("rolls one session per room with sums, rounded averages, and latest-day date", () => {
+    const data = predictability([
+      room("A", [
+        scored("5", DAY1, 80, 100),
+        scored("3", DAY2, 60, 300),
+        issue({ finalEstimate: "13", votedAt: undefined }), // unusable — no votedAt
+      ]),
+    ]);
+    expect(data.sessions).toEqual([
+      {
+        roomName: "A",
+        date: "2026-01-11",
+        estimatedPoints: 8,
+        issueCount: 2,
+        averageAgreement: 70,
+        averageTimeToConsensus: 200,
+      },
+    ]);
+  });
+
+  it("drops rooms with no usable issues and sorts sessions by date", () => {
+    const data = predictability([
+      room("empty", [issue({ votedAt: undefined, finalEstimate: "5" })]),
+      room("B", [scored("5", DAY2, 80)]),
+      room("A", [scored("5", DAY1, 80)]),
+    ]);
+    expect(data.sessions.map((s) => s.roomName)).toEqual(["A", "B"]);
+  });
+
+  it("returns a defined empty-ish result for empty history", () => {
+    expect(predictability([])).toEqual({
+      predictabilityScore: null,
+      sessions: [],
+      averageVelocityPerSession: 0,
+      velocityTrend: "stable",
+      averageAgreement: 0,
+      agreementTrend: "stable",
+    });
+  });
+});
+
+describe("dashboardSummary", () => {
+  it("sums sessions, points, and rounds average agreement", () => {
+    expect(
+      dashboardSummary([
+        { issuesCompleted: 2, totalStoryPoints: 8, averageAgreement: 80 },
+        { issuesCompleted: 1, totalStoryPoints: null, averageAgreement: null },
+        { issuesCompleted: 3, totalStoryPoints: 5, averageAgreement: 61 },
+      ])
+    ).toEqual({
+      totalSessions: 3,
+      totalIssuesEstimated: 6,
+      totalStoryPoints: 13,
+      averageAgreement: 71,
+    });
+  });
+
+  it("returns nulls when no session has points or agreement", () => {
+    expect(
+      dashboardSummary([{ issuesCompleted: 0, totalStoryPoints: null, averageAgreement: null }])
+    ).toEqual({
+      totalSessions: 1,
+      totalIssuesEstimated: 0,
+      totalStoryPoints: null,
+      averageAgreement: null,
+    });
+  });
+
+  it("returns a defined zeroed result for empty history", () => {
+    expect(dashboardSummary([])).toEqual({
+      totalSessions: 0,
+      totalIssuesEstimated: 0,
+      totalStoryPoints: null,
+      averageAgreement: null,
+    });
+  });
+});
+
+describe("sessionIssueStats", () => {
+  it("sums numeric estimates and rounds average agreement", () => {
+    expect(
+      sessionIssueStats([
+        issue({ finalEstimate: "5", voteStats: { agreement: 80 } }),
+        issue({ finalEstimate: "3", voteStats: { agreement: 60 } }),
+      ])
+    ).toEqual({ issuesCompleted: 2, totalStoryPoints: 8, averageAgreement: 70 });
+  });
+
+  it("reports null points for a fully non-numeric scale", () => {
+    expect(sessionIssueStats([issue({ finalEstimate: "M" })]).totalStoryPoints).toBeNull();
+  });
+
+  it("reports null agreement when no issue has one", () => {
+    expect(sessionIssueStats([issue({})]).averageAgreement).toBeNull();
+  });
+});

--- a/convex/analyticsMath.ts
+++ b/convex/analyticsMath.ts
@@ -1,0 +1,625 @@
+/**
+ * analyticsMath — the ONE pure computation layer behind the analytics dashboard.
+ *
+ * Every dashboard number is projected here from plain rows, with no database
+ * access, so the math is testable without a ctx (the summarize.ts precedent).
+ * The model layer (model/analytics.ts) owns the single memberships → rooms →
+ * history scan (`completedIssueHistory`); these functions own the projections.
+ * Scan → project, never scan-and-compute inline.
+ *
+ * Date-window semantics live in the aggregate, not here: a range windows on
+ * `issue.votedAt`. Projections only decide which fields their metric requires
+ * (velocity needs a numeric estimate, the agreement trend needs an agreement,
+ * and so on), and skip rows that lack them.
+ */
+
+// ---------------------------------------------------------------------------
+// Row types — minimal structural views of the table Docs, so projections are
+// callable with plain objects in tests and with `Doc<"issues">` /
+// `Doc<"individualVotes">` in the model layer.
+// ---------------------------------------------------------------------------
+
+export interface HistoryIssue {
+  title: string;
+  votedAt?: number;
+  finalEstimate?: string;
+  voteStats?: {
+    agreement: number;
+    timeToConsensusMs?: number;
+  };
+}
+
+export interface HistoryVote {
+  userId: string;
+  cardLabel: string;
+  consensusLabel?: string;
+  deltaSteps?: number;
+  votedAt: number;
+}
+
+/** A completed issue with the room context some projections group by. */
+export interface RoomIssue {
+  roomId: string;
+  roomName: string;
+  issue: HistoryIssue;
+}
+
+/** A room's completed issues, for per-session (per-room) projections. */
+export interface RoomIssues {
+  roomId: string;
+  roomName: string;
+  issues: HistoryIssue[];
+}
+
+// ---------------------------------------------------------------------------
+// Result shapes (the registered queries' response field names — stable API).
+// ---------------------------------------------------------------------------
+
+export interface AgreementDataPoint {
+  date: string; // ISO date string (YYYY-MM-DD)
+  timestamp: number;
+  agreement: number;
+  issueTitle: string;
+  roomName: string;
+}
+
+export interface VelocityDataPoint {
+  date: string; // ISO date string (YYYY-MM-DD)
+  storyPoints: number;
+  issueCount: number;
+}
+
+export interface VoteDistributionItem {
+  value: string;
+  count: number;
+  percentage: number;
+}
+
+export interface ParticipationStats {
+  totalSessions: number;
+  totalIssuesVoted: number;
+  totalVotesCast: number;
+  averageVotesPerSession: number;
+}
+
+export interface TimeToConsensusStats {
+  averageMs: number | null;
+  medianMs: number | null;
+  outliers: Array<{
+    issueTitle: string;
+    roomName: string;
+    durationMs: number;
+    multiplierVsAverage: number;
+  }>;
+  trendBySession: Array<{
+    date: string;
+    roomName: string;
+    averageMs: number;
+  }>;
+}
+
+export interface VoterAlignmentUser {
+  userId: string;
+  userName: string;
+  totalVotes: number;
+  agreesWithConsensus: number;
+  agreementRate: number;
+  averageDelta: number | null;
+  tendency: "under" | "over" | "aligned" | "unknown";
+}
+
+export interface VoterAlignmentScatterPoint {
+  userId: string;
+  userName: string;
+  x: number; // averageDelta
+  y: number; // stdDev (consistency)
+}
+
+export interface VoterAlignmentData {
+  users: VoterAlignmentUser[];
+  scatterPoints: VoterAlignmentScatterPoint[];
+}
+
+export interface PredictabilitySession {
+  roomName: string;
+  date: string;
+  estimatedPoints: number;
+  issueCount: number;
+  averageAgreement: number;
+  averageTimeToConsensus: number;
+}
+
+export interface PredictabilityData {
+  predictabilityScore: number | null;
+  sessions: PredictabilitySession[];
+  averageVelocityPerSession: number;
+  velocityTrend: "increasing" | "stable" | "decreasing";
+  averageAgreement: number;
+  agreementTrend: "improving" | "stable" | "declining";
+}
+
+export interface DashboardSummary {
+  totalSessions: number;
+  totalIssuesEstimated: number;
+  totalStoryPoints: number | null;
+  averageAgreement: number | null;
+}
+
+/** The per-session issue stats getUserSessions reports for one room. */
+export interface SessionIssueStats {
+  issuesCompleted: number;
+  totalStoryPoints: number | null; // null if non-numeric scale
+  averageAgreement: number | null;
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+function isoDay(timestamp: number): string {
+  return new Date(timestamp).toISOString().split("T")[0];
+}
+
+function round(value: number, decimals = 0): number {
+  const factor = 10 ** decimals;
+  return Math.round(value * factor) / factor;
+}
+
+function mean(values: number[]): number {
+  return values.reduce((sum, v) => sum + v, 0) / values.length;
+}
+
+/** Population stddev (divide by n, matching the original inline math). */
+function stdDev(values: number[]): number {
+  const m = mean(values);
+  return Math.sqrt(mean(values.map((v) => (v - m) ** 2)));
+}
+
+/**
+ * Compares the first half vs second half of a numeric series.
+ * Returns "increasing" if second half is >threshold% higher,
+ * "decreasing" if lower, "stable" otherwise.
+ */
+function computeTrend(
+  values: number[],
+  thresholdPct: number
+): "increasing" | "stable" | "decreasing" {
+  if (values.length < 2) return "stable";
+
+  const mid = Math.floor(values.length / 2);
+  const firstHalf = values.slice(0, mid);
+  const secondHalf = values.slice(mid);
+
+  const firstAvg = mean(firstHalf);
+  const secondAvg = mean(secondHalf);
+
+  if (firstAvg === 0) return secondAvg > 0 ? "increasing" : "stable";
+
+  const diffPct = ((secondAvg - firstAvg) / firstAvg) * 100;
+
+  if (diffPct > thresholdPct) return "increasing";
+  if (diffPct < -thresholdPct) return "decreasing";
+  return "stable";
+}
+
+// ---------------------------------------------------------------------------
+// Projections
+// ---------------------------------------------------------------------------
+
+/** Agreement over time: one point per issue with an agreement, sorted by time. */
+export function agreementTrend(entries: RoomIssue[]): AgreementDataPoint[] {
+  const points: AgreementDataPoint[] = [];
+
+  for (const { roomName, issue } of entries) {
+    if (issue.votedAt && issue.voteStats?.agreement !== undefined) {
+      points.push({
+        date: isoDay(issue.votedAt),
+        timestamp: issue.votedAt,
+        agreement: issue.voteStats.agreement,
+        issueTitle: issue.title,
+        roomName,
+      });
+    }
+  }
+
+  return points.sort((a, b) => a.timestamp - b.timestamp);
+}
+
+/** Velocity: story points and issue counts bucketed by day. */
+export function velocityByDay(entries: RoomIssue[]): VelocityDataPoint[] {
+  const byDate: Record<string, { storyPoints: number; issueCount: number }> =
+    {};
+
+  for (const { issue } of entries) {
+    if (issue.votedAt && issue.finalEstimate) {
+      const storyPoints = parseFloat(issue.finalEstimate);
+      if (isNaN(storyPoints)) continue;
+
+      const date = isoDay(issue.votedAt);
+      if (!byDate[date]) {
+        byDate[date] = { storyPoints: 0, issueCount: 0 };
+      }
+      byDate[date].storyPoints += storyPoints;
+      byDate[date].issueCount += 1;
+    }
+  }
+
+  return Object.entries(byDate)
+    .map(([date, data]) => ({
+      date,
+      storyPoints: data.storyPoints,
+      issueCount: data.issueCount,
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+}
+
+/**
+ * Distribution of final estimates. Counts whatever history it is given —
+ * the aggregate decides the window, so a ranged call never sees issues that
+ * lack a `votedAt` (the old inline copy leaked them into ranged results).
+ */
+export function voteDistribution(
+  issues: HistoryIssue[]
+): VoteDistributionItem[] {
+  const counts: Record<string, number> = {};
+  let total = 0;
+
+  for (const issue of issues) {
+    if (issue.finalEstimate) {
+      counts[issue.finalEstimate] = (counts[issue.finalEstimate] || 0) + 1;
+      total += 1;
+    }
+  }
+
+  const distribution = Object.entries(counts).map(([value, count]) => ({
+    value,
+    count,
+    percentage: total > 0 ? Math.round((count / total) * 100) : 0,
+  }));
+
+  return distribution.sort((a, b) => b.count - a.count);
+}
+
+/** Participation header numbers from pre-counted totals. */
+export function participationStats(totals: {
+  totalSessions: number;
+  totalIssuesVoted: number;
+  totalVotesCast: number;
+}): ParticipationStats {
+  const { totalSessions, totalIssuesVoted, totalVotesCast } = totals;
+  return {
+    totalSessions,
+    totalIssuesVoted,
+    totalVotesCast,
+    averageVotesPerSession:
+      totalSessions > 0 ? Math.round(totalVotesCast / totalSessions) : 0,
+  };
+}
+
+/** Time-to-consensus: average/median, >2x outliers, and per-session trend. */
+export function timeToConsensus(entries: RoomIssue[]): TimeToConsensusStats {
+  const issuesWithTime: Array<{
+    issueTitle: string;
+    roomId: string;
+    roomName: string;
+    durationMs: number;
+    votedAt: number;
+  }> = [];
+
+  for (const { roomId, roomName, issue } of entries) {
+    if (issue.voteStats?.timeToConsensusMs !== undefined && issue.votedAt) {
+      issuesWithTime.push({
+        issueTitle: issue.title,
+        roomId,
+        roomName,
+        durationMs: issue.voteStats.timeToConsensusMs,
+        votedAt: issue.votedAt,
+      });
+    }
+  }
+
+  if (issuesWithTime.length === 0) {
+    return { averageMs: null, medianMs: null, outliers: [], trendBySession: [] };
+  }
+
+  const durations = issuesWithTime.map((i) => i.durationMs);
+  const averageMs = mean(durations);
+
+  const sorted = [...durations].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  const medianMs =
+    sorted.length % 2 !== 0
+      ? sorted[mid]
+      : (sorted[mid - 1] + sorted[mid]) / 2;
+
+  // Identify outliers (> 2x average)
+  const outliers = issuesWithTime
+    .filter((i) => i.durationMs > averageMs * 2)
+    .map((i) => ({
+      issueTitle: i.issueTitle,
+      roomName: i.roomName,
+      durationMs: i.durationMs,
+      multiplierVsAverage: round(i.durationMs / averageMs, 1),
+    }))
+    .sort((a, b) => b.durationMs - a.durationMs)
+    .slice(0, 10);
+
+  // Group by room+date for trend (use roomId as key to avoid name collisions)
+  const bySessionKey: Record<
+    string,
+    { date: string; roomName: string; totalMs: number; count: number }
+  > = {};
+
+  for (const item of issuesWithTime) {
+    const date = isoDay(item.votedAt);
+    const key = `${date}::${item.roomId}`;
+    if (!bySessionKey[key]) {
+      bySessionKey[key] = { date, roomName: item.roomName, totalMs: 0, count: 0 };
+    }
+    bySessionKey[key].totalMs += item.durationMs;
+    bySessionKey[key].count += 1;
+  }
+
+  const trendBySession = Object.values(bySessionKey)
+    .map((s) => ({
+      date: s.date,
+      roomName: s.roomName,
+      averageMs: Math.round(s.totalMs / s.count),
+    }))
+    .sort((a, b) => a.date.localeCompare(b.date));
+
+  return {
+    averageMs: Math.round(averageMs),
+    medianMs: Math.round(medianMs),
+    outliers,
+    trendBySession,
+  };
+}
+
+/**
+ * Voter alignment: per-user agreement with consensus, average delta in scale
+ * steps, and the scatter (x = averageDelta, y = delta stdDev) for numeric
+ * scales. `userNames` maps userId → display name (missing ids render
+ * "Unknown").
+ */
+export function voterAlignment(
+  votes: HistoryVote[],
+  userNames: Record<string, string>
+): VoterAlignmentData {
+  if (votes.length === 0) {
+    return { users: [], scatterPoints: [] };
+  }
+
+  const byUser = new Map<string, HistoryVote[]>();
+  for (const vote of votes) {
+    const existing = byUser.get(vote.userId) ?? [];
+    existing.push(vote);
+    byUser.set(vote.userId, existing);
+  }
+
+  const users: VoterAlignmentUser[] = [];
+  const scatterPoints: VoterAlignmentScatterPoint[] = [];
+
+  for (const [userId, userVotes] of byUser) {
+    const userName = userNames[userId] ?? "Unknown";
+
+    const totalVotes = userVotes.length;
+    const agreesWithConsensus = userVotes.filter(
+      (v) => v.consensusLabel !== undefined && v.cardLabel === v.consensusLabel
+    ).length;
+    const agreementRate =
+      totalVotes > 0 ? Math.round((agreesWithConsensus / totalVotes) * 100) : 0;
+
+    // Average delta / consistency from deltaSteps (only votes with delta)
+    const deltas = userVotes
+      .map((v) => v.deltaSteps)
+      .filter((d): d is number => d !== undefined);
+
+    const averageDelta =
+      deltas.length > 0 ? round(mean(deltas), 2) : null;
+    const stdDevValue = deltas.length > 1 ? round(stdDev(deltas), 2) : 0;
+
+    const tendency: "under" | "over" | "aligned" | "unknown" =
+      averageDelta === null
+        ? "unknown"
+        : averageDelta < -0.5
+          ? "under"
+          : averageDelta > 0.5
+            ? "over"
+            : "aligned";
+
+    users.push({
+      userId,
+      userName,
+      totalVotes,
+      agreesWithConsensus,
+      agreementRate,
+      averageDelta,
+      tendency,
+    });
+
+    // Only include in scatter chart if we have delta data (numeric scales)
+    if (averageDelta !== null) {
+      scatterPoints.push({
+        userId,
+        userName,
+        x: averageDelta,
+        y: stdDevValue,
+      });
+    }
+  }
+
+  // Sort users by total votes descending
+  users.sort((a, b) => b.totalVotes - a.totalVotes);
+  const votesMap = new Map(users.map((u) => [u.userId, u.totalVotes]));
+  scatterPoints.sort(
+    (a, b) => (votesMap.get(b.userId) ?? 0) - (votesMap.get(a.userId) ?? 0)
+  );
+
+  return { users, scatterPoints };
+}
+
+/**
+ * Sprint predictability score and related metrics.
+ *
+ * Score formula:
+ *   velocityConsistency = 1 - (stdDev(points) / mean(points))
+ *   score = avgAgreement * 0.6 + velocityConsistency * 100 * 0.4
+ *   clamped to 0-100
+ *
+ * Returns null score when < 3 sessions have story points.
+ */
+export function predictability(rooms: RoomIssues[]): PredictabilityData {
+  // One "session" per room over its usable history (issues need a votedAt to
+  // be placed on the timeline at all).
+  const sessions: PredictabilitySession[] = [];
+
+  for (const { roomName, issues } of rooms) {
+    const usable = issues.filter((i) => i.votedAt !== undefined);
+    if (usable.length === 0) continue;
+
+    // Story points
+    const numericEstimates = usable
+      .map((i) => (i.finalEstimate ? parseFloat(i.finalEstimate) : NaN))
+      .filter((v) => !isNaN(v));
+    const estimatedPoints =
+      numericEstimates.length > 0
+        ? numericEstimates.reduce((sum, v) => sum + v, 0)
+        : 0;
+
+    // Agreement
+    const agreements = usable
+      .map((i) => i.voteStats?.agreement)
+      .filter((a): a is number => a !== undefined);
+    const averageAgreement =
+      agreements.length > 0 ? Math.round(mean(agreements)) : 0;
+
+    // Time to consensus
+    const consensusTimes = usable
+      .map((i) => i.voteStats?.timeToConsensusMs)
+      .filter((t): t is number => t !== undefined);
+    const averageTimeToConsensus =
+      consensusTimes.length > 0 ? Math.round(mean(consensusTimes)) : 0;
+
+    // Session date = latest votedAt among completed issues in this room
+    const latestVotedAt = Math.max(...usable.map((i) => i.votedAt!));
+
+    sessions.push({
+      roomName,
+      date: isoDay(latestVotedAt),
+      estimatedPoints,
+      issueCount: usable.length,
+      averageAgreement,
+      averageTimeToConsensus,
+    });
+  }
+
+  sessions.sort((a, b) => a.date.localeCompare(b.date));
+
+  // Sessions with story points (for velocity metrics)
+  const sessionsWithPoints = sessions.filter((s) => s.estimatedPoints > 0);
+
+  const velocities = sessionsWithPoints.map((s) => s.estimatedPoints);
+  const averageVelocityPerSession =
+    velocities.length > 0 ? round(mean(velocities), 1) : 0;
+  const velocityTrend = computeTrend(velocities, 10);
+
+  const allAgreements = sessions
+    .map((s) => s.averageAgreement)
+    .filter((a) => a > 0);
+  const overallAgreement =
+    allAgreements.length > 0 ? Math.round(mean(allAgreements)) : 0;
+
+  const agreementTrendDir = computeTrend(allAgreements, 5);
+  const agreementTrend: "improving" | "stable" | "declining" =
+    agreementTrendDir === "increasing"
+      ? "improving"
+      : agreementTrendDir === "decreasing"
+        ? "declining"
+        : "stable";
+
+  // Predictability score (need at least 3 sessions with points)
+  let predictabilityScore: number | null = null;
+
+  if (sessionsWithPoints.length >= 3) {
+    const velocityMean = mean(velocities);
+    const velocityStdDev = stdDev(velocities);
+
+    const velocityConsistency =
+      velocityMean > 0 ? 1 - velocityStdDev / velocityMean : 0;
+    const rawScore =
+      overallAgreement * 0.6 + velocityConsistency * 100 * 0.4;
+
+    predictabilityScore = Math.round(Math.min(100, Math.max(0, rawScore)));
+  }
+
+  return {
+    predictabilityScore,
+    sessions,
+    averageVelocityPerSession,
+    velocityTrend,
+    averageAgreement: overallAgreement,
+    agreementTrend,
+  };
+}
+
+/** Dashboard header totals over the session list. */
+export function dashboardSummary(sessions: SessionIssueStats[]): DashboardSummary {
+  const totalSessions = sessions.length;
+  const totalIssuesEstimated = sessions.reduce(
+    (sum, s) => sum + s.issuesCompleted,
+    0
+  );
+
+  // Sum story points (only if we have numeric data)
+  const sessionsWithPoints = sessions.filter((s) => s.totalStoryPoints !== null);
+  const totalStoryPoints =
+    sessionsWithPoints.length > 0
+      ? sessionsWithPoints.reduce((sum, s) => sum + (s.totalStoryPoints ?? 0), 0)
+      : null;
+
+  // Average agreement across all sessions
+  const sessionsWithAgreement = sessions.filter(
+    (s) => s.averageAgreement !== null
+  );
+  const averageAgreement =
+    sessionsWithAgreement.length > 0
+      ? Math.round(
+          sessionsWithAgreement.reduce(
+            (sum, s) => sum + (s.averageAgreement ?? 0),
+            0
+          ) / sessionsWithAgreement.length
+        )
+      : null;
+
+  return {
+    totalSessions,
+    totalIssuesEstimated,
+    totalStoryPoints,
+    averageAgreement,
+  };
+}
+
+/** Per-room issue rollup for one session-history row. */
+export function sessionIssueStats(issues: HistoryIssue[]): SessionIssueStats {
+  // Total story points (numeric estimates only)
+  const numericEstimates = issues
+    .map((i) => (i.finalEstimate ? parseFloat(i.finalEstimate) : NaN))
+    .filter((v) => !isNaN(v));
+  const totalStoryPoints =
+    numericEstimates.length > 0
+      ? numericEstimates.reduce((sum, v) => sum + v, 0)
+      : null;
+
+  const agreements = issues
+    .map((i) => i.voteStats?.agreement)
+    .filter((a): a is number => a !== undefined);
+  const averageAgreement =
+    agreements.length > 0 ? Math.round(mean(agreements)) : null;
+
+  return {
+    issuesCompleted: issues.length,
+    totalStoryPoints,
+    averageAgreement,
+  };
+}

--- a/convex/canvas.ts
+++ b/convex/canvas.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import * as Canvas from "./model/canvas";
-import { requireRoomMember } from "./model/auth";
+import { requireRoomMember, requireActingUser } from "./model/auth";
 
 // Initialize canvas nodes when a canvas room is created
 export const initializeCanvasNodes = mutation({
@@ -13,9 +13,11 @@ export const initializeCanvasNodes = mutation({
 });
 
 // Get all canvas nodes for a room
+// Requires room membership: note contents are private to the room.
 export const getCanvasNodes = query({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
+    await requireRoomMember(ctx, args.roomId);
     return await Canvas.getCanvasNodes(ctx, args.roomId);
   },
 });
@@ -29,10 +31,7 @@ export const updateNodePosition = mutation({
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot act as another user");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId);
     await Canvas.updateNodePosition(ctx, args);
   },
 });
@@ -45,10 +44,7 @@ export const upsertPlayerNode = mutation({
     position: v.optional(v.object({ x: v.number(), y: v.number() })),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot act as another user");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId);
     return await Canvas.upsertPlayerNode(ctx, args);
   },
 });
@@ -69,10 +65,7 @@ export const removePlayerNode = mutation({
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot act as another user");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId);
     await Canvas.removePlayerNode(ctx, args);
   },
 });
@@ -98,10 +91,7 @@ export const createNote = mutation({
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot act as another user");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId);
     return await Canvas.createNoteNode(ctx, args);
   },
 });
@@ -115,10 +105,7 @@ export const updateNoteContent = mutation({
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot act as another user");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId);
     await Canvas.updateNoteContent(ctx, args);
   },
 });
@@ -144,10 +131,7 @@ export const deleteNote = mutation({
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot act as another user");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId);
     await Canvas.deleteNoteNode(ctx, args);
   },
 });

--- a/convex/crons.ts
+++ b/convex/crons.ts
@@ -31,4 +31,12 @@ crons.daily(
   internal.integrations.jira.cleanupOldWebhookEvents
 );
 
+// Sweep orphaned rows (rows whose room/issue is gone) — the safety net under
+// the room cascade
+crons.daily(
+  "cleanup-orphaned-data",
+  { hourUTC: 5, minuteUTC: 0 },
+  internal.maintenance.cleanupOrphanedData
+);
+
 export default crons;

--- a/convex/integrations.ts
+++ b/convex/integrations.ts
@@ -1,11 +1,11 @@
 /**
  * Public API layer for integration connections and mappings.
- * Thin handlers with auth guards — delegates to model/DB.
+ * Thin handlers with auth guards — delegates to model/integrations.
  */
 
 import { mutation, query } from "./_generated/server";
-import { internal } from "./_generated/api";
 import { v } from "convex/values";
+import * as Integrations from "./model/integrations";
 import { requireAuthUser, requireRoomMember, requireCan } from "./model/auth";
 
 // ---------------------------------------------------------------------------
@@ -21,15 +21,8 @@ export const getConnections = query({
       .withIndex("by_user_provider", (q) => q.eq("userId", user._id))
       .collect();
 
-    // Return sanitized — never expose encrypted tokens
-    return connections.map((c) => ({
-      _id: c._id,
-      provider: c.provider,
-      siteUrl: c.siteUrl,
-      providerUserEmail: c.providerUserEmail,
-      connectedAt: c.connectedAt,
-      scopes: c.scopes,
-    }));
+    // Sanitized projection — never expose encrypted tokens
+    return connections.map(Integrations.toConnectionView);
   },
 });
 
@@ -42,16 +35,7 @@ export const disconnect = mutation({
       throw new Error("Connection not found");
     }
 
-    // Cascade delete all mappings using this connection
-    const mappings = await ctx.db
-      .query("integrationMappings")
-      .withIndex("by_connection", (q) =>
-        q.eq("connectionId", args.connectionId)
-      )
-      .collect();
-    await Promise.all(mappings.map((m) => ctx.db.delete(m._id)));
-
-    await ctx.db.delete(args.connectionId);
+    await Integrations.disconnectConnection(ctx, args.connectionId);
   },
 });
 
@@ -138,63 +122,7 @@ export const saveRoomMapping = mutation({
       throw new Error("Connection not found");
     }
 
-    // Upsert: check for existing mapping
-    const existing = await ctx.db
-      .query("integrationMappings")
-      .withIndex("by_room", (q) => q.eq("roomId", args.roomId))
-      .first();
-
-    if (existing) {
-      await ctx.db.patch(existing._id, {
-        connectionId: args.connectionId,
-        provider: args.provider,
-        jiraProjectKey: args.jiraProjectKey,
-        jiraBoardId: args.jiraBoardId,
-        jiraSprintId: args.jiraSprintId,
-        storyPointsFieldId: args.storyPointsFieldId,
-        autoImport: args.autoImport,
-        autoPushEstimates: args.autoPushEstimates,
-      });
-
-      // Schedule webhook registration if auto-push enabled
-      if (args.autoPushEstimates && args.jiraProjectKey) {
-        await ctx.scheduler.runAfter(
-          0,
-          internal.integrations.jira.registerWebhook,
-          {
-            mappingId: existing._id,
-          }
-        );
-      }
-
-      return existing._id;
-    }
-
-    const mappingId = await ctx.db.insert("integrationMappings", {
-      roomId: args.roomId,
-      connectionId: args.connectionId,
-      provider: args.provider,
-      jiraProjectKey: args.jiraProjectKey,
-      jiraBoardId: args.jiraBoardId,
-      jiraSprintId: args.jiraSprintId,
-      storyPointsFieldId: args.storyPointsFieldId,
-      autoImport: args.autoImport,
-      autoPushEstimates: args.autoPushEstimates,
-      createdAt: Date.now(),
-    });
-
-    // Schedule webhook registration if auto-push enabled
-    if (args.autoPushEstimates && args.jiraProjectKey) {
-      await ctx.scheduler.runAfter(
-        0,
-        internal.integrations.jira.registerWebhook,
-        {
-          mappingId,
-        }
-      );
-    }
-
-    return mappingId;
+    return await Integrations.saveRoomMapping(ctx, args);
   },
 });
 
@@ -203,13 +131,6 @@ export const removeRoomMapping = mutation({
   handler: async (ctx, args) => {
     await requireCan(ctx, args.roomId, { kind: "category", category: "roomSettings" });
 
-    const mapping = await ctx.db
-      .query("integrationMappings")
-      .withIndex("by_room", (q) => q.eq("roomId", args.roomId))
-      .first();
-
-    if (mapping) {
-      await ctx.db.delete(mapping._id);
-    }
+    await Integrations.removeRoomMapping(ctx, args.roomId);
   },
 });

--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -11,16 +11,10 @@ import {
 } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { v } from "convex/values";
-import { Doc } from "../_generated/dataModel";
+import { Doc, Id } from "../_generated/dataModel";
 import { ActionCtx } from "../_generated/server";
 import { encryptToken, decryptToken } from "../lib/encryption";
-import {
-  Action,
-  resolve,
-  getEffectivePermissions,
-  getEffectiveRole,
-} from "../permissions";
-import { isRoomOwnerAbsent } from "../model/permissions";
+import { requireAuth, requireCanForUser } from "../model/auth";
 import { JiraClient } from "./jiraClient";
 import { validateIssueTitle } from "../model/issues";
 import { MAX_ISSUES_PER_ROOM } from "../constants";
@@ -468,8 +462,7 @@ export const connectJira = action({
     providerUserEmail: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
+    const user = await requireActionUser(ctx);
 
     // The siteUrl is stored and later concatenated into issue browse links
     // rendered as anchor hrefs. This action is public, so a client could
@@ -486,13 +479,6 @@ export const connectJira = action({
     ) {
       throw new Error("Jira site URL must be an https://*.atlassian.net URL");
     }
-
-    // Resolve user from auth identity
-    const user: Doc<"users"> | null = await ctx.runQuery(
-      internal.integrations.jira.getUserByAuthId,
-      { authUserId: identity.subject }
-    );
-    if (!user) throw new Error("User not found");
 
     // Delegate to internal action that handles encryption + storage
     await ctx.runAction(internal.integrations.jira.storeConnection, {
@@ -512,10 +498,8 @@ export const connectJira = action({
 export const getJiraProjects = action({
   args: {},
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
-
-    const connection = await getConnectionFromIdentity(ctx, identity.subject);
+    const user = await requireActionUser(ctx);
+    const connection = await getConnectionForUserId(ctx, user._id);
     const client = await buildJiraClient(ctx, connection);
     return await client.getProjects();
   },
@@ -524,10 +508,8 @@ export const getJiraProjects = action({
 export const getJiraBoards = action({
   args: { projectKey: v.string() },
   handler: async (ctx, { projectKey }) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
-
-    const connection = await getConnectionFromIdentity(ctx, identity.subject);
+    const user = await requireActionUser(ctx);
+    const connection = await getConnectionForUserId(ctx, user._id);
     const client = await buildJiraClient(ctx, connection);
     return await client.getBoards(projectKey);
   },
@@ -536,10 +518,8 @@ export const getJiraBoards = action({
 export const getJiraSprints = action({
   args: { boardId: v.number() },
   handler: async (ctx, { boardId }) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
-
-    const connection = await getConnectionFromIdentity(ctx, identity.subject);
+    const user = await requireActionUser(ctx);
+    const connection = await getConnectionForUserId(ctx, user._id);
     const client = await buildJiraClient(ctx, connection);
     return await client.getSprints(boardId);
   },
@@ -551,10 +531,8 @@ export const getJiraIssues = action({
     sprintId: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
-
-    const connection = await getConnectionFromIdentity(ctx, identity.subject);
+    const user = await requireActionUser(ctx);
+    const connection = await getConnectionForUserId(ctx, user._id);
     const client = await buildJiraClient(ctx, connection);
 
     if (args.sprintId) {
@@ -570,16 +548,15 @@ export const importIssues = action({
     jiraIssueKeys: v.array(v.string()),
   },
   handler: async (ctx, { roomId, jiraIssueKeys }) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
+    const user = await requireActionUser(ctx);
 
     // Verify the caller is a member of the room with issue management permission
-    await ctx.runQuery(internal.integrations.jira.verifyRoomAccess, {
-      authUserId: identity.subject,
+    await ctx.runQuery(internal.integrations.jira.verifyCanManageIssues, {
+      userId: user._id,
       roomId,
     });
 
-    const connection = await getConnectionFromIdentity(ctx, identity.subject);
+    const connection = await getConnectionForUserId(ctx, user._id);
     const client = await buildJiraClient(ctx, connection);
     const siteUrl = connection.siteUrl ?? "";
 
@@ -683,10 +660,8 @@ export const pushEstimateToJira = internalAction({
 export const detectStoryPointsField = action({
   args: {},
   handler: async (ctx) => {
-    const identity = await ctx.auth.getUserIdentity();
-    if (!identity) throw new Error("Not authenticated");
-
-    const connection = await getConnectionFromIdentity(ctx, identity.subject);
+    const user = await requireActionUser(ctx);
+    const connection = await getConnectionForUserId(ctx, user._id);
     const client = await buildJiraClient(ctx, connection);
     return await client.findStoryPointsField();
   },
@@ -863,20 +838,28 @@ export const getAllJiraMappings = internalQuery({
 // Helpers
 // ---------------------------------------------------------------------------
 
-async function getConnectionFromIdentity(
-  ctx: ActionCtx,
-  authSubject: string
-): Promise<Doc<"integrationConnections">> {
-  // Resolve user from auth identity
+/**
+ * ActionCtx-compatible identity→user resolution: actions have no db access,
+ * so the lookup goes through the internal query. Throws the same messages as
+ * requireAuthUser ("Not authenticated" / "User not found").
+ */
+async function requireActionUser(ctx: ActionCtx): Promise<Doc<"users">> {
+  const identity = await requireAuth(ctx);
   const user: Doc<"users"> | null = await ctx.runQuery(
     internal.integrations.jira.getUserByAuthId,
-    { authUserId: authSubject }
+    { authUserId: identity.subject }
   );
   if (!user) throw new Error("User not found");
+  return user;
+}
 
+async function getConnectionForUserId(
+  ctx: ActionCtx,
+  userId: Id<"users">
+): Promise<Doc<"integrationConnections">> {
   const connection: Doc<"integrationConnections"> | null = await ctx.runQuery(
     internal.integrations.jira.getConnectionForUser,
-    { userId: user._id, provider: "jira" }
+    { userId, provider: "jira" }
   );
   if (!connection) throw new Error("No Jira connection found. Please connect Jira first.");
 
@@ -893,47 +876,26 @@ export const getUserByAuthId = internalQuery({
   },
 });
 
-/** Verifies that the user is a room member with issueManagement permission. */
-export const verifyRoomAccess = internalQuery({
+/**
+ * Verifies that the user may manage issues in the room. The calling action
+ * resolves the user from its own auth identity (actions have no db access)
+ * and passes it through; this internal query routes the check through the
+ * permission guard's explicit-user entry point, so the decision and the
+ * thrown messages are the guard's own.
+ */
+export const verifyCanManageIssues = internalQuery({
   args: {
-    authUserId: v.string(),
+    userId: v.id("users"),
     roomId: v.id("rooms"),
   },
   handler: async (ctx, args) => {
-    const user = await ctx.db
-      .query("users")
-      .withIndex("by_auth_user", (q) => q.eq("authUserId", args.authUserId))
-      .first();
+    const user = await ctx.db.get(args.userId);
     if (!user) throw new Error("User not found");
 
-    const membership = await ctx.db
-      .query("roomMemberships")
-      .withIndex("by_room_user", (q) =>
-        q.eq("roomId", args.roomId).eq("userId", user._id)
-      )
-      .first();
-    if (!membership) throw new Error("Not a member of this room");
-
-    const room = await ctx.db.get(args.roomId);
-    if (!room) throw new Error("Room not found");
-
-    // This internal query authenticates via an explicit authUserId rather than
-    // ctx.auth, so it can't use requireCan; it reaches the permission decision
-    // directly with the room and membership already in hand.
-    const permissions = getEffectivePermissions(room);
-    const action: Action = {
+    await requireCanForUser(ctx, user, args.roomId, {
       kind: "category",
       category: "issueManagement",
-      level: permissions.issueManagement,
-    };
-    const decision = resolve(action, {
-      actorRole: getEffectiveRole(membership),
-      permissions,
-      ownerAbsent: await isRoomOwnerAbsent(ctx, room),
     });
-    if (!decision.allowed) {
-      throw new Error(decision.message);
-    }
 
     return { userId: user._id };
   },

--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -1,6 +1,11 @@
 /**
  * Jira integration - actions and internal mutations for OAuth,
  * token management, issue import, and estimate push-back.
+ *
+ * Fetch orchestration (OAuth token exchange/refresh, Jira REST calls through
+ * JiraClient, webhook registration) lives here; the db-side invariants
+ * (connection upsert, mapping writes, webhook event dedup/apply) live in
+ * model/integrations.ts and the handlers below delegate to it.
  */
 
 import {
@@ -17,6 +22,7 @@ import { encryptToken, decryptToken } from "../lib/encryption";
 import { requireAuth, requireCanForUser } from "../model/auth";
 import { JiraClient } from "./jiraClient";
 import { createIssueInRoom } from "../model/issues";
+import * as Integrations from "../model/integrations";
 import { MAX_ISSUES_PER_ROOM } from "../constants";
 
 function getTokenEncryptionKey(): string {
@@ -148,53 +154,7 @@ export const saveConnection = internalMutation({
     scopes: v.array(v.string()),
   },
   handler: async (ctx, args) => {
-    // Check for existing connection
-    const existing = await ctx.db
-      .query("integrationConnections")
-      .withIndex("by_user_provider", (q) =>
-        q.eq("userId", args.userId).eq("provider", args.provider)
-      )
-      .first();
-
-    const now = Date.now();
-
-    if (existing) {
-      await ctx.db.patch(existing._id, {
-        encryptedAccessToken: args.encryptedAccessToken,
-        accessTokenIv: args.accessTokenIv,
-        accessTokenAuthTag: args.accessTokenAuthTag,
-        encryptedRefreshToken: args.encryptedRefreshToken,
-        refreshTokenIv: args.refreshTokenIv,
-        refreshTokenAuthTag: args.refreshTokenAuthTag,
-        expiresAt: args.expiresAt,
-        cloudId: args.cloudId,
-        siteUrl: args.siteUrl,
-        providerUserId: args.providerUserId,
-        providerUserEmail: args.providerUserEmail,
-        scopes: args.scopes,
-        lastRefreshedAt: now,
-      });
-      return existing._id;
-    }
-
-    return await ctx.db.insert("integrationConnections", {
-      userId: args.userId,
-      provider: args.provider,
-      encryptedAccessToken: args.encryptedAccessToken,
-      accessTokenIv: args.accessTokenIv,
-      accessTokenAuthTag: args.accessTokenAuthTag,
-      encryptedRefreshToken: args.encryptedRefreshToken,
-      refreshTokenIv: args.refreshTokenIv,
-      refreshTokenAuthTag: args.refreshTokenAuthTag,
-      expiresAt: args.expiresAt,
-      cloudId: args.cloudId,
-      siteUrl: args.siteUrl,
-      providerUserId: args.providerUserId,
-      providerUserEmail: args.providerUserEmail,
-      scopes: args.scopes,
-      connectedAt: now,
-      lastRefreshedAt: now,
-    });
+    return await Integrations.saveConnection(ctx, args);
   },
 });
 
@@ -290,10 +250,19 @@ export const setMappingWebhook = internalMutation({
     jiraWebhookId: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.mappingId, {
-      jiraWebhookId: args.jiraWebhookId,
-      jiraWebhookRegisteredAt: args.jiraWebhookId ? Date.now() : undefined,
-    });
+    await Integrations.setMappingWebhook(
+      ctx,
+      args.mappingId,
+      args.jiraWebhookId
+    );
+  },
+});
+
+/** Scheduled tail of the disconnect cascade — see model/integrations.ts. */
+export const deleteConnection = internalMutation({
+  args: { connectionId: v.id("integrationConnections") },
+  handler: async (ctx, args) => {
+    await Integrations.deleteConnection(ctx, args.connectionId);
   },
 });
 
@@ -660,59 +629,50 @@ export const processJiraWebhook = internalMutation({
     issueSummary: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    // Atomic dedup: check + insert in the same mutation (no race window)
-    const existing = await ctx.db
-      .query("webhookEvents")
-      .withIndex("by_event_key", (q) => q.eq("eventKey", args.eventKey))
-      .first();
-    if (existing) return; // Already processed
-
-    await ctx.db.insert("webhookEvents", {
-      eventKey: args.eventKey,
-      provider: "jira",
-      processedAt: Date.now(),
-    });
-
-    // Find linked issue
-    const link = await ctx.db
-      .query("issueLinks")
-      .withIndex("by_external", (q) =>
-        q.eq("provider", "jira").eq("externalId", args.issueKey)
-      )
-      .first();
-
-    if (!link) return; // Not a tracked issue
-
-    if (args.eventType === "jira:issue_updated" && args.issueSummary) {
-      // Update issue title
-      const issue = await ctx.db.get(link.issueId);
-      if (issue) {
-        await ctx.db.patch(link.issueId, {
-          title: `${args.issueKey} - ${args.issueSummary}`,
-        });
-      }
-      await ctx.db.patch(link._id, { lastSyncedAt: Date.now() });
-    }
-
-    if (args.eventType === "jira:issue_deleted") {
-      // Remove the link (keep the AgileKit issue)
-      await ctx.db.delete(link._id);
-    }
+    await Integrations.processJiraWebhookEvent(ctx, args);
   },
 });
 
 export const cleanupOldWebhookEvents = internalMutation({
   args: {},
   handler: async (ctx) => {
-    const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
-    const oldEvents = await ctx.db
-      .query("webhookEvents")
-      .withIndex("by_processed", (q) => q.lt("processedAt", sevenDaysAgo))
-      .collect();
+    await Integrations.cleanupOldWebhookEvents(ctx);
+  },
+});
 
-    await Promise.all(oldEvents.map((e) => ctx.db.delete(e._id)));
-    if (oldEvents.length > 0) {
-      console.log(`Cleaned up ${oldEvents.length} old webhook events`);
+/**
+ * Best-effort remote deregistration of one Jira webhook. The model schedules
+ * this whenever a mapping or connection is torn down, so the remote webhook
+ * is deleted instead of being orphaned until its 30-day expiry. If the
+ * connection is already gone the webhook is left to expire — logged here so
+ * the leak is tracked rather than silent.
+ */
+export const deregisterWebhook = internalAction({
+  args: {
+    connectionId: v.id("integrationConnections"),
+    jiraWebhookId: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const connection = await ctx.runQuery(
+      internal.integrations.jira.getConnectionById,
+      { connectionId: args.connectionId }
+    );
+    if (!connection) {
+      console.warn(
+        `Jira connection ${args.connectionId} already removed; webhook ${args.jiraWebhookId} left to expire remotely`
+      );
+      return;
+    }
+
+    try {
+      const client = await buildJiraClient(ctx, connection);
+      await client.deleteWebhooks([args.jiraWebhookId]);
+      console.log(`Deregistered Jira webhook ${args.jiraWebhookId}`);
+    } catch (error) {
+      console.warn(
+        `Failed to deregister Jira webhook ${args.jiraWebhookId}:`,
+        error
+      );
     }
   },
 });

--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -16,7 +16,7 @@ import { ActionCtx } from "../_generated/server";
 import { encryptToken, decryptToken } from "../lib/encryption";
 import { requireAuth, requireCanForUser } from "../model/auth";
 import { JiraClient } from "./jiraClient";
-import { validateIssueTitle } from "../model/issues";
+import { createIssueInRoom } from "../model/issues";
 import { MAX_ISSUES_PER_ROOM } from "../constants";
 
 function getTokenEncryptionKey(): string {
@@ -246,6 +246,8 @@ export const createIssueWithLink = internalMutation({
       .withIndex("by_room", (q) => q.eq("roomId", args.roomId))
       .collect();
 
+    // Cap check stays ahead of dedup so a full room errors even when this key
+    // was already imported; createIssueInRoom re-enforces it on creation.
     if (roomIssues.length >= MAX_ISSUES_PER_ROOM) {
       throw new Error(`Rooms are limited to ${MAX_ISSUES_PER_ROOM} issues`);
     }
@@ -264,30 +266,9 @@ export const createIssueWithLink = internalMutation({
       }
     }
 
-    // Create issue (follows Issues.createIssue pattern)
-    const room = await ctx.db.get(args.roomId);
-    if (!room) throw new Error("Room not found");
-
-    const currentNumber = room.nextIssueNumber ?? 1;
-    await ctx.db.patch(args.roomId, { nextIssueNumber: currentNumber + 1 });
-
-    // Find current max order
-    const existingIssues = await ctx.db
-      .query("issues")
-      .withIndex("by_room_order", (q) => q.eq("roomId", args.roomId))
-      .collect();
-    const maxOrder =
-      existingIssues.length > 0
-        ? Math.max(...existingIssues.map((i) => i.order))
-        : 0;
-
-    const issueId = await ctx.db.insert("issues", {
+    const issueId = await createIssueInRoom(ctx, {
       roomId: args.roomId,
-      sequentialId: currentNumber,
-      title: validateIssueTitle(args.title),
-      status: "pending",
-      createdAt: Date.now(),
-      order: maxOrder + 1,
+      title: args.title,
     });
 
     // Create bidirectional link

--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -5,7 +5,9 @@
  * Fetch orchestration (OAuth token exchange/refresh, Jira REST calls through
  * JiraClient, webhook registration) lives here; the db-side invariants
  * (connection upsert, mapping writes, webhook event dedup/apply) live in
- * model/integrations.ts and the handlers below delegate to it.
+ * model/integrations.ts and the handlers below delegate to it. The
+ * token-field contract (key validation, encrypt-on-write, decrypt-on-read,
+ * expiry rule) lives in model/tokenVault.ts.
  */
 
 import {
@@ -18,27 +20,12 @@ import { internal } from "../_generated/api";
 import { v } from "convex/values";
 import { Doc, Id } from "../_generated/dataModel";
 import { ActionCtx } from "../_generated/server";
-import { encryptToken, decryptToken } from "../lib/encryption";
 import { requireAuth, requireCanForUser } from "../model/auth";
 import { JiraClient } from "./jiraClient";
 import { createIssueInRoom } from "../model/issues";
 import * as Integrations from "../model/integrations";
+import * as TokenVault from "../model/tokenVault";
 import { MAX_ISSUES_PER_ROOM } from "../constants";
-
-function getTokenEncryptionKey(): string {
-  const key = process.env.TOKEN_ENCRYPTION_KEY;
-  if (!key) {
-    throw new Error(
-      "Missing TOKEN_ENCRYPTION_KEY environment variable. Set a 32-byte hex key."
-    );
-  }
-  if (!/^[0-9a-fA-F]{64}$/.test(key)) {
-    throw new Error(
-      "Invalid TOKEN_ENCRYPTION_KEY. Expected 64 hex characters (32 bytes)."
-    );
-  }
-  return key;
-}
 
 // ---------------------------------------------------------------------------
 // Token helpers (used within actions)
@@ -48,16 +35,9 @@ export async function getValidAccessToken(
   ctx: ActionCtx,
   connection: Doc<"integrationConnections">
 ): Promise<string> {
-  const encKey = getTokenEncryptionKey();
-
   // If token is valid for >1 minute, decrypt and return
-  if (connection.expiresAt > Date.now() + 60_000) {
-    return decryptToken(
-      connection.encryptedAccessToken,
-      connection.accessTokenIv,
-      connection.accessTokenAuthTag,
-      encKey
-    );
+  if (TokenVault.isAccessTokenFresh(connection.expiresAt)) {
+    return TokenVault.decryptAccessToken(connection);
   }
 
   // Token expired or about to expire — refresh
@@ -68,22 +48,7 @@ export async function refreshJiraToken(
   ctx: ActionCtx,
   connection: Doc<"integrationConnections">
 ): Promise<string> {
-  const encKey = getTokenEncryptionKey();
-
-  if (
-    !connection.encryptedRefreshToken ||
-    !connection.refreshTokenIv ||
-    !connection.refreshTokenAuthTag
-  ) {
-    throw new Error("No refresh token available for this connection");
-  }
-
-  const refreshToken = await decryptToken(
-    connection.encryptedRefreshToken,
-    connection.refreshTokenIv,
-    connection.refreshTokenAuthTag,
-    encKey
-  );
+  const refreshToken = await TokenVault.decryptRefreshToken(connection);
 
   const response = await fetch("https://auth.atlassian.com/oauth/token", {
     method: "POST",
@@ -104,17 +69,14 @@ export async function refreshJiraToken(
   const tokens = await response.json();
 
   // Atlassian uses rotating refresh tokens — encrypt both new tokens
-  const encAccess = await encryptToken(tokens.access_token, encKey);
-  const encRefresh = await encryptToken(tokens.refresh_token, encKey);
+  const enc = await TokenVault.encryptTokens({
+    accessToken: tokens.access_token,
+    refreshToken: tokens.refresh_token,
+  });
 
   await ctx.runMutation(internal.integrations.jira.updateTokens, {
     connectionId: connection._id,
-    encryptedAccessToken: encAccess.ciphertext,
-    accessTokenIv: encAccess.iv,
-    accessTokenAuthTag: encAccess.authTag,
-    encryptedRefreshToken: encRefresh.ciphertext,
-    refreshTokenIv: encRefresh.iv,
-    refreshTokenAuthTag: encRefresh.authTag,
+    ...enc,
     expiresAt: Date.now() + tokens.expires_in * 1000,
   });
 
@@ -170,16 +132,7 @@ export const updateTokens = internalMutation({
     expiresAt: v.number(),
   },
   handler: async (ctx, args) => {
-    await ctx.db.patch(args.connectionId, {
-      encryptedAccessToken: args.encryptedAccessToken,
-      accessTokenIv: args.accessTokenIv,
-      accessTokenAuthTag: args.accessTokenAuthTag,
-      encryptedRefreshToken: args.encryptedRefreshToken,
-      refreshTokenIv: args.refreshTokenIv,
-      refreshTokenAuthTag: args.refreshTokenAuthTag,
-      expiresAt: args.expiresAt,
-      lastRefreshedAt: Date.now(),
-    });
+    await Integrations.updateConnectionTokens(ctx, args);
   },
 });
 
@@ -345,20 +298,15 @@ export const storeConnection = internalAction({
     providerUserEmail: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const encKey = getTokenEncryptionKey();
-
-    const encAccess = await encryptToken(args.accessToken, encKey);
-    const encRefresh = await encryptToken(args.refreshToken, encKey);
+    const enc = await TokenVault.encryptTokens({
+      accessToken: args.accessToken,
+      refreshToken: args.refreshToken,
+    });
 
     await ctx.runMutation(internal.integrations.jira.saveConnection, {
       userId: args.userId,
       provider: "jira",
-      encryptedAccessToken: encAccess.ciphertext,
-      accessTokenIv: encAccess.iv,
-      accessTokenAuthTag: encAccess.authTag,
-      encryptedRefreshToken: encRefresh.ciphertext,
-      refreshTokenIv: encRefresh.iv,
-      refreshTokenAuthTag: encRefresh.authTag,
+      ...enc,
       expiresAt: Date.now() + args.expiresIn * 1000,
       cloudId: args.cloudId,
       siteUrl: args.siteUrl,

--- a/convex/integrations/jira.ts
+++ b/convex/integrations/jira.ts
@@ -591,14 +591,16 @@ export const cleanupOldWebhookEvents = internalMutation({
 /**
  * Best-effort remote deregistration of one Jira webhook. The model schedules
  * this whenever a mapping or connection is torn down, so the remote webhook
- * is deleted instead of being orphaned until its 30-day expiry. If the
- * connection is already gone the webhook is left to expire — logged here so
- * the leak is tracked rather than silent.
+ * is deleted instead of being orphaned until its 30-day expiry. A failure is
+ * retried once after a delay (the connection row still exists at that point,
+ * so the retry can authenticate); a webhook that survives the retry is left
+ * to expire — logged here so the leak is tracked rather than silent.
  */
 export const deregisterWebhook = internalAction({
   args: {
     connectionId: v.id("integrationConnections"),
     jiraWebhookId: v.string(),
+    attemptsLeft: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const connection = await ctx.runQuery(
@@ -617,11 +619,84 @@ export const deregisterWebhook = internalAction({
       await client.deleteWebhooks([args.jiraWebhookId]);
       console.log(`Deregistered Jira webhook ${args.jiraWebhookId}`);
     } catch (error) {
+      const attemptsLeft = args.attemptsLeft ?? 1;
+      if (attemptsLeft > 0) {
+        console.warn(
+          `Failed to deregister Jira webhook ${args.jiraWebhookId}; retrying in 5 minutes:`,
+          error
+        );
+        await ctx.scheduler.runAfter(
+          5 * 60 * 1000,
+          internal.integrations.jira.deregisterWebhook,
+          {
+            connectionId: args.connectionId,
+            jiraWebhookId: args.jiraWebhookId,
+            attemptsLeft: attemptsLeft - 1,
+          }
+        );
+        return;
+      }
       console.warn(
-        `Failed to deregister Jira webhook ${args.jiraWebhookId}:`,
+        `Failed to deregister Jira webhook ${args.jiraWebhookId} (no retries left); left to expire remotely:`,
         error
       );
     }
+  },
+});
+
+/**
+ * The disconnect tail: deregisters every live webhook of a torn-down
+ * connection, then deletes the connection row. Scheduling deregistrations and
+ * the row deletion as independent same-tick jobs would race (the deletion
+ * could win, leaving the deregistrations unable to authenticate), so the
+ * ordering is enforced here by the action's own awaits. Deregistration is
+ * best-effort: a webhook that cannot be deleted remotely is logged and left
+ * to its 30-day expiry rather than blocking the disconnect.
+ */
+export const finalizeDisconnect = internalAction({
+  args: {
+    connectionId: v.id("integrationConnections"),
+    jiraWebhookIds: v.array(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const connection = await ctx.runQuery(
+      internal.integrations.jira.getConnectionById,
+      { connectionId: args.connectionId }
+    );
+
+    if (!connection) {
+      console.warn(
+        `Jira connection ${args.connectionId} already removed; ${args.jiraWebhookIds.length} webhook(s) left to expire remotely`
+      );
+    } else {
+      let client: JiraClient | null = null;
+      try {
+        client = await buildJiraClient(ctx, connection);
+      } catch (error) {
+        console.warn(
+          `Could not build a Jira client for connection ${args.connectionId}; ${args.jiraWebhookIds.length} webhook(s) left to expire remotely:`,
+          error
+        );
+      }
+      if (client) {
+        for (const jiraWebhookId of args.jiraWebhookIds) {
+          try {
+            await client.deleteWebhooks([jiraWebhookId]);
+            console.log(`Deregistered Jira webhook ${jiraWebhookId}`);
+          } catch (error) {
+            console.warn(
+              `Failed to deregister Jira webhook ${jiraWebhookId} during disconnect; left to expire remotely:`,
+              error
+            );
+          }
+        }
+      }
+    }
+
+    // The row goes only now — after every deregistration has had its turn.
+    await ctx.runMutation(internal.integrations.jira.deleteConnection, {
+      connectionId: args.connectionId,
+    });
   },
 });
 

--- a/convex/integrationsModel.test.ts
+++ b/convex/integrationsModel.test.ts
@@ -1,0 +1,355 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { api, internal } from "./_generated/api";
+import schema from "./schema";
+import type { Id } from "./_generated/dataModel";
+import * as Integrations from "./model/integrations";
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+// convex-test dispatches runAfter(0) jobs through a real setTimeout, which
+// can fire mid-test — racing the _scheduled_functions assertions and running
+// Jira actions that need env vars. Faking setTimeout keeps scheduled jobs
+// pending for the duration of each test.
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["setTimeout"] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+async function seedRoom(t: T): Promise<Id<"rooms">> {
+  return t.run((ctx) =>
+    ctx.db.insert("rooms", {
+      name: "R",
+      autoCompleteVoting: true,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    })
+  );
+}
+
+async function seedUser(t: T, authUserId: string): Promise<Id<"users">> {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      authUserId,
+      name: "U",
+      createdAt: Date.now(),
+    })
+  );
+}
+
+async function seedConnection(
+  t: T,
+  userId: Id<"users">
+): Promise<Id<"integrationConnections">> {
+  return t.run((ctx) =>
+    ctx.db.insert("integrationConnections", {
+      userId,
+      provider: "jira",
+      encryptedAccessToken: "enc-access",
+      accessTokenIv: "iv",
+      accessTokenAuthTag: "tag",
+      encryptedRefreshToken: "enc-refresh",
+      refreshTokenIv: "riv",
+      refreshTokenAuthTag: "rtag",
+      expiresAt: Date.now() + 3_600_000,
+      cloudId: "cloud-1",
+      siteUrl: "https://team.atlassian.net",
+      providerUserId: "jira-user-1",
+      providerUserEmail: "u@example.com",
+      scopes: ["read:jira-work"],
+      connectedAt: Date.now(),
+      lastRefreshedAt: Date.now(),
+    })
+  );
+}
+
+async function seedMapping(
+  t: T,
+  roomId: Id<"rooms">,
+  connectionId: Id<"integrationConnections">,
+  opts: { jiraWebhookId?: string } = {}
+): Promise<Id<"integrationMappings">> {
+  return t.run((ctx) =>
+    ctx.db.insert("integrationMappings", {
+      roomId,
+      connectionId,
+      provider: "jira",
+      jiraProjectKey: "PROJ",
+      jiraWebhookId: opts.jiraWebhookId,
+      jiraWebhookRegisteredAt: opts.jiraWebhookId ? Date.now() : undefined,
+      autoImport: false,
+      autoPushEstimates: true,
+      createdAt: Date.now(),
+    })
+  );
+}
+
+async function seedIssue(
+  t: T,
+  roomId: Id<"rooms">
+): Promise<Id<"issues">> {
+  return t.run((ctx) =>
+    ctx.db.insert("issues", {
+      roomId,
+      sequentialId: 1,
+      title: "PROJ-1 - Old summary",
+      status: "pending",
+      createdAt: Date.now(),
+      order: 0,
+    })
+  );
+}
+
+async function seedIssueLink(
+  t: T,
+  issueId: Id<"issues">,
+  externalId: string
+): Promise<Id<"issueLinks">> {
+  return t.run((ctx) =>
+    ctx.db.insert("issueLinks", {
+      issueId,
+      provider: "jira",
+      externalId,
+      externalUrl: `https://team.atlassian.net/browse/${externalId}`,
+      lastSyncedAt: Date.now(),
+    })
+  );
+}
+
+async function countRows(
+  t: T,
+  table: "integrationConnections" | "integrationMappings" | "issueLinks" | "webhookEvents"
+): Promise<number> {
+  return t.run(async (ctx) => (await ctx.db.query(table).collect()).length);
+}
+
+async function scheduledByName(t: T, suffix: string) {
+  const scheduled = await t.run((ctx) =>
+    ctx.db.system.query("_scheduled_functions").collect()
+  );
+  return scheduled.filter((s) => s.name.endsWith(suffix));
+}
+
+describe("processJiraWebhookEvent", () => {
+  it("applies a redelivered event only once", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const issueId = await seedIssue(t, roomId);
+    await seedIssueLink(t, issueId, "PROJ-1");
+
+    const event = {
+      eventKey: "jira:10001:1700000000000",
+      eventType: "jira:issue_updated",
+      issueKey: "PROJ-1",
+      issueSummary: "First summary",
+    };
+    await t.mutation(internal.integrations.jira.processJiraWebhook, event);
+    // Redelivery of the same event key must no-op — even carrying a
+    // different summary, the title must not move again.
+    await t.mutation(internal.integrations.jira.processJiraWebhook, {
+      ...event,
+      issueSummary: "Second summary",
+    });
+
+    const issue = await t.run((ctx) => ctx.db.get(issueId));
+    expect(issue?.title).toBe("PROJ-1 - First summary");
+    expect(await countRows(t, "webhookEvents")).toBe(1);
+  });
+
+  it("jira:issue_deleted removes the link but keeps the local issue", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const issueId = await seedIssue(t, roomId);
+    await seedIssueLink(t, issueId, "PROJ-1");
+
+    await t.mutation(internal.integrations.jira.processJiraWebhook, {
+      eventKey: "jira:10001:1700000000001",
+      eventType: "jira:issue_deleted",
+      issueKey: "PROJ-1",
+    });
+
+    expect(await countRows(t, "issueLinks")).toBe(0);
+    expect(await t.run((ctx) => ctx.db.get(issueId))).not.toBeNull();
+  });
+});
+
+describe("disconnect", () => {
+  it("cascades the connection's mappings and schedules a deregistration per live webhook", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+    const connectionId = await seedConnection(t, userId);
+    const roomA = await seedRoom(t);
+    const roomB = await seedRoom(t);
+    await seedMapping(t, roomA, connectionId, { jiraWebhookId: "wh-a" });
+    await seedMapping(t, roomB, connectionId, { jiraWebhookId: "wh-b" });
+
+    const asU = t.withIdentity({ subject: "auth-u" });
+    await asU.mutation(api.integrations.disconnect, { connectionId });
+
+    expect(await countRows(t, "integrationMappings")).toBe(0);
+
+    const deregistrations = await scheduledByName(t, ":deregisterWebhook");
+    expect(deregistrations).toHaveLength(2);
+    const deregisteredIds = deregistrations
+      .map(
+        (s) =>
+          (s.args as [{ connectionId: string; jiraWebhookId: string }])[0]
+            .jiraWebhookId
+      )
+      .sort();
+    expect(deregisteredIds).toEqual(["wh-a", "wh-b"]);
+
+    // The connection row stays until the deregistrations have read its
+    // credentials — deletion is the scheduled tail of the cascade.
+    expect(await countRows(t, "integrationConnections")).toBe(1);
+    expect(await scheduledByName(t, ":deleteConnection")).toHaveLength(1);
+  });
+
+  it("deletes the connection directly when no webhook is live", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+    const connectionId = await seedConnection(t, userId);
+    const roomId = await seedRoom(t);
+    await seedMapping(t, roomId, connectionId); // no jiraWebhookId
+
+    const asU = t.withIdentity({ subject: "auth-u" });
+    await asU.mutation(api.integrations.disconnect, { connectionId });
+
+    expect(await countRows(t, "integrationMappings")).toBe(0);
+    expect(await countRows(t, "integrationConnections")).toBe(0);
+    expect(await scheduledByName(t, ":deregisterWebhook")).toHaveLength(0);
+    expect(await scheduledByName(t, ":deleteConnection")).toHaveLength(0);
+  });
+});
+
+describe("removeRoomMapping", () => {
+  it("deregisters the mapping's own webhook", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+    const connectionId = await seedConnection(t, userId);
+    const roomId = await seedRoom(t);
+    await seedMapping(t, roomId, connectionId, { jiraWebhookId: "wh-room" });
+
+    await t.run((ctx) => Integrations.removeRoomMapping(ctx, roomId));
+
+    expect(await countRows(t, "integrationMappings")).toBe(0);
+
+    const deregistrations = await scheduledByName(t, ":deregisterWebhook");
+    expect(deregistrations).toHaveLength(1);
+    expect(
+      (deregistrations[0].args as [{ jiraWebhookId: string }])[0].jiraWebhookId
+    ).toBe("wh-room");
+
+    // The connection survives the mapping — the scheduled action uses its
+    // credentials for the remote delete.
+    expect(await countRows(t, "integrationConnections")).toBe(1);
+  });
+});
+
+describe("saveRoomMapping", () => {
+  it("upsert preserves createdAt on update and schedules re-registration", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+    const connectionId = await seedConnection(t, userId);
+    const roomId = await seedRoom(t);
+
+    const mappingId = await t.run((ctx) =>
+      Integrations.saveRoomMapping(ctx, {
+        roomId,
+        connectionId,
+        provider: "jira",
+        jiraProjectKey: "PROJ",
+        autoImport: false,
+        autoPushEstimates: true,
+      })
+    );
+
+    // Backdate createdAt to a sentinel so preservation is observable.
+    const sentinel = 1_000_000;
+    await t.run((ctx) => ctx.db.patch(mappingId, { createdAt: sentinel }));
+
+    const again = await t.run((ctx) =>
+      Integrations.saveRoomMapping(ctx, {
+        roomId,
+        connectionId,
+        provider: "jira",
+        jiraProjectKey: "PROJ",
+        storyPointsFieldId: "customfield_10016",
+        autoImport: false,
+        autoPushEstimates: true,
+      })
+    );
+
+    expect(again).toBe(mappingId);
+    const mapping = await t.run((ctx) => ctx.db.get(mappingId));
+    expect(mapping?.createdAt).toBe(sentinel);
+    expect(mapping?.storyPointsFieldId).toBe("customfield_10016");
+    expect(await countRows(t, "integrationMappings")).toBe(1);
+
+    // Both the insert and the update scheduled a webhook (re-)registration.
+    expect(await scheduledByName(t, ":registerWebhook")).toHaveLength(2);
+  });
+});
+
+describe("toConnectionView", () => {
+  it("never exposes encrypted token fields", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+    const connectionId = await seedConnection(t, userId);
+
+    const connection = await t.run((ctx) => ctx.db.get(connectionId));
+    const view = Integrations.toConnectionView(connection!);
+
+    expect(Object.keys(view).sort()).toEqual([
+      "_id",
+      "connectedAt",
+      "provider",
+      "providerUserEmail",
+      "scopes",
+      "siteUrl",
+    ]);
+    expect(view).toMatchObject({
+      _id: connectionId,
+      provider: "jira",
+      siteUrl: "https://team.atlassian.net",
+      providerUserEmail: "u@example.com",
+      scopes: ["read:jira-work"],
+    });
+  });
+});
+
+describe("setMappingWebhook", () => {
+  it("replaces the webhook id on re-registration and clears it on removal", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+    const connectionId = await seedConnection(t, userId);
+    const roomId = await seedRoom(t);
+    const mappingId = await seedMapping(t, roomId, connectionId, {
+      jiraWebhookId: "wh-old",
+    });
+    await t.run((ctx) =>
+      ctx.db.patch(mappingId, { jiraWebhookRegisteredAt: 1_000_000 })
+    );
+
+    await t.run((ctx) =>
+      Integrations.setMappingWebhook(ctx, mappingId, "wh-new")
+    );
+    const replaced = await t.run((ctx) => ctx.db.get(mappingId));
+    expect(replaced?.jiraWebhookId).toBe("wh-new");
+    expect(replaced?.jiraWebhookRegisteredAt).toBeGreaterThan(1_000_000);
+
+    await t.run((ctx) =>
+      Integrations.setMappingWebhook(ctx, mappingId, undefined)
+    );
+    const cleared = await t.run((ctx) => ctx.db.get(mappingId));
+    expect(cleared?.jiraWebhookId).toBeUndefined();
+    expect(cleared?.jiraWebhookRegisteredAt).toBeUndefined();
+  });
+});

--- a/convex/integrationsModel.test.ts
+++ b/convex/integrationsModel.test.ts
@@ -181,7 +181,7 @@ describe("processJiraWebhookEvent", () => {
 });
 
 describe("disconnect", () => {
-  it("cascades the connection's mappings and schedules a deregistration per live webhook", async () => {
+  it("cascades the connection's mappings and hands live webhooks to one finalizeDisconnect tail", async () => {
     const t = convexTest(schema, modules);
     const userId = await seedUser(t, "auth-u");
     const connectionId = await seedConnection(t, userId);
@@ -195,21 +195,41 @@ describe("disconnect", () => {
 
     expect(await countRows(t, "integrationMappings")).toBe(0);
 
-    const deregistrations = await scheduledByName(t, ":deregisterWebhook");
-    expect(deregistrations).toHaveLength(2);
-    const deregisteredIds = deregistrations
-      .map(
-        (s) =>
-          (s.args as [{ connectionId: string; jiraWebhookId: string }])[0]
-            .jiraWebhookId
-      )
-      .sort();
-    expect(deregisteredIds).toEqual(["wh-a", "wh-b"]);
-
     // The connection row stays until the deregistrations have read its
-    // credentials — deletion is the scheduled tail of the cascade.
+    // credentials — and there is exactly ONE scheduled tail carrying both
+    // webhooks, so the row delete can never race the deregistrations (two
+    // independent same-tick jobs had no ordering guarantee).
     expect(await countRows(t, "integrationConnections")).toBe(1);
-    expect(await scheduledByName(t, ":deleteConnection")).toHaveLength(1);
+    const finalize = await scheduledByName(t, ":finalizeDisconnect");
+    expect(finalize).toHaveLength(1);
+    const finalizeArgs = (
+      finalize[0].args as [{ connectionId: string; jiraWebhookIds: string[] }]
+    )[0];
+    expect(finalizeArgs.connectionId).toBe(connectionId);
+    expect([...finalizeArgs.jiraWebhookIds].sort()).toEqual(["wh-a", "wh-b"]);
+    expect(await scheduledByName(t, ":deleteConnection")).toHaveLength(0);
+    expect(await scheduledByName(t, ":deregisterWebhook")).toHaveLength(0);
+  });
+
+  it("finalizeDisconnect deletes the connection row only after the deregistrations had their turn", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+    const connectionId = await seedConnection(t, userId);
+    const roomId = await seedRoom(t);
+    await seedMapping(t, roomId, connectionId, { jiraWebhookId: "wh-a" });
+
+    const asU = t.withIdentity({ subject: "auth-u" });
+    await asU.mutation(api.integrations.disconnect, { connectionId });
+    expect(await countRows(t, "integrationConnections")).toBe(1);
+
+    // Run the scheduled tail. Deregistration fails closed in the test env
+    // (seed tokens don't decrypt), is logged, and the row delete still
+    // lands — the leak is tracked, never silent, and never blocks disconnect.
+    await t.action(internal.integrations.jira.finalizeDisconnect, {
+      connectionId,
+      jiraWebhookIds: ["wh-a"],
+    });
+    expect(await countRows(t, "integrationConnections")).toBe(0);
   });
 
   it("deletes the connection directly when no webhook is live", async () => {
@@ -224,8 +244,88 @@ describe("disconnect", () => {
 
     expect(await countRows(t, "integrationMappings")).toBe(0);
     expect(await countRows(t, "integrationConnections")).toBe(0);
+    expect(await scheduledByName(t, ":finalizeDisconnect")).toHaveLength(0);
     expect(await scheduledByName(t, ":deregisterWebhook")).toHaveLength(0);
     expect(await scheduledByName(t, ":deleteConnection")).toHaveLength(0);
+  });
+});
+
+describe("deregisterWebhook", () => {
+  it("schedules one bounded retry on failure, then stops", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+    const connectionId = await seedConnection(t, userId);
+
+    // Deregistration fails in the test env (seed tokens don't decrypt)…
+    await t.action(internal.integrations.jira.deregisterWebhook, {
+      connectionId,
+      jiraWebhookId: "wh-x",
+    });
+
+    // …so exactly one retry is pending, disarmed (attemptsLeft: 0).
+    const retries = await scheduledByName(t, ":deregisterWebhook");
+    expect(retries).toHaveLength(1);
+    expect(
+      (retries[0].args as [{ attemptsLeft: number }])[0].attemptsLeft
+    ).toBe(0);
+
+    // The disarmed retry does not chain another retry.
+    await t.action(internal.integrations.jira.deregisterWebhook, {
+      connectionId,
+      jiraWebhookId: "wh-x",
+      attemptsLeft: 0,
+    });
+    expect(await scheduledByName(t, ":deregisterWebhook")).toHaveLength(1);
+  });
+
+  it("does nothing when the connection is already gone", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+    const connectionId = await seedConnection(t, userId);
+    await t.run((ctx) => ctx.db.delete(connectionId));
+
+    await t.action(internal.integrations.jira.deregisterWebhook, {
+      connectionId,
+      jiraWebhookId: "wh-x",
+    });
+
+    expect(await scheduledByName(t, ":deregisterWebhook")).toHaveLength(0);
+  });
+});
+
+describe("public Jira actions require authentication", () => {
+  it("rejects unauthenticated callers before touching the network", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+
+    await expect(t.action(api.integrations.jira.getJiraProjects, {})).rejects.toThrow(
+      "Not authenticated"
+    );
+    await expect(
+      t.action(api.integrations.jira.importIssues, {
+        roomId,
+        jiraIssueKeys: ["PROJ-1"],
+      })
+    ).rejects.toThrow("Not authenticated");
+    await expect(
+      t.action(api.integrations.jira.connectJira, {
+        accessToken: "a",
+        refreshToken: "r",
+        expiresIn: 3600,
+        cloudId: "cloud-1",
+        siteUrl: "https://team.atlassian.net",
+        scopes: [],
+      })
+    ).rejects.toThrow("Not authenticated");
+  });
+
+  it("rejects an identity with no app-level user record", async () => {
+    const t = convexTest(schema, modules);
+    const ghost = t.withIdentity({ subject: "auth-ghost" }); // no users row
+
+    await expect(
+      ghost.action(api.integrations.jira.getJiraProjects, {})
+    ).rejects.toThrow("User not found");
   });
 });
 

--- a/convex/issueCreation.test.ts
+++ b/convex/issueCreation.test.ts
@@ -1,0 +1,184 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import { internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import * as Issues from "./model/issues";
+import { MAX_ISSUES_PER_ROOM } from "./constants";
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+async function seedRoom(t: T): Promise<Id<"rooms">> {
+  return t.run((ctx) =>
+    ctx.db.insert("rooms", {
+      name: "R",
+      autoCompleteVoting: true,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    })
+  );
+}
+
+async function createLocal(
+  t: T,
+  roomId: Id<"rooms">,
+  title: string
+): Promise<Id<"issues">> {
+  return t.run((ctx) => Issues.createIssue(ctx, { roomId, title }));
+}
+
+async function importJira(
+  t: T,
+  roomId: Id<"rooms">,
+  externalId: string
+): Promise<Id<"issues"> | null> {
+  return t.mutation(internal.integrations.jira.createIssueWithLink, {
+    roomId,
+    title: `${externalId} - Summary`,
+    provider: "jira",
+    externalId,
+    externalUrl: `https://site.atlassian.net/browse/${externalId}`,
+  });
+}
+
+async function listRoomIssues(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) =>
+    ctx.db
+      .query("issues")
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .collect()
+  );
+}
+
+async function readRoom(t: T, roomId: Id<"rooms">) {
+  return t.run((ctx) => ctx.db.get(roomId));
+}
+
+describe("issue creation (createIssueInRoom)", () => {
+  it("allocates sequential IDs across local + imported issues with no reuse", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+
+    await createLocal(t, roomId, "First");
+    await createLocal(t, roomId, "Second");
+    const importedId = await importJira(t, roomId, "PROJ-1");
+
+    const issues = await listRoomIssues(t, roomId);
+    expect(issues.map((i) => i.sequentialId).sort((a, b) => a - b)).toEqual([
+      1, 2, 3,
+    ]);
+    const imported = issues.find((i) => i._id === importedId);
+    // The drifted pre-increment copy reused sequentialId 2 here (PP-2 dupe)
+    expect(imported?.sequentialId).toBe(3);
+    expect((await readRoom(t, roomId))?.nextIssueNumber).toBe(3);
+  });
+
+  it("enforces the per-room cap on both local create and import", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+
+    // Fill the room to the cap in batches to stay within transaction limits
+    for (let batch = 0; batch < MAX_ISSUES_PER_ROOM / 100; batch++) {
+      await t.run(async (ctx) => {
+        for (let i = 0; i < 100; i++) {
+          const n = batch * 100 + i + 1;
+          await ctx.db.insert("issues", {
+            roomId,
+            sequentialId: n,
+            title: `Issue ${n}`,
+            status: "pending",
+            createdAt: Date.now(),
+            order: n,
+          });
+        }
+      });
+    }
+    await t.run((ctx) =>
+      ctx.db.patch(roomId, { nextIssueNumber: MAX_ISSUES_PER_ROOM })
+    );
+
+    await expect(createLocal(t, roomId, "One too many")).rejects.toThrow(
+      `Rooms are limited to ${MAX_ISSUES_PER_ROOM} issues`
+    );
+    await expect(importJira(t, roomId, "PROJ-9")).rejects.toThrow(
+      `Rooms are limited to ${MAX_ISSUES_PER_ROOM} issues`
+    );
+    expect((await readRoom(t, roomId))?.nextIssueNumber).toBe(
+      MAX_ISSUES_PER_ROOM
+    );
+  });
+
+  it("appends an imported issue after the current max order", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+
+    // Non-contiguous high order exercises the max-order scan
+    await t.run((ctx) =>
+      ctx.db.insert("issues", {
+        roomId,
+        sequentialId: 1,
+        title: "Seeded",
+        status: "pending",
+        createdAt: Date.now(),
+        order: 7,
+      })
+    );
+    await t.run((ctx) => ctx.db.patch(roomId, { nextIssueNumber: 1 }));
+
+    const importedId = await importJira(t, roomId, "PROJ-2");
+    const imported = await t.run((ctx) => ctx.db.get(importedId!));
+    expect(imported?.order).toBe(8);
+    expect(imported?.sequentialId).toBe(2);
+  });
+
+  it("advances the room counter exactly once per issue across a mixed batch", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+
+    await createLocal(t, roomId, "Local 1");
+    await importJira(t, roomId, "PROJ-1");
+    await createLocal(t, roomId, "Local 2");
+    await importJira(t, roomId, "PROJ-2");
+
+    const issues = await listRoomIssues(t, roomId);
+    expect(issues).toHaveLength(4);
+    expect(issues.map((i) => i.sequentialId).sort((a, b) => a - b)).toEqual([
+      1, 2, 3, 4,
+    ]);
+    expect((await readRoom(t, roomId))?.nextIssueNumber).toBe(4);
+  });
+
+  it("re-importing the same external id in one room creates no second issue", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+
+    const first = await importJira(t, roomId, "PROJ-3");
+    const again = await importJira(t, roomId, "PROJ-3");
+
+    expect(first).not.toBeNull();
+    expect(again).toBeNull();
+
+    const issues = await listRoomIssues(t, roomId);
+    expect(issues).toHaveLength(1);
+    // The skipped re-import must not advance the counter
+    expect((await readRoom(t, roomId))?.nextIssueNumber).toBe(1);
+
+    const links = await t.run((ctx) => ctx.db.query("issueLinks").collect());
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({
+      issueId: first,
+      provider: "jira",
+      externalId: "PROJ-3",
+      externalUrl: "https://site.atlassian.net/browse/PROJ-3",
+    });
+
+    // Dedup is per-room: the same external id is allowed in another room
+    const otherRoomId = await seedRoom(t);
+    const otherImport = await importJira(t, otherRoomId, "PROJ-3");
+    expect(otherImport).not.toBeNull();
+  });
+});

--- a/convex/issueCreation.test.ts
+++ b/convex/issueCreation.test.ts
@@ -152,6 +152,27 @@ describe("issue creation (createIssueInRoom)", () => {
     expect((await readRoom(t, roomId))?.nextIssueNumber).toBe(4);
   });
 
+  it("concurrent callers all get unique sequential IDs", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+
+    // convex-test serializes function execution, so this locks in uniqueness
+    // under simultaneous invocation; the OCC guarantee underneath is Convex's
+    // own transactionality (single-document read-modify-write per mutation).
+    await Promise.all(
+      ["A", "B", "C", "D", "E"].map((title) =>
+        t.run((ctx) => Issues.createIssueInRoom(ctx, { roomId, title }))
+      )
+    );
+
+    const issues = await listRoomIssues(t, roomId);
+    expect(issues).toHaveLength(5);
+    expect(issues.map((i) => i.sequentialId).sort((a, b) => a - b)).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
+    expect((await readRoom(t, roomId))?.nextIssueNumber).toBe(5);
+  });
+
   it("re-importing the same external id in one room creates no second issue", async () => {
     const t = convexTest(schema, modules);
     const roomId = await seedRoom(t);

--- a/convex/maintenance.ts
+++ b/convex/maintenance.ts
@@ -1,5 +1,31 @@
 import { internalMutation } from "./_generated/server";
+import { v } from "convex/values";
+import { internal } from "./_generated/api";
 import * as Cleanup from "./model/cleanup";
+import * as RoomAggregate from "./model/roomAggregate";
+
+/**
+ * One bounded step of a room's cascade delete; reschedules itself until the
+ * step reports done. Each invocation stays within per-transaction limits, so
+ * even a pathological room (500 issues, thousands of votes) deletes in
+ * batches instead of throwing and rolling back an all-or-nothing cascade.
+ */
+export const deleteRoomAggregateChunk = internalMutation({
+  args: {
+    roomId: v.id("rooms"),
+  },
+  handler: async (ctx, args) => {
+    const step = await RoomAggregate.deleteRoomAggregateChunk(ctx, args.roomId);
+    if (!step.done) {
+      await ctx.scheduler.runAfter(
+        0,
+        internal.maintenance.deleteRoomAggregateChunk,
+        { roomId: args.roomId }
+      );
+    }
+    return step;
+  },
+});
 
 /**
  * Internal mutation to clean up orphaned data

--- a/convex/model/analytics.ts
+++ b/convex/model/analytics.ts
@@ -1,7 +1,23 @@
 import { QueryCtx } from "../_generated/server";
-import { Doc, Id } from "../_generated/dataModel";
+import { Doc } from "../_generated/dataModel";
+import * as AnalyticsMath from "../analyticsMath";
 
-// Types for analytics data
+// The response shapes are owned by the pure projection module; re-exported
+// here so existing imports from this module keep working.
+export type {
+  AgreementDataPoint,
+  VelocityDataPoint,
+  VoteDistributionItem,
+  ParticipationStats,
+  TimeToConsensusStats,
+  VoterAlignmentUser,
+  VoterAlignmentScatterPoint,
+  VoterAlignmentData,
+  PredictabilitySession,
+  PredictabilityData,
+  DashboardSummary,
+} from "../analyticsMath";
+
 export interface SessionSummary {
   roomId: string;
   roomName: string;
@@ -13,36 +29,21 @@ export interface SessionSummary {
   participantCount: number;
 }
 
-export interface AgreementDataPoint {
-  date: string; // ISO date string (YYYY-MM-DD)
-  timestamp: number;
-  agreement: number;
-  issueTitle: string;
-  roomName: string;
-}
-
-export interface VelocityDataPoint {
-  date: string; // ISO date string (YYYY-MM-DD)
-  storyPoints: number;
-  issueCount: number;
-}
-
-export interface VoteDistributionItem {
-  value: string;
-  count: number;
-  percentage: number;
-}
-
-export interface ParticipationStats {
-  totalSessions: number;
-  totalIssuesVoted: number;
-  totalVotesCast: number;
-  averageVotesPerSession: number;
-}
-
 export interface DateRange {
   from: number; // timestamp
   to: number; // timestamp
+}
+
+/**
+ * One room's slice of the user's completed-issue history: the room's
+ * completed issues plus the joins analytics metrics need, each fetched once.
+ */
+export interface RoomHistory {
+  membership: Doc<"roomMemberships">;
+  room: Doc<"rooms">;
+  completedIssues: Doc<"issues">[];
+  individualVotes: Doc<"individualVotes">[];
+  votingTimestamps: Doc<"votingTimestamps">[];
 }
 
 /**
@@ -79,6 +80,86 @@ export async function getUserMemberships(
 }
 
 /**
+ * completedIssueHistory — THE one memberships → rooms → history scan behind
+ * every analytics metric. Model functions are scan → project: they call this
+ * aggregate and hand the rows to a pure projection in analyticsMath.
+ *
+ * Date semantics: a date range windows on `issue.votedAt` — when voting
+ * completed — never on `membership.joinedAt`. An issue without a `votedAt`
+ * can't be placed in a window, so a range excludes it; with no range every
+ * completed issue is history. Membership-tenure filtering survives only in
+ * getUserSessions and getParticipationStats.totalSessions, where the metric
+ * is about the membership itself (see those functions).
+ *
+ * individualVotes and votingTimestamps are fetched once per room alongside
+ * the issues; vote-level metrics window on the vote's own `votedAt`.
+ */
+export async function completedIssueHistory(
+  ctx: QueryCtx,
+  authUserId: string,
+  dateRange?: DateRange
+): Promise<RoomHistory[]> {
+  const membershipsWithRooms = await getUserMemberships(ctx, authUserId);
+
+  return Promise.all(
+    membershipsWithRooms.map(async ({ membership, room }) => {
+      const [issues, individualVotes, votingTimestamps] = await Promise.all([
+        ctx.db
+          .query("issues")
+          .withIndex("by_room", (q) => q.eq("roomId", room._id))
+          .collect(),
+        ctx.db
+          .query("individualVotes")
+          .withIndex("by_room", (q) => q.eq("roomId", room._id))
+          .collect(),
+        ctx.db
+          .query("votingTimestamps")
+          .withIndex("by_room", (q) => q.eq("roomId", room._id))
+          .collect(),
+      ]);
+
+      const completedIssues = issues.filter((i) => {
+        if (i.status !== "completed") return false;
+        if (dateRange) {
+          return (
+            i.votedAt !== undefined &&
+            i.votedAt >= dateRange.from &&
+            i.votedAt <= dateRange.to
+          );
+        }
+        return true;
+      });
+
+      return { membership, room, completedIssues, individualVotes, votingTimestamps };
+    })
+  );
+}
+
+/** Flattens the aggregate into issue entries carrying their room context. */
+function flattenIssues(history: RoomHistory[]): AnalyticsMath.RoomIssue[] {
+  return history.flatMap(({ room, completedIssues }) =>
+    completedIssues.map((issue) => ({
+      roomId: room._id,
+      roomName: room.name,
+      issue,
+    }))
+  );
+}
+
+/** Filters vote rows to a date range on the vote's own votedAt. */
+function votesInRange(
+  history: RoomHistory[],
+  dateRange?: DateRange
+): Doc<"individualVotes">[] {
+  return history
+    .flatMap((h) => h.individualVotes)
+    .filter(
+      (v) =>
+        !dateRange || (v.votedAt >= dateRange.from && v.votedAt <= dateRange.to)
+    );
+}
+
+/**
  * Gets session history summaries for a user
  */
 export async function getUserSessions(
@@ -86,50 +167,22 @@ export async function getUserSessions(
   authUserId: string,
   dateRange?: DateRange
 ): Promise<SessionSummary[]> {
-  const membershipsWithRooms = await getUserMemberships(ctx, authUserId);
+  // No range on the aggregate: a session row reports the room's lifetime
+  // issue stats. The range instead windows on membership.joinedAt — session
+  // history is a membership-tenure view ("rooms I joined in this window"),
+  // and joinedAt is a displayed field of each row.
+  const history = await completedIssueHistory(ctx, authUserId);
 
-  // Filter by date range if provided
   const filtered = dateRange
-    ? membershipsWithRooms.filter(
+    ? history.filter(
         ({ membership }) =>
           membership.joinedAt >= dateRange.from &&
           membership.joinedAt <= dateRange.to
       )
-    : membershipsWithRooms;
+    : history;
 
-  // Get session summaries with issue stats
   const summaries = await Promise.all(
-    filtered.map(async ({ membership, room }) => {
-      // Get completed issues for this room
-      const issues = await ctx.db
-        .query("issues")
-        .withIndex("by_room", (q) => q.eq("roomId", room._id))
-        .collect();
-
-      const completedIssues = issues.filter((i) => i.status === "completed");
-
-      // Calculate total story points (numeric estimates only)
-      let totalStoryPoints: number | null = null;
-      const numericEstimates = completedIssues
-        .map((i) => (i.finalEstimate ? parseFloat(i.finalEstimate) : NaN))
-        .filter((v) => !isNaN(v));
-
-      if (numericEstimates.length > 0) {
-        totalStoryPoints = numericEstimates.reduce((sum, v) => sum + v, 0);
-      }
-
-      // Calculate average agreement
-      const agreements = completedIssues
-        .map((i) => i.voteStats?.agreement)
-        .filter((a): a is number => a !== undefined);
-
-      const averageAgreement =
-        agreements.length > 0
-          ? Math.round(
-              agreements.reduce((sum, a) => sum + a, 0) / agreements.length
-            )
-          : null;
-
+    filtered.map(async ({ membership, room, completedIssues }) => {
       const roomMembers = await ctx.db
         .query("roomMemberships")
         .withIndex("by_room", (q) => q.eq("roomId", room._id))
@@ -140,9 +193,7 @@ export async function getUserSessions(
         roomName: room.name,
         joinedAt: membership.joinedAt,
         lastActivityAt: room.lastActivityAt,
-        issuesCompleted: completedIssues.length,
-        totalStoryPoints,
-        averageAgreement,
+        ...AnalyticsMath.sessionIssueStats(completedIssues),
         participantCount: roomMembers.length,
       };
     })
@@ -159,44 +210,9 @@ export async function getAgreementTrend(
   ctx: QueryCtx,
   authUserId: string,
   dateRange?: DateRange
-): Promise<AgreementDataPoint[]> {
-  const membershipsWithRooms = await getUserMemberships(ctx, authUserId);
-
-  // Collect all completed issues with timestamps
-  const dataPoints: AgreementDataPoint[] = [];
-
-  for (const { room } of membershipsWithRooms) {
-    const issues = await ctx.db
-      .query("issues")
-      .withIndex("by_room", (q) => q.eq("roomId", room._id))
-      .collect();
-
-    for (const issue of issues) {
-      if (
-        issue.status === "completed" &&
-        issue.votedAt &&
-        issue.voteStats?.agreement !== undefined
-      ) {
-        // Apply date range filter
-        if (dateRange) {
-          if (issue.votedAt < dateRange.from || issue.votedAt > dateRange.to) {
-            continue;
-          }
-        }
-
-        dataPoints.push({
-          date: new Date(issue.votedAt).toISOString().split("T")[0],
-          timestamp: issue.votedAt,
-          agreement: issue.voteStats.agreement,
-          issueTitle: issue.title,
-          roomName: room.name,
-        });
-      }
-    }
-  }
-
-  // Sort by timestamp
-  return dataPoints.sort((a, b) => a.timestamp - b.timestamp);
+): Promise<AnalyticsMath.AgreementDataPoint[]> {
+  const history = await completedIssueHistory(ctx, authUserId, dateRange);
+  return AnalyticsMath.agreementTrend(flattenIssues(history));
 }
 
 /**
@@ -206,49 +222,9 @@ export async function getVelocityStats(
   ctx: QueryCtx,
   authUserId: string,
   dateRange?: DateRange
-): Promise<VelocityDataPoint[]> {
-  const membershipsWithRooms = await getUserMemberships(ctx, authUserId);
-
-  // Group by date
-  const byDate: Record<string, { storyPoints: number; issueCount: number }> =
-    {};
-
-  for (const { room } of membershipsWithRooms) {
-    const issues = await ctx.db
-      .query("issues")
-      .withIndex("by_room", (q) => q.eq("roomId", room._id))
-      .collect();
-
-    for (const issue of issues) {
-      if (issue.status === "completed" && issue.votedAt && issue.finalEstimate) {
-        // Apply date range filter
-        if (dateRange) {
-          if (issue.votedAt < dateRange.from || issue.votedAt > dateRange.to) {
-            continue;
-          }
-        }
-
-        const storyPoints = parseFloat(issue.finalEstimate);
-        if (isNaN(storyPoints)) continue;
-
-        const date = new Date(issue.votedAt).toISOString().split("T")[0];
-        if (!byDate[date]) {
-          byDate[date] = { storyPoints: 0, issueCount: 0 };
-        }
-        byDate[date].storyPoints += storyPoints;
-        byDate[date].issueCount += 1;
-      }
-    }
-  }
-
-  // Convert to array and sort
-  return Object.entries(byDate)
-    .map(([date, data]) => ({
-      date,
-      storyPoints: data.storyPoints,
-      issueCount: data.issueCount,
-    }))
-    .sort((a, b) => a.date.localeCompare(b.date));
+): Promise<AnalyticsMath.VelocityDataPoint[]> {
+  const history = await completedIssueHistory(ctx, authUserId, dateRange);
+  return AnalyticsMath.velocityByDay(flattenIssues(history));
 }
 
 /**
@@ -258,43 +234,11 @@ export async function getVoteDistribution(
   ctx: QueryCtx,
   authUserId: string,
   dateRange?: DateRange
-): Promise<VoteDistributionItem[]> {
-  const membershipsWithRooms = await getUserMemberships(ctx, authUserId);
-
-  // Count occurrences of each final estimate
-  const counts: Record<string, number> = {};
-  let total = 0;
-
-  for (const { room } of membershipsWithRooms) {
-    const issues = await ctx.db
-      .query("issues")
-      .withIndex("by_room", (q) => q.eq("roomId", room._id))
-      .collect();
-
-    for (const issue of issues) {
-      if (issue.status === "completed" && issue.finalEstimate) {
-        // Apply date range filter
-        if (dateRange && issue.votedAt) {
-          if (issue.votedAt < dateRange.from || issue.votedAt > dateRange.to) {
-            continue;
-          }
-        }
-
-        counts[issue.finalEstimate] = (counts[issue.finalEstimate] || 0) + 1;
-        total += 1;
-      }
-    }
-  }
-
-  // Convert to array with percentages
-  const distribution = Object.entries(counts).map(([value, count]) => ({
-    value,
-    count,
-    percentage: total > 0 ? Math.round((count / total) * 100) : 0,
-  }));
-
-  // Sort by count descending
-  return distribution.sort((a, b) => b.count - a.count);
+): Promise<AnalyticsMath.VoteDistributionItem[]> {
+  const history = await completedIssueHistory(ctx, authUserId, dateRange);
+  return AnalyticsMath.voteDistribution(
+    history.flatMap((h) => h.completedIssues)
+  );
 }
 
 /**
@@ -304,85 +248,32 @@ export async function getParticipationStats(
   ctx: QueryCtx,
   authUserId: string,
   dateRange?: DateRange
-): Promise<ParticipationStats> {
-  // Find global user
-  const user = await ctx.db
-    .query("users")
-    .withIndex("by_auth_user", (q) => q.eq("authUserId", authUserId))
-    .first();
+): Promise<AnalyticsMath.ParticipationStats> {
+  const history = await completedIssueHistory(ctx, authUserId, dateRange);
 
-  if (!user) {
-    return {
-      totalSessions: 0,
-      totalIssuesVoted: 0,
-      totalVotesCast: 0,
-      averageVotesPerSession: 0,
-    };
-  }
-
-  const membershipsWithRooms = await getUserMemberships(ctx, authUserId);
-
-  // Filter by date range if provided
-  const filteredMemberships = dateRange
-    ? membershipsWithRooms.filter(
+  // totalSessions is membership-tenure: sessions joined within the window.
+  const totalSessions = dateRange
+    ? history.filter(
         ({ membership }) =>
           membership.joinedAt >= dateRange.from &&
           membership.joinedAt <= dateRange.to
-      )
-    : membershipsWithRooms;
+      ).length
+    : history.length;
 
-  const totalSessions = filteredMemberships.length;
+  // Issue/vote activity windows on votedAt via the aggregate, across all of
+  // the user's rooms. totalVotesCast counts real individualVotes snapshots
+  // (the old code faked it with the completed-issue count).
+  const totalIssuesVoted = history.reduce(
+    (sum, h) => sum + h.completedIssues.length,
+    0
+  );
+  const totalVotesCast = votesInRange(history, dateRange).length;
 
-  // Count issues with votes from this user
-  let totalIssuesVoted = 0;
-  let totalVotesCast = 0;
-
-  for (const { room } of filteredMemberships) {
-    // Count completed issues in this room
-    const issues = await ctx.db
-      .query("issues")
-      .withIndex("by_room", (q) => q.eq("roomId", room._id))
-      .collect();
-
-    const completedIssues = issues.filter((i) => {
-      if (i.status !== "completed") return false;
-      if (dateRange && i.votedAt) {
-        return i.votedAt >= dateRange.from && i.votedAt <= dateRange.to;
-      }
-      return true;
-    });
-
-    totalIssuesVoted += completedIssues.length;
-
-    // Note: We can't track individual vote participation per-issue
-    // since votes are cleared after each round. We can only count total completed.
-    totalVotesCast += completedIssues.length;
-  }
-
-  return {
+  return AnalyticsMath.participationStats({
     totalSessions,
     totalIssuesVoted,
     totalVotesCast,
-    averageVotesPerSession:
-      totalSessions > 0 ? Math.round(totalVotesCast / totalSessions) : 0,
-  };
-}
-
-// Types for time-to-consensus analytics
-export interface TimeToConsensusStats {
-  averageMs: number | null;
-  medianMs: number | null;
-  outliers: Array<{
-    issueTitle: string;
-    roomName: string;
-    durationMs: number;
-    multiplierVsAverage: number;
-  }>;
-  trendBySession: Array<{
-    date: string;
-    roomName: string;
-    averageMs: number;
-  }>;
+  });
 }
 
 /**
@@ -392,105 +283,9 @@ export async function getTimeToConsensusStats(
   ctx: QueryCtx,
   authUserId: string,
   dateRange?: DateRange
-): Promise<TimeToConsensusStats> {
-  const membershipsWithRooms = await getUserMemberships(ctx, authUserId);
-
-  // Collect all completed issues with timeToConsensusMs
-  const issuesWithTime: Array<{
-    issueTitle: string;
-    roomId: string;
-    roomName: string;
-    durationMs: number;
-    votedAt: number;
-  }> = [];
-
-  for (const { room } of membershipsWithRooms) {
-    const issues = await ctx.db
-      .query("issues")
-      .withIndex("by_room", (q) => q.eq("roomId", room._id))
-      .collect();
-
-    for (const issue of issues) {
-      if (
-        issue.status === "completed" &&
-        issue.voteStats?.timeToConsensusMs !== undefined &&
-        issue.votedAt
-      ) {
-        if (dateRange) {
-          if (issue.votedAt < dateRange.from || issue.votedAt > dateRange.to) {
-            continue;
-          }
-        }
-
-        issuesWithTime.push({
-          issueTitle: issue.title,
-          roomId: room._id,
-          roomName: room.name,
-          durationMs: issue.voteStats.timeToConsensusMs,
-          votedAt: issue.votedAt,
-        });
-      }
-    }
-  }
-
-  if (issuesWithTime.length === 0) {
-    return { averageMs: null, medianMs: null, outliers: [], trendBySession: [] };
-  }
-
-  // Compute average
-  const durations = issuesWithTime.map((i) => i.durationMs);
-  const averageMs = durations.reduce((sum, d) => sum + d, 0) / durations.length;
-
-  // Compute median
-  const sorted = [...durations].sort((a, b) => a - b);
-  const mid = Math.floor(sorted.length / 2);
-  const medianMs =
-    sorted.length % 2 !== 0
-      ? sorted[mid]
-      : (sorted[mid - 1] + sorted[mid]) / 2;
-
-  // Identify outliers (> 2x average)
-  const outliers = issuesWithTime
-    .filter((i) => i.durationMs > averageMs * 2)
-    .map((i) => ({
-      issueTitle: i.issueTitle,
-      roomName: i.roomName,
-      durationMs: i.durationMs,
-      multiplierVsAverage: Math.round((i.durationMs / averageMs) * 10) / 10,
-    }))
-    .sort((a, b) => b.durationMs - a.durationMs)
-    .slice(0, 10);
-
-  // Group by room+date for trend (use roomId as key to avoid name collisions)
-  const bySessionKey: Record<
-    string,
-    { date: string; roomName: string; totalMs: number; count: number }
-  > = {};
-
-  for (const item of issuesWithTime) {
-    const date = new Date(item.votedAt).toISOString().split("T")[0];
-    const key = `${date}::${item.roomId}`;
-    if (!bySessionKey[key]) {
-      bySessionKey[key] = { date, roomName: item.roomName, totalMs: 0, count: 0 };
-    }
-    bySessionKey[key].totalMs += item.durationMs;
-    bySessionKey[key].count += 1;
-  }
-
-  const trendBySession = Object.values(bySessionKey)
-    .map((s) => ({
-      date: s.date,
-      roomName: s.roomName,
-      averageMs: Math.round(s.totalMs / s.count),
-    }))
-    .sort((a, b) => a.date.localeCompare(b.date));
-
-  return {
-    averageMs: Math.round(averageMs),
-    medianMs: Math.round(medianMs),
-    outliers,
-    trendBySession,
-  };
+): Promise<AnalyticsMath.TimeToConsensusStats> {
+  const history = await completedIssueHistory(ctx, authUserId, dateRange);
+  return AnalyticsMath.timeToConsensus(flattenIssues(history));
 }
 
 /**
@@ -500,70 +295,9 @@ export async function getDashboardSummary(
   ctx: QueryCtx,
   authUserId: string,
   dateRange?: DateRange
-): Promise<{
-  totalSessions: number;
-  totalIssuesEstimated: number;
-  totalStoryPoints: number | null;
-  averageAgreement: number | null;
-}> {
+): Promise<AnalyticsMath.DashboardSummary> {
   const sessions = await getUserSessions(ctx, authUserId, dateRange);
-
-  const totalSessions = sessions.length;
-  const totalIssuesEstimated = sessions.reduce(
-    (sum, s) => sum + s.issuesCompleted,
-    0
-  );
-
-  // Sum story points (only if we have numeric data)
-  const sessionsWithPoints = sessions.filter((s) => s.totalStoryPoints !== null);
-  const totalStoryPoints =
-    sessionsWithPoints.length > 0
-      ? sessionsWithPoints.reduce((sum, s) => sum + (s.totalStoryPoints ?? 0), 0)
-      : null;
-
-  // Average agreement across all sessions
-  const sessionsWithAgreement = sessions.filter(
-    (s) => s.averageAgreement !== null
-  );
-  const averageAgreement =
-    sessionsWithAgreement.length > 0
-      ? Math.round(
-          sessionsWithAgreement.reduce(
-            (sum, s) => sum + (s.averageAgreement ?? 0),
-            0
-          ) / sessionsWithAgreement.length
-        )
-      : null;
-
-  return {
-    totalSessions,
-    totalIssuesEstimated,
-    totalStoryPoints,
-    averageAgreement,
-  };
-}
-
-// Types for voter alignment analytics
-export interface VoterAlignmentUser {
-  userId: string;
-  userName: string;
-  totalVotes: number;
-  agreesWithConsensus: number;
-  agreementRate: number;
-  averageDelta: number | null;
-  tendency: "under" | "over" | "aligned" | "unknown";
-}
-
-export interface VoterAlignmentScatterPoint {
-  userId: string;
-  userName: string;
-  x: number; // averageDelta
-  y: number; // stdDev (consistency)
-}
-
-export interface VoterAlignmentData {
-  users: VoterAlignmentUser[];
-  scatterPoints: VoterAlignmentScatterPoint[];
+  return AnalyticsMath.dashboardSummary(sessions);
 }
 
 /**
@@ -573,323 +307,36 @@ export async function getVoterAlignment(
   ctx: QueryCtx,
   authUserId: string,
   dateRange?: DateRange
-): Promise<VoterAlignmentData> {
-  const membershipsWithRooms = await getUserMemberships(ctx, authUserId);
-
-  // Collect all individual votes across rooms
-  const allVotes: Doc<"individualVotes">[] = [];
-
-  for (const { room } of membershipsWithRooms) {
-    const votes = await ctx.db
-      .query("individualVotes")
-      .withIndex("by_room", (q) => q.eq("roomId", room._id))
-      .collect();
-
-    for (const vote of votes) {
-      if (dateRange) {
-        if (vote.votedAt < dateRange.from || vote.votedAt > dateRange.to) {
-          continue;
-        }
-      }
-      allVotes.push(vote);
-    }
-  }
-
-  if (allVotes.length === 0) {
-    return { users: [], scatterPoints: [] };
-  }
-
-  // Group by userId
-  const byUser = new Map<
-    Id<"users">,
-    Doc<"individualVotes">[]
-  >();
-
-  for (const vote of allVotes) {
-    const existing = byUser.get(vote.userId) ?? [];
-    existing.push(vote);
-    byUser.set(vote.userId, existing);
-  }
+): Promise<AnalyticsMath.VoterAlignmentData> {
+  const history = await completedIssueHistory(ctx, authUserId, dateRange);
+  const votes = votesInRange(history, dateRange);
 
   // Batch-resolve user names
-  const userIds = [...byUser.keys()];
+  const userIds = [...new Set(votes.map((v) => v.userId))];
   const resolvedUsers = await Promise.all(userIds.map((id) => ctx.db.get(id)));
-  const userNameMap = new Map(
-    userIds.map((id, i) => [id, resolvedUsers[i]?.name ?? "Unknown"])
-  );
+  const userNames: Record<string, string> = {};
+  userIds.forEach((id, i) => {
+    userNames[id] = resolvedUsers[i]?.name ?? "Unknown";
+  });
 
-  // Compute stats per user
-  const users: VoterAlignmentUser[] = [];
-  const scatterPoints: VoterAlignmentScatterPoint[] = [];
-
-  for (const [userId, votes] of byUser) {
-    const userName = userNameMap.get(userId) ?? "Unknown";
-
-    const totalVotes = votes.length;
-    const agreesWithConsensus = votes.filter(
-      (v) => v.consensusLabel !== undefined && v.cardLabel === v.consensusLabel
-    ).length;
-    const agreementRate =
-      totalVotes > 0 ? Math.round((agreesWithConsensus / totalVotes) * 100) : 0;
-
-    // Compute average delta from deltaSteps (only votes with delta)
-    const deltas = votes
-      .map((v) => v.deltaSteps)
-      .filter((d): d is number => d !== undefined);
-
-    const hasDeltas = deltas.length > 0;
-    const averageDelta = hasDeltas
-      ? Math.round((deltas.reduce((s, d) => s + d, 0) / deltas.length) * 100) / 100
-      : null;
-
-    // Compute stdDev of deltaSteps for scatter y-axis
-    let stdDev = 0;
-    if (deltas.length > 1) {
-      const mean = deltas.reduce((s, d) => s + d, 0) / deltas.length;
-      const variance =
-        deltas.reduce((s, d) => s + (d - mean) ** 2, 0) / deltas.length;
-      stdDev = Math.round(Math.sqrt(variance) * 100) / 100;
-    }
-
-    const tendency: "under" | "over" | "aligned" | "unknown" =
-      averageDelta === null
-        ? "unknown"
-        : averageDelta < -0.5
-          ? "under"
-          : averageDelta > 0.5
-            ? "over"
-            : "aligned";
-
-    users.push({
-      userId,
-      userName,
-      totalVotes,
-      agreesWithConsensus,
-      agreementRate,
-      averageDelta,
-      tendency,
-    });
-
-    // Only include in scatter chart if we have delta data (numeric scales)
-    if (averageDelta !== null) {
-      scatterPoints.push({
-        userId,
-        userName,
-        x: averageDelta,
-        y: stdDev,
-      });
-    }
-  }
-
-  // Sort users by total votes descending
-  users.sort((a, b) => b.totalVotes - a.totalVotes);
-  const votesMap = new Map(users.map((u) => [u.userId, u.totalVotes]));
-  scatterPoints.sort(
-    (a, b) => (votesMap.get(b.userId) ?? 0) - (votesMap.get(a.userId) ?? 0)
-  );
-
-  return { users, scatterPoints };
-}
-
-// Types for predictability analytics
-export interface PredictabilitySession {
-  roomName: string;
-  date: string;
-  estimatedPoints: number;
-  issueCount: number;
-  averageAgreement: number;
-  averageTimeToConsensus: number;
-}
-
-export interface PredictabilityData {
-  predictabilityScore: number | null;
-  sessions: PredictabilitySession[];
-  averageVelocityPerSession: number;
-  velocityTrend: "increasing" | "stable" | "decreasing";
-  averageAgreement: number;
-  agreementTrend: "improving" | "stable" | "declining";
+  return AnalyticsMath.voterAlignment(votes, userNames);
 }
 
 /**
  * Computes sprint predictability score and related metrics.
- *
- * Score formula:
- *   velocityConsistency = 1 - (stdDev(points) / mean(points))
- *   score = avgAgreement * 0.6 + velocityConsistency * 100 * 0.4
- *   clamped to 0-100
- *
- * Returns null score when < 3 sessions have story points.
+ * The score formula lives in analyticsMath.predictability.
  */
 export async function getPredictabilityScore(
   ctx: QueryCtx,
   authUserId: string,
   dateRange?: DateRange
-): Promise<PredictabilityData> {
-  const membershipsWithRooms = await getUserMemberships(ctx, authUserId);
-
-  // Build per-session data — date range filters at issue level (by votedAt),
-  // not at membership level, matching the pattern in getVelocityStats et al.
-  const sessions: PredictabilitySession[] = [];
-
-  for (const { room } of membershipsWithRooms) {
-    const issues = await ctx.db
-      .query("issues")
-      .withIndex("by_room", (q) => q.eq("roomId", room._id))
-      .collect();
-
-    // Filter completed issues, applying date range to votedAt
-    const completedIssues = issues.filter((i) => {
-      if (i.status !== "completed" || !i.votedAt) return false;
-      if (dateRange) {
-        return i.votedAt >= dateRange.from && i.votedAt <= dateRange.to;
-      }
-      return true;
-    });
-
-    if (completedIssues.length === 0) continue;
-
-    // Story points
-    const numericEstimates = completedIssues
-      .map((i) => (i.finalEstimate ? parseFloat(i.finalEstimate) : NaN))
-      .filter((v) => !isNaN(v));
-    const estimatedPoints =
-      numericEstimates.length > 0
-        ? numericEstimates.reduce((sum, v) => sum + v, 0)
-        : 0;
-
-    // Agreement
-    const agreements = completedIssues
-      .map((i) => i.voteStats?.agreement)
-      .filter((a): a is number => a !== undefined);
-    const averageAgreement =
-      agreements.length > 0
-        ? Math.round(
-            agreements.reduce((sum, a) => sum + a, 0) / agreements.length
-          )
-        : 0;
-
-    // Time to consensus
-    const consensusTimes = completedIssues
-      .map((i) => i.voteStats?.timeToConsensusMs)
-      .filter((t): t is number => t !== undefined);
-    const averageTimeToConsensus =
-      consensusTimes.length > 0
-        ? Math.round(
-            consensusTimes.reduce((sum, t) => sum + t, 0) /
-              consensusTimes.length
-          )
-        : 0;
-
-    // Session date = latest votedAt among completed issues in this room
-    const latestVotedAt = Math.max(...completedIssues.map((i) => i.votedAt!));
-    const date = new Date(latestVotedAt).toISOString().split("T")[0];
-
-    sessions.push({
+): Promise<AnalyticsMath.PredictabilityData> {
+  const history = await completedIssueHistory(ctx, authUserId, dateRange);
+  return AnalyticsMath.predictability(
+    history.map(({ room, completedIssues }) => ({
+      roomId: room._id,
       roomName: room.name,
-      date,
-      estimatedPoints,
-      issueCount: completedIssues.length,
-      averageAgreement,
-      averageTimeToConsensus,
-    });
-  }
-
-  // Sort sessions by date
-  sessions.sort((a, b) => a.date.localeCompare(b.date));
-
-  // Sessions with story points (for velocity metrics)
-  const sessionsWithPoints = sessions.filter((s) => s.estimatedPoints > 0);
-
-  // Velocity stats
-  const velocities = sessionsWithPoints.map((s) => s.estimatedPoints);
-  const averageVelocityPerSession =
-    velocities.length > 0
-      ? Math.round(
-          (velocities.reduce((sum, v) => sum + v, 0) / velocities.length) * 10
-        ) / 10
-      : 0;
-
-  // Velocity trend (first half vs second half)
-  const velocityTrend = computeTrend(velocities, 10);
-
-  // Agreement stats
-  const allAgreements = sessions
-    .map((s) => s.averageAgreement)
-    .filter((a) => a > 0);
-  const overallAgreement =
-    allAgreements.length > 0
-      ? Math.round(
-          allAgreements.reduce((sum, a) => sum + a, 0) / allAgreements.length
-        )
-      : 0;
-
-  // Agreement trend
-  const agreementTrendDir = computeTrend(allAgreements, 5);
-  const agreementTrend: "improving" | "stable" | "declining" =
-    agreementTrendDir === "increasing"
-      ? "improving"
-      : agreementTrendDir === "decreasing"
-        ? "declining"
-        : "stable";
-
-  // Predictability score (need at least 3 sessions with points)
-  let predictabilityScore: number | null = null;
-
-  if (sessionsWithPoints.length >= 3) {
-    const mean =
-      velocities.reduce((sum, v) => sum + v, 0) / velocities.length;
-    const variance =
-      velocities.reduce((sum, v) => sum + (v - mean) ** 2, 0) /
-      velocities.length;
-    const stdDev = Math.sqrt(variance);
-
-    const velocityConsistency = mean > 0 ? 1 - stdDev / mean : 0;
-    const rawScore =
-      overallAgreement * 0.6 + velocityConsistency * 100 * 0.4;
-
-    predictabilityScore = Math.round(Math.min(100, Math.max(0, rawScore)));
-  }
-
-  return {
-    predictabilityScore,
-    sessions,
-    averageVelocityPerSession,
-    velocityTrend:
-      velocityTrend === "increasing"
-        ? "increasing"
-        : velocityTrend === "decreasing"
-          ? "decreasing"
-          : "stable",
-    averageAgreement: overallAgreement,
-    agreementTrend,
-  };
-}
-
-/**
- * Compares the first half vs second half of a numeric series.
- * Returns "increasing" if second half is >threshold% higher,
- * "decreasing" if lower, "stable" otherwise.
- */
-function computeTrend(
-  values: number[],
-  thresholdPct: number
-): "increasing" | "stable" | "decreasing" {
-  if (values.length < 2) return "stable";
-
-  const mid = Math.floor(values.length / 2);
-  const firstHalf = values.slice(0, mid);
-  const secondHalf = values.slice(mid);
-
-  const firstAvg =
-    firstHalf.reduce((s, v) => s + v, 0) / firstHalf.length;
-  const secondAvg =
-    secondHalf.reduce((s, v) => s + v, 0) / secondHalf.length;
-
-  if (firstAvg === 0) return secondAvg > 0 ? "increasing" : "stable";
-
-  const diffPct = ((secondAvg - firstAvg) / firstAvg) * 100;
-
-  if (diffPct > thresholdPct) return "increasing";
-  if (diffPct < -thresholdPct) return "decreasing";
-  return "stable";
+      issues: completedIssues,
+    }))
+  );
 }

--- a/convex/model/auth.ts
+++ b/convex/model/auth.ts
@@ -92,6 +92,31 @@ export async function requireRoomMember(
 }
 
 /**
+ * Requires authentication and room membership, and verifies the authenticated
+ * user IS `userId` — handlers that accept a userId argument must not let one
+ * member act as another. Returns the verified identity, user, and membership.
+ *
+ * `message` preserves each handler's existing denial copy; it is thrown only
+ * on the acting-user mismatch (membership failures throw from requireRoomMember).
+ */
+export async function requireActingUser(
+  ctx: QueryCtx | MutationCtx,
+  roomId: Id<"rooms">,
+  userId: Id<"users">,
+  message = "Cannot act as another user"
+): Promise<{
+  identity: AuthIdentity;
+  user: Doc<"users">;
+  membership: Doc<"roomMemberships">;
+}> {
+  const { identity, user, membership } = await requireRoomMember(ctx, roomId);
+  if (user._id !== userId) {
+    throw new Error(message);
+  }
+  return { identity, user, membership };
+}
+
+/**
  * What an authorization guard is being asked to permit. The caller names the
  * category or relationship verb; it cannot know the target's role, so the
  * guard fills targetRole itself for target-constrained verbs.

--- a/convex/model/auth.ts
+++ b/convex/model/auth.ts
@@ -1,4 +1,4 @@
-import { QueryCtx, MutationCtx } from "../_generated/server";
+import { QueryCtx, MutationCtx, ActionCtx } from "../_generated/server";
 import { Id, Doc } from "../_generated/dataModel";
 import {
   PermissionCategory,
@@ -22,9 +22,11 @@ interface AuthIdentity {
 /**
  * Requires authentication. Throws if the user is not authenticated.
  * Returns the auth identity (identity.subject = authUserId).
+ * Works in any function context — it only reads ctx.auth, which actions
+ * have too.
  */
 export async function requireAuth(
-  ctx: QueryCtx | MutationCtx
+  ctx: QueryCtx | MutationCtx | ActionCtx
 ): Promise<AuthIdentity> {
   const identity = await ctx.auth.getUserIdentity();
   if (!identity) {
@@ -129,11 +131,22 @@ export type RequireCanSpec =
     };
 
 /**
+ * The loaded bundle the guard returns: everything its IO assembly fetched
+ * while assembling the Action. `requireCan` adds the identity it
+ * authenticated with; the explicit-user entry point has none to add.
+ */
+export type GuardBundle = {
+  user: Doc<"users">;
+  membership: Doc<"roomMemberships">;
+  room: Doc<"rooms">;
+  target?: Doc<"roomMemberships">;
+};
+
+/**
  * The permission guard: the single authorization entry point for room
- * mutations. Does the IO — loads the room and memberships, computes owner
- * absence, fetches the target for target-constrained verbs — assembles the
- * precise Action, calls evaluate, and throws a reason-derived message on
- * denial. Returns the loaded bundle so callers stop re-fetching.
+ * mutations, authenticating via ctx.auth. Funnels into the shared assembly
+ * (guardRoomAction) and returns the loaded bundle plus the identity, so
+ * callers stop re-fetching.
  *
  * Identity rules (self-transfer, authoritative ownerId) are NOT enforced here;
  * they stay in the calling handler, after the guard.
@@ -143,14 +156,60 @@ export async function requireCan(
   roomId: Id<"rooms">,
   spec: RequireCanSpec,
   targetUserId?: Id<"users">
-): Promise<{
-  identity: AuthIdentity;
-  user: Doc<"users">;
-  membership: Doc<"roomMemberships">;
-  room: Doc<"rooms">;
-  target?: Doc<"roomMemberships">;
-}> {
+): Promise<GuardBundle & { identity: AuthIdentity }> {
   const { identity, user, membership } = await requireRoomMember(ctx, roomId);
+  const bundle = await guardRoomAction(
+    ctx,
+    user,
+    membership,
+    roomId,
+    spec,
+    targetUserId
+  );
+  return { identity, ...bundle };
+}
+
+/**
+ * The explicit-user entry point to the same permission guard, for callers
+ * that resolved the user outside ctx.auth (e.g. an action that authenticated
+ * via an explicit authUserId and called in through an internal query).
+ * Resolves the actor's membership, then funnels into the same shared assembly
+ * as requireCan — same Action, same decision, same thrown messages.
+ */
+export async function requireCanForUser(
+  ctx: QueryCtx | MutationCtx,
+  user: Doc<"users">,
+  roomId: Id<"rooms">,
+  spec: RequireCanSpec,
+  targetUserId?: Id<"users">
+): Promise<GuardBundle> {
+  const membership = await ctx.db
+    .query("roomMemberships")
+    .withIndex("by_room_user", (q) =>
+      q.eq("roomId", roomId).eq("userId", user._id)
+    )
+    .first();
+  if (!membership) {
+    throw new Error("Not a member of this room");
+  }
+  return guardRoomAction(ctx, user, membership, roomId, spec, targetUserId);
+}
+
+/**
+ * The guard's shared IO assembly, given the actor's user and membership from
+ * either authentication mode. Loads the room, assembles the precise Action,
+ * fetches the target for target-constrained verbs, reads owner absence only
+ * when an owner-level outcome could depend on it, calls resolve, and throws
+ * the resolved decision's message on denial. Returns the loaded bundle.
+ */
+async function guardRoomAction(
+  ctx: QueryCtx | MutationCtx,
+  user: Doc<"users">,
+  membership: Doc<"roomMemberships">,
+  roomId: Id<"rooms">,
+  spec: RequireCanSpec,
+  targetUserId?: Id<"users">
+): Promise<GuardBundle> {
   const room = await ctx.db.get(roomId);
   if (!room) {
     throw new Error("Room not found");
@@ -213,5 +272,5 @@ export async function requireCan(
     throw new Error(decision.message);
   }
 
-  return { identity, user, membership, room, target };
+  return { user, membership, room, target };
 }

--- a/convex/model/canvas.ts
+++ b/convex/model/canvas.ts
@@ -59,24 +59,6 @@ export type CanvasNode = {
 const MAX_NOTE_CONTENT_LENGTH = 10000;
 
 /**
- * Verifies that a user belongs to a room (via membership)
- */
-async function verifyUserInRoom(
-  ctx: MutationCtx,
-  roomId: Id<"rooms">,
-  userId: Id<"users">
-): Promise<void> {
-  const membership = await ctx.db
-    .query("roomMemberships")
-    .withIndex("by_room_user", (q) => q.eq("roomId", roomId).eq("userId", userId))
-    .first();
-
-  if (!membership) {
-    throw new Error("User not found in room");
-  }
-}
-
-/**
  * Recalculates layout for all session/player nodes.
  * Called when players join or leave to maintain balanced layout.
  */
@@ -362,9 +344,6 @@ export async function createNoteNode(
     userId: Id<"users">;
   }
 ): Promise<Id<"canvasNodes">> {
-  // Verify user belongs to the room
-  await verifyUserInRoom(ctx, args.roomId, args.userId);
-
   const nodeId = `note-${args.issueId}`;
 
   // Check if note already exists for this issue
@@ -416,9 +395,6 @@ export async function updateNoteContent(
     userId: Id<"users">;
   }
 ): Promise<void> {
-  // Verify user belongs to the room
-  await verifyUserInRoom(ctx, args.roomId, args.userId);
-
   // Validate content length
   if (args.content.length > MAX_NOTE_CONTENT_LENGTH) {
     throw new Error(`Note content too long (max ${MAX_NOTE_CONTENT_LENGTH} characters)`);
@@ -486,9 +462,6 @@ export async function deleteNoteNode(
   ctx: MutationCtx,
   args: { roomId: Id<"rooms">; nodeId: string; userId: Id<"users"> }
 ): Promise<void> {
-  // Verify user belongs to the room
-  await verifyUserInRoom(ctx, args.roomId, args.userId);
-
   const node = await ctx.db
     .query("canvasNodes")
     .withIndex("by_room_node", (q) =>

--- a/convex/model/canvas.ts
+++ b/convex/model/canvas.ts
@@ -8,6 +8,7 @@ import {
   TIMER_POSITION,
   type Position,
 } from "../canvasLayout";
+import type { TimerState } from "../timerState";
 
 // Re-exported for compatibility — the geometry now lives in canvasLayout.ts.
 export type { Position } from "../canvasLayout";
@@ -20,17 +21,7 @@ export type { Position } from "../canvasLayout";
  */
 export type CanvasNodeData =
   | { type: "player"; data: { userId: Id<"users"> } }
-  | {
-      type: "timer";
-      data: {
-        startedAt: number | null;
-        pausedAt: number | null;
-        elapsedSeconds: number;
-        isRunning?: boolean;
-        lastUpdatedBy: Id<"users"> | null;
-        lastAction: "start" | "pause" | "reset" | null;
-      };
-    }
+  | { type: "timer"; data: TimerState }
   | {
       type: "note";
       data: {

--- a/convex/model/cleanup.ts
+++ b/convex/model/cleanup.ts
@@ -1,74 +1,49 @@
 import { MutationCtx } from "../_generated/server";
-import { Doc, Id } from "../_generated/dataModel";
-import {
-  ROOM_OWNED_TABLES,
-  RoomOwnedTable,
-  deleteRoomAggregate,
-} from "./roomAggregate";
+import { Doc } from "../_generated/dataModel";
+import { internal } from "../_generated/api";
+import { ROOM_OWNED_TABLES, RoomOwnedTable } from "./roomAggregate";
 
-export interface CleanupResult {
-  roomsDeleted: number;
-  votesDeleted: number;
-  membershipsDeleted: number;
-  canvasNodesDeleted?: number;
+export interface RemoveInactiveRoomsResult {
+  /** Rooms whose cascade was scheduled (each runs as its own mutation). */
+  roomsScheduled: number;
 }
 
 /**
- * Removes inactive rooms and all associated data
- * @param inactiveDays - Number of days of inactivity before a room is considered inactive
+ * How many inactive rooms one cron tick hands to the cascade. The rest are
+ * picked up by the next daily run — bounding the scan keeps the cron mutation
+ * small no matter how many rooms went stale at once.
+ */
+const INACTIVE_ROOMS_PER_TICK = 100;
+
+/**
+ * Schedules deletion of inactive rooms (default 5 days of inactivity). Each
+ * room's cascade runs as its own scheduled mutation
+ * (internal.maintenance.deleteRoomAggregateChunk), so one oversized or
+ * failing room can neither blow the cron's transaction limits nor take the
+ * other rooms down with it.
  */
 export async function removeInactiveRooms(
   ctx: MutationCtx,
   inactiveDays: number = 5
-): Promise<CleanupResult> {
-  const cutoffTime = Date.now() - (inactiveDays * 24 * 60 * 60 * 1000);
+): Promise<RemoveInactiveRoomsResult> {
+  const cutoffTime = Date.now() - inactiveDays * 24 * 60 * 60 * 1000;
 
-  // Find inactive rooms.
   const inactiveRooms = await ctx.db
     .query("rooms")
     .withIndex("by_activity", (q) => q.lt("lastActivityAt", cutoffTime))
-    .collect();
+    .take(INACTIVE_ROOMS_PER_TICK);
 
-  console.log(`Found ${inactiveRooms.length} inactive rooms to clean up`);
+  console.log(`Scheduling ${inactiveRooms.length} inactive rooms for cleanup`);
 
-  const result: CleanupResult = {
-    roomsDeleted: 0,
-    votesDeleted: 0,
-    membershipsDeleted: 0,
-    canvasNodesDeleted: 0,
-  };
-
-  // Process each room
   for (const room of inactiveRooms) {
-    const cleanupStats = await cleanupRoom(ctx, room._id);
-
-    // Aggregate stats
-    result.votesDeleted += cleanupStats.votesDeleted;
-    result.membershipsDeleted += cleanupStats.membershipsDeleted;
-    result.canvasNodesDeleted! += cleanupStats.canvasNodesDeleted || 0;
-    result.roomsDeleted++;
-
-    console.log(`Cleaned up room ${room.name} (${room._id})`);
+    await ctx.scheduler.runAfter(
+      0,
+      internal.maintenance.deleteRoomAggregateChunk,
+      { roomId: room._id }
+    );
   }
 
-  return result;
-}
-
-/**
- * Cleans up all data associated with a single room.
- * The table set comes from the one room-aggregate inventory
- * (convex/model/roomAggregate.ts) — including issues, which used to leak.
- */
-export async function cleanupRoom(
-  ctx: MutationCtx,
-  roomId: Id<"rooms">
-): Promise<Omit<CleanupResult, "roomsDeleted">> {
-  const deleted = await deleteRoomAggregate(ctx, roomId);
-  return {
-    votesDeleted: deleted.votes,
-    membershipsDeleted: deleted.roomMemberships,
-    canvasNodesDeleted: deleted.canvasNodes,
-  };
+  return { roomsScheduled: inactiveRooms.length };
 }
 
 /**

--- a/convex/model/cleanup.ts
+++ b/convex/model/cleanup.ts
@@ -1,5 +1,10 @@
 import { MutationCtx } from "../_generated/server";
-import { Id } from "../_generated/dataModel";
+import { Doc, Id } from "../_generated/dataModel";
+import {
+  ROOM_OWNED_TABLES,
+  RoomOwnedTable,
+  deleteRoomAggregate,
+} from "./roomAggregate";
 
 export interface CleanupResult {
   roomsDeleted: number;
@@ -50,89 +55,19 @@ export async function removeInactiveRooms(
 }
 
 /**
- * Cleans up all data associated with a single room
+ * Cleans up all data associated with a single room.
+ * The table set comes from the one room-aggregate inventory
+ * (convex/model/roomAggregate.ts) — including issues, which used to leak.
  */
 export async function cleanupRoom(
   ctx: MutationCtx,
   roomId: Id<"rooms">
 ): Promise<Omit<CleanupResult, "roomsDeleted">> {
-  // Get all related data in parallel
-  const [votes, memberships, canvasNodes, votingTimestamps, individualVotes, issues, integrationMappings] = await Promise.all([
-    ctx.db
-      .query("votes")
-      .withIndex("by_room", (q) => q.eq("roomId", roomId))
-      .collect(),
-    ctx.db
-      .query("roomMemberships")
-      .withIndex("by_room", (q) => q.eq("roomId", roomId))
-      .collect(),
-    ctx.db
-      .query("canvasNodes")
-      .withIndex("by_room", (q) => q.eq("roomId", roomId))
-      .collect(),
-    ctx.db
-      .query("votingTimestamps")
-      .withIndex("by_room", (q) => q.eq("roomId", roomId))
-      .collect(),
-    ctx.db
-      .query("individualVotes")
-      .withIndex("by_room", (q) => q.eq("roomId", roomId))
-      .collect(),
-    ctx.db
-      .query("issues")
-      .withIndex("by_room", (q) => q.eq("roomId", roomId))
-      .collect(),
-    ctx.db
-      .query("integrationMappings")
-      .withIndex("by_room", (q) => q.eq("roomId", roomId))
-      .collect(),
-  ]);
-
-  // Batch-query issueLinks for all issues in this room
-  const allIssueLinks = await Promise.all(
-    issues.map((issue) =>
-      ctx.db
-        .query("issueLinks")
-        .withIndex("by_issue", (q) => q.eq("issueId", issue._id))
-        .collect()
-    )
-  );
-  const issueLinks = allIssueLinks.flat();
-
-  // Delete all related data in parallel
-  const deletePromises: Promise<void>[] = [];
-
-  // Delete votes
-  deletePromises.push(...votes.map((vote) => ctx.db.delete(vote._id)));
-
-  // Delete memberships (not global users - they persist)
-  deletePromises.push(...memberships.map((m) => ctx.db.delete(m._id)));
-
-  // Delete canvas nodes
-  deletePromises.push(...canvasNodes.map((node) => ctx.db.delete(node._id)));
-
-  // Delete voting timestamps
-  deletePromises.push(...votingTimestamps.map((ts) => ctx.db.delete(ts._id)));
-
-  // Delete individual vote snapshots
-  deletePromises.push(...individualVotes.map((iv) => ctx.db.delete(iv._id)));
-
-  // Delete integration mappings
-  deletePromises.push(...integrationMappings.map((m) => ctx.db.delete(m._id)));
-
-  // Delete issue links
-  deletePromises.push(...issueLinks.map((link) => ctx.db.delete(link._id)));
-
-  // Wait for all deletions to complete
-  await Promise.all(deletePromises);
-
-  // Delete the room itself
-  await ctx.db.delete(roomId);
-
+  const deleted = await deleteRoomAggregate(ctx, roomId);
   return {
-    votesDeleted: votes.length,
-    membershipsDeleted: memberships.length,
-    canvasNodesDeleted: canvasNodes.length,
+    votesDeleted: deleted.votes,
+    membershipsDeleted: deleted.roomMemberships,
+    canvasNodesDeleted: deleted.canvasNodes,
   };
 }
 
@@ -147,116 +82,72 @@ export async function cleanupOrphanedData(ctx: MutationCtx): Promise<{
   orphanedVotingTimestamps: number;
   orphanedIndividualVotes: number;
   orphanedIntegrationMappings: number;
+  orphanedIssues: number;
+  orphanedIssueLinks: number;
 }> {
   // Get all existing room IDs once
   const allRooms = await ctx.db.query("rooms").collect();
   const existingRoomIds = new Set(allRooms.map(room => room._id));
 
-  // Process each table in parallel
-  const [
-    orphanedVotes,
-    orphanedMemberships,
-    orphanedCanvasNodes,
-    orphanedVotingTimestamps,
-    orphanedIndividualVotes,
-    orphanedIntegrationMappings,
-  ] = await Promise.all([
-    // Clean orphaned votes
-    cleanupOrphanedRecords(ctx, "votes", existingRoomIds),
-    // Clean orphaned memberships
-    cleanupOrphanedRecords(ctx, "roomMemberships", existingRoomIds),
-    // Clean orphaned canvas nodes
-    cleanupOrphanedRecords(ctx, "canvasNodes", existingRoomIds),
-    // Clean orphaned voting timestamps
-    cleanupOrphanedRecords(ctx, "votingTimestamps", existingRoomIds),
-    // Clean orphaned individual votes
-    cleanupOrphanedRecords(ctx, "individualVotes", existingRoomIds),
-    // Clean orphaned integration mappings
-    cleanupOrphanedRecords(ctx, "integrationMappings", existingRoomIds),
-  ]);
+  // Sweep every room-owned table — the same inventory the room cascade uses.
+  const swept = {} as Record<RoomOwnedTable, number>;
+  await Promise.all(
+    ROOM_OWNED_TABLES.map(async (table) => {
+      swept[table] = await cleanupOrphanedRecords(
+        ctx,
+        table,
+        (doc) => !existingRoomIds.has(doc.roomId)
+      );
+    })
+  );
+
+  // issueLinks are room-owned through their issue: a link is orphaned once its
+  // issue is gone. Runs after the issue sweep above, so links left behind by
+  // just-swept issues are collected too.
+  const remainingIssues = await ctx.db.query("issues").collect();
+  const existingIssueIds = new Set(remainingIssues.map((issue) => issue._id));
+  const orphanedIssueLinks = await cleanupOrphanedRecords(
+    ctx,
+    "issueLinks",
+    (doc) => !existingIssueIds.has(doc.issueId)
+  );
 
   return {
-    orphanedVotes,
-    orphanedMemberships,
-    orphanedCanvasNodes,
-    orphanedVotingTimestamps,
-    orphanedIndividualVotes,
-    orphanedIntegrationMappings,
+    orphanedVotes: swept.votes,
+    orphanedMemberships: swept.roomMemberships,
+    orphanedCanvasNodes: swept.canvasNodes,
+    orphanedVotingTimestamps: swept.votingTimestamps,
+    orphanedIndividualVotes: swept.individualVotes,
+    orphanedIntegrationMappings: swept.integrationMappings,
+    orphanedIssues: swept.issues,
+    orphanedIssueLinks,
   };
 }
 
 /**
- * Helper function to clean orphaned records from a specific table
- * Processes records in batches to avoid overwhelming the system
+ * Helper function to clean orphaned records from a specific table.
+ * One full scan per table: the old loop re-collected the entire table once
+ * per 100-row batch (O(n²)), and batching buys nothing inside a single
+ * transaction anyway. Carrying a `.paginate()` cursor instead is not an
+ * option — Convex allows only one paginated query per function execution,
+ * and the sweep touches several tables per run.
  */
-async function cleanupOrphanedRecords(
+async function cleanupOrphanedRecords<Table extends RoomOwnedTable | "issueLinks">(
   ctx: MutationCtx,
-  tableName: "votes" | "roomMemberships" | "canvasNodes" | "votingTimestamps" | "individualVotes" | "integrationMappings",
-  existingRoomIds: Set<Id<"rooms">>
+  tableName: Table,
+  isOrphan: (doc: Doc<Table>) => boolean
 ): Promise<number> {
-  const BATCH_SIZE = 100;
-  let orphanedCount = 0;
-  let hasMore = true;
-  let lastId: string | undefined;
+  const docs = await ctx.db.query(tableName).collect();
 
-  while (hasMore) {
-    // Query a batch of records
-    const query = ctx.db.query(tableName);
-
-    // For pagination, we'll use the ID as a cursor
-    // This is more efficient than using skip/take
-    if (lastId) {
-      // Get records after the last processed ID
-      const records = await query.collect();
-      const startIndex = records.findIndex(r => r._id > lastId!) + 1;
-      const batch = records.slice(startIndex, startIndex + BATCH_SIZE);
-
-      if (batch.length === 0) {
-        hasMore = false;
-        break;
-      }
-
-      // Process the batch
-      const deletePromises: Promise<void>[] = [];
-      for (const record of batch) {
-        if (!existingRoomIds.has(record.roomId)) {
-          deletePromises.push(ctx.db.delete(record._id));
-          orphanedCount++;
-        }
-      }
-
-      // Execute deletions in parallel
-      await Promise.all(deletePromises);
-
-      // Update cursor
-      lastId = batch[batch.length - 1]._id;
-      hasMore = batch.length === BATCH_SIZE;
-    } else {
-      // First batch
-      const batch = await query.take(BATCH_SIZE);
-
-      if (batch.length === 0) {
-        hasMore = false;
-        break;
-      }
-
-      // Process the batch
-      const deletePromises: Promise<void>[] = [];
-      for (const record of batch) {
-        if (!existingRoomIds.has(record.roomId)) {
-          deletePromises.push(ctx.db.delete(record._id));
-          orphanedCount++;
-        }
-      }
-
-      // Execute deletions in parallel
-      await Promise.all(deletePromises);
-
-      // Update cursor
-      lastId = batch[batch.length - 1]._id;
-      hasMore = batch.length === BATCH_SIZE;
+  const deletePromises: Promise<void>[] = [];
+  for (const doc of docs) {
+    if (isOrphan(doc)) {
+      deletePromises.push(ctx.db.delete(doc._id));
     }
   }
 
-  return orphanedCount;
+  // Execute deletions in parallel
+  await Promise.all(deletePromises);
+
+  return deletePromises.length;
 }

--- a/convex/model/integrations.ts
+++ b/convex/model/integrations.ts
@@ -144,9 +144,10 @@ export function toConnectionView(connection: Doc<"integrationConnections">): {
 }
 
 /**
- * Deletes a connection row directly. Runs as the scheduled tail of
- * disconnectConnection, after the deregistration actions that still need the
- * row's credentials have had their turn.
+ * Deletes a connection row directly. Runs as the tail of finalizeDisconnect —
+ * the action that deregisters the connection's webhooks first, so the row
+ * deletion happens only after every deregistration has read the credentials
+ * it authenticates with.
  */
 export async function deleteConnection(
   ctx: MutationCtx,
@@ -277,11 +278,12 @@ export async function removeRoomMapping(
 }
 
 /**
- * The disconnect cascade: deletes every mapping on the connection (scheduling
- * deregistration per live Jira webhook), then removes the connection itself.
- * When deregistrations are pending, the row deletion is deferred to a
- * scheduled mutation so those actions can still read the credentials they
- * authenticate with; with nothing to deregister the row goes immediately.
+ * The disconnect cascade: deletes every mapping on the connection, then hands
+ * the live Jira webhooks to one finalizeDisconnect action, which deregisters
+ * them and deletes the connection row only afterwards — the ordering comes
+ * from that action's own awaits, not from same-tick scheduled-job ordering
+ * (which Convex does not guarantee). With nothing to deregister the row goes
+ * immediately.
  */
 export async function disconnectConnection(
   ctx: MutationCtx,
@@ -294,18 +296,15 @@ export async function disconnectConnection(
     .collect();
   await Promise.all(mappings.map((m) => ctx.db.delete(m._id)));
 
-  let hasPendingDeregistrations = false;
-  for (const mapping of mappings) {
-    await scheduleWebhookDeregistration(ctx, mapping);
-    hasPendingDeregistrations ||=
-      mapping.provider === "jira" && !!mapping.jiraWebhookId;
-  }
+  const liveWebhookIds = mappings
+    .filter((m) => m.provider === "jira" && !!m.jiraWebhookId)
+    .map((m) => m.jiraWebhookId!);
 
-  if (hasPendingDeregistrations) {
+  if (liveWebhookIds.length > 0) {
     await ctx.scheduler.runAfter(
       0,
-      internal.integrations.jira.deleteConnection,
-      { connectionId }
+      internal.integrations.jira.finalizeDisconnect,
+      { connectionId, jiraWebhookIds: liveWebhookIds }
     );
   } else {
     await ctx.db.delete(connectionId);
@@ -315,9 +314,10 @@ export async function disconnectConnection(
 /**
  * Schedules remote deregistration of a mapping's Jira webhook. Deleting the
  * mapping row alone orphans the remote webhook — it keeps POSTing until its
- * 30-day expiry — so every mapping-removal path must go through this.
+ * 30-day expiry — so every mapping-removal path (removeRoomMapping, the room
+ * cascade in model/roomAggregate) must go through this.
  */
-async function scheduleWebhookDeregistration(
+export async function scheduleWebhookDeregistration(
   ctx: MutationCtx,
   mapping: Doc<"integrationMappings">
 ): Promise<void> {

--- a/convex/model/integrations.ts
+++ b/convex/model/integrations.ts
@@ -1,6 +1,10 @@
 import { MutationCtx } from "../_generated/server";
 import { internal } from "../_generated/api";
 import { Doc, Id } from "../_generated/dataModel";
+import {
+  EncryptedTokenFields,
+  assertEncryptedTokenFields,
+} from "./tokenVault";
 
 /**
  * The integrations model: the one owner of the db-side invariants for
@@ -17,15 +21,9 @@ import { Doc, Id } from "../_generated/dataModel";
 // Connections
 // ---------------------------------------------------------------------------
 
-export interface ConnectionArgs {
+export interface ConnectionArgs extends EncryptedTokenFields {
   userId: Id<"users">;
   provider: Doc<"integrationConnections">["provider"];
-  encryptedAccessToken: string;
-  accessTokenIv: string;
-  accessTokenAuthTag: string;
-  encryptedRefreshToken?: string;
-  refreshTokenIv?: string;
-  refreshTokenAuthTag?: string;
   expiresAt: number;
   cloudId?: string;
   siteUrl?: string;
@@ -36,13 +34,16 @@ export interface ConnectionArgs {
 
 /**
  * Upserts a user's provider connection: one row per (userId, provider).
- * Token material is always re-encrypted by the caller and re-written here;
- * `connectedAt` survives re-connects, `lastRefreshedAt` always advances.
+ * Token material is always re-encrypted by the caller (through the token
+ * vault) and re-written here; the vault tripwire runs first so only
+ * ciphertext can ever reach the token columns. `connectedAt` survives
+ * re-connects, `lastRefreshedAt` always advances.
  */
 export async function saveConnection(
   ctx: MutationCtx,
   args: ConnectionArgs
 ): Promise<Id<"integrationConnections">> {
+  assertEncryptedTokenFields(args);
   // Check for existing connection
   const existing = await ctx.db
     .query("integrationConnections")
@@ -89,6 +90,33 @@ export async function saveConnection(
     scopes: args.scopes,
     connectedAt: now,
     lastRefreshedAt: now,
+  });
+}
+
+export interface TokenUpdateArgs extends EncryptedTokenFields {
+  connectionId: Id<"integrationConnections">;
+  expiresAt: number;
+}
+
+/**
+ * Re-writes the token fields after a provider refresh. Like saveConnection,
+ * only vault-produced ciphertext is accepted; `lastRefreshedAt` always
+ * advances with the tokens.
+ */
+export async function updateConnectionTokens(
+  ctx: MutationCtx,
+  args: TokenUpdateArgs
+): Promise<void> {
+  assertEncryptedTokenFields(args);
+  await ctx.db.patch(args.connectionId, {
+    encryptedAccessToken: args.encryptedAccessToken,
+    accessTokenIv: args.accessTokenIv,
+    accessTokenAuthTag: args.accessTokenAuthTag,
+    encryptedRefreshToken: args.encryptedRefreshToken,
+    refreshTokenIv: args.refreshTokenIv,
+    refreshTokenAuthTag: args.refreshTokenAuthTag,
+    expiresAt: args.expiresAt,
+    lastRefreshedAt: Date.now(),
   });
 }
 

--- a/convex/model/integrations.ts
+++ b/convex/model/integrations.ts
@@ -1,0 +1,383 @@
+import { MutationCtx } from "../_generated/server";
+import { internal } from "../_generated/api";
+import { Doc, Id } from "../_generated/dataModel";
+
+/**
+ * The integrations model: the one owner of the db-side invariants for
+ * provider connections, room mappings, and webhook event processing.
+ *
+ * Everything here is db-pure (MutationCtx only) — remote Jira calls stay in
+ * the integrations/jira.ts actions; this module schedules them, the way the
+ * voting round schedules the estimate push. The registered wrappers in
+ * integrations.ts (public API) and integrations/jira.ts (internal) delegate
+ * here, so every writer of these tables funnels through the same code.
+ */
+
+// ---------------------------------------------------------------------------
+// Connections
+// ---------------------------------------------------------------------------
+
+export interface ConnectionArgs {
+  userId: Id<"users">;
+  provider: Doc<"integrationConnections">["provider"];
+  encryptedAccessToken: string;
+  accessTokenIv: string;
+  accessTokenAuthTag: string;
+  encryptedRefreshToken?: string;
+  refreshTokenIv?: string;
+  refreshTokenAuthTag?: string;
+  expiresAt: number;
+  cloudId?: string;
+  siteUrl?: string;
+  providerUserId?: string;
+  providerUserEmail?: string;
+  scopes: string[];
+}
+
+/**
+ * Upserts a user's provider connection: one row per (userId, provider).
+ * Token material is always re-encrypted by the caller and re-written here;
+ * `connectedAt` survives re-connects, `lastRefreshedAt` always advances.
+ */
+export async function saveConnection(
+  ctx: MutationCtx,
+  args: ConnectionArgs
+): Promise<Id<"integrationConnections">> {
+  // Check for existing connection
+  const existing = await ctx.db
+    .query("integrationConnections")
+    .withIndex("by_user_provider", (q) =>
+      q.eq("userId", args.userId).eq("provider", args.provider)
+    )
+    .first();
+
+  const now = Date.now();
+
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      encryptedAccessToken: args.encryptedAccessToken,
+      accessTokenIv: args.accessTokenIv,
+      accessTokenAuthTag: args.accessTokenAuthTag,
+      encryptedRefreshToken: args.encryptedRefreshToken,
+      refreshTokenIv: args.refreshTokenIv,
+      refreshTokenAuthTag: args.refreshTokenAuthTag,
+      expiresAt: args.expiresAt,
+      cloudId: args.cloudId,
+      siteUrl: args.siteUrl,
+      providerUserId: args.providerUserId,
+      providerUserEmail: args.providerUserEmail,
+      scopes: args.scopes,
+      lastRefreshedAt: now,
+    });
+    return existing._id;
+  }
+
+  return await ctx.db.insert("integrationConnections", {
+    userId: args.userId,
+    provider: args.provider,
+    encryptedAccessToken: args.encryptedAccessToken,
+    accessTokenIv: args.accessTokenIv,
+    accessTokenAuthTag: args.accessTokenAuthTag,
+    encryptedRefreshToken: args.encryptedRefreshToken,
+    refreshTokenIv: args.refreshTokenIv,
+    refreshTokenAuthTag: args.refreshTokenAuthTag,
+    expiresAt: args.expiresAt,
+    cloudId: args.cloudId,
+    siteUrl: args.siteUrl,
+    providerUserId: args.providerUserId,
+    providerUserEmail: args.providerUserEmail,
+    scopes: args.scopes,
+    connectedAt: now,
+    lastRefreshedAt: now,
+  });
+}
+
+/**
+ * The sanitized read projection of a connection — exactly the fields a reader
+ * may see. Encrypted token material never leaves the db layer; every reader
+ * must go through this projection.
+ */
+export function toConnectionView(connection: Doc<"integrationConnections">): {
+  _id: Id<"integrationConnections">;
+  provider: Doc<"integrationConnections">["provider"];
+  siteUrl?: string;
+  providerUserEmail?: string;
+  connectedAt: number;
+  scopes: string[];
+} {
+  return {
+    _id: connection._id,
+    provider: connection.provider,
+    siteUrl: connection.siteUrl,
+    providerUserEmail: connection.providerUserEmail,
+    connectedAt: connection.connectedAt,
+    scopes: connection.scopes,
+  };
+}
+
+/**
+ * Deletes a connection row directly. Runs as the scheduled tail of
+ * disconnectConnection, after the deregistration actions that still need the
+ * row's credentials have had their turn.
+ */
+export async function deleteConnection(
+  ctx: MutationCtx,
+  connectionId: Id<"integrationConnections">
+): Promise<void> {
+  const connection = await ctx.db.get(connectionId);
+  if (connection) {
+    await ctx.db.delete(connectionId);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Room mappings
+// ---------------------------------------------------------------------------
+
+export interface RoomMappingArgs {
+  roomId: Id<"rooms">;
+  connectionId: Id<"integrationConnections">;
+  provider: Doc<"integrationMappings">["provider"];
+  jiraProjectKey?: string;
+  jiraBoardId?: number;
+  jiraSprintId?: number;
+  storyPointsFieldId?: string;
+  autoImport: boolean;
+  autoPushEstimates: boolean;
+}
+
+/**
+ * Upserts the room's provider mapping (one per room), preserving the original
+ * `createdAt` on update. When auto-push is enabled for a Jira project,
+ * schedules webhook (re-)registration — the registration action deletes any
+ * previous remote webhook before registering the new one.
+ */
+export async function saveRoomMapping(
+  ctx: MutationCtx,
+  args: RoomMappingArgs
+): Promise<Id<"integrationMappings">> {
+  // Upsert: check for existing mapping
+  const existing = await ctx.db
+    .query("integrationMappings")
+    .withIndex("by_room", (q) => q.eq("roomId", args.roomId))
+    .first();
+
+  if (existing) {
+    await ctx.db.patch(existing._id, {
+      connectionId: args.connectionId,
+      provider: args.provider,
+      jiraProjectKey: args.jiraProjectKey,
+      jiraBoardId: args.jiraBoardId,
+      jiraSprintId: args.jiraSprintId,
+      storyPointsFieldId: args.storyPointsFieldId,
+      autoImport: args.autoImport,
+      autoPushEstimates: args.autoPushEstimates,
+    });
+
+    await scheduleWebhookRegistration(ctx, args, existing._id);
+    return existing._id;
+  }
+
+  const mappingId = await ctx.db.insert("integrationMappings", {
+    roomId: args.roomId,
+    connectionId: args.connectionId,
+    provider: args.provider,
+    jiraProjectKey: args.jiraProjectKey,
+    jiraBoardId: args.jiraBoardId,
+    jiraSprintId: args.jiraSprintId,
+    storyPointsFieldId: args.storyPointsFieldId,
+    autoImport: args.autoImport,
+    autoPushEstimates: args.autoPushEstimates,
+    createdAt: Date.now(),
+  });
+
+  await scheduleWebhookRegistration(ctx, args, mappingId);
+  return mappingId;
+}
+
+async function scheduleWebhookRegistration(
+  ctx: MutationCtx,
+  args: RoomMappingArgs,
+  mappingId: Id<"integrationMappings">
+): Promise<void> {
+  // Schedule webhook registration if auto-push enabled
+  if (args.autoPushEstimates && args.jiraProjectKey) {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.integrations.jira.registerWebhook,
+      {
+        mappingId,
+      }
+    );
+  }
+}
+
+/**
+ * Records the registered Jira webhook on a mapping — or clears it when called
+ * without an id. The registration timestamp is written iff an id is present,
+ * so the pair never drifts.
+ */
+export async function setMappingWebhook(
+  ctx: MutationCtx,
+  mappingId: Id<"integrationMappings">,
+  jiraWebhookId?: string
+): Promise<void> {
+  await ctx.db.patch(mappingId, {
+    jiraWebhookId,
+    jiraWebhookRegisteredAt: jiraWebhookId ? Date.now() : undefined,
+  });
+}
+
+/**
+ * Removes the room's mapping (if any) and schedules deregistration of its
+ * Jira webhook. The connection row survives the mapping, so the scheduled
+ * action can still authenticate the remote delete.
+ */
+export async function removeRoomMapping(
+  ctx: MutationCtx,
+  roomId: Id<"rooms">
+): Promise<void> {
+  const mapping = await ctx.db
+    .query("integrationMappings")
+    .withIndex("by_room", (q) => q.eq("roomId", roomId))
+    .first();
+
+  if (mapping) {
+    await ctx.db.delete(mapping._id);
+    await scheduleWebhookDeregistration(ctx, mapping);
+  }
+}
+
+/**
+ * The disconnect cascade: deletes every mapping on the connection (scheduling
+ * deregistration per live Jira webhook), then removes the connection itself.
+ * When deregistrations are pending, the row deletion is deferred to a
+ * scheduled mutation so those actions can still read the credentials they
+ * authenticate with; with nothing to deregister the row goes immediately.
+ */
+export async function disconnectConnection(
+  ctx: MutationCtx,
+  connectionId: Id<"integrationConnections">
+): Promise<void> {
+  // Cascade delete all mappings using this connection
+  const mappings = await ctx.db
+    .query("integrationMappings")
+    .withIndex("by_connection", (q) => q.eq("connectionId", connectionId))
+    .collect();
+  await Promise.all(mappings.map((m) => ctx.db.delete(m._id)));
+
+  let hasPendingDeregistrations = false;
+  for (const mapping of mappings) {
+    await scheduleWebhookDeregistration(ctx, mapping);
+    hasPendingDeregistrations ||=
+      mapping.provider === "jira" && !!mapping.jiraWebhookId;
+  }
+
+  if (hasPendingDeregistrations) {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.integrations.jira.deleteConnection,
+      { connectionId }
+    );
+  } else {
+    await ctx.db.delete(connectionId);
+  }
+}
+
+/**
+ * Schedules remote deregistration of a mapping's Jira webhook. Deleting the
+ * mapping row alone orphans the remote webhook — it keeps POSTing until its
+ * 30-day expiry — so every mapping-removal path must go through this.
+ */
+async function scheduleWebhookDeregistration(
+  ctx: MutationCtx,
+  mapping: Doc<"integrationMappings">
+): Promise<void> {
+  if (mapping.provider === "jira" && mapping.jiraWebhookId) {
+    await ctx.scheduler.runAfter(
+      0,
+      internal.integrations.jira.deregisterWebhook,
+      {
+        connectionId: mapping.connectionId,
+        jiraWebhookId: mapping.jiraWebhookId,
+      }
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Webhook events
+// ---------------------------------------------------------------------------
+
+export interface JiraWebhookEvent {
+  eventKey: string;
+  eventType: string;
+  issueKey: string;
+  issueSummary?: string;
+}
+
+/**
+ * Applies a Jira webhook delivery, deduplicated by event key: the dedup check
+ * and insert happen in this one mutation, so a redelivery of the same event
+ * can never re-apply. `jira:issue_updated` syncs the linked issue's title;
+ * `jira:issue_deleted` removes the link but keeps the AgileKit issue.
+ */
+export async function processJiraWebhookEvent(
+  ctx: MutationCtx,
+  event: JiraWebhookEvent
+): Promise<void> {
+  // Atomic dedup: check + insert in the same mutation (no race window)
+  const existing = await ctx.db
+    .query("webhookEvents")
+    .withIndex("by_event_key", (q) => q.eq("eventKey", event.eventKey))
+    .first();
+  if (existing) return; // Already processed
+
+  await ctx.db.insert("webhookEvents", {
+    eventKey: event.eventKey,
+    provider: "jira",
+    processedAt: Date.now(),
+  });
+
+  // Find linked issue
+  const link = await ctx.db
+    .query("issueLinks")
+    .withIndex("by_external", (q) =>
+      q.eq("provider", "jira").eq("externalId", event.issueKey)
+    )
+    .first();
+
+  if (!link) return; // Not a tracked issue
+
+  if (event.eventType === "jira:issue_updated" && event.issueSummary) {
+    // Update issue title
+    const issue = await ctx.db.get(link.issueId);
+    if (issue) {
+      await ctx.db.patch(link.issueId, {
+        title: `${event.issueKey} - ${event.issueSummary}`,
+      });
+    }
+    await ctx.db.patch(link._id, { lastSyncedAt: Date.now() });
+  }
+
+  if (event.eventType === "jira:issue_deleted") {
+    // Remove the link (keep the AgileKit issue)
+    await ctx.db.delete(link._id);
+  }
+}
+
+/** Sweeps processed webhook dedup rows older than 7 days. */
+export async function cleanupOldWebhookEvents(
+  ctx: MutationCtx
+): Promise<void> {
+  const sevenDaysAgo = Date.now() - 7 * 24 * 60 * 60 * 1000;
+  const oldEvents = await ctx.db
+    .query("webhookEvents")
+    .withIndex("by_processed", (q) => q.lt("processedAt", sevenDaysAgo))
+    .collect();
+
+  await Promise.all(oldEvents.map((e) => ctx.db.delete(e._id)));
+  if (oldEvents.length > 0) {
+    console.log(`Cleaned up ${oldEvents.length} old webhook events`);
+  }
+}

--- a/convex/model/issues.ts
+++ b/convex/model/issues.ts
@@ -109,9 +109,11 @@ export async function getCurrentIssue(
 }
 
 /**
- * Creates a new issue with an auto-incremented sequential ID
+ * Canonical issue creation, shared by local creates and integration imports:
+ * enforces the per-room cap, allocates the next sequential ID, advances the
+ * room counter exactly once, and appends after the current max order.
  */
-export async function createIssue(
+export async function createIssueInRoom(
   ctx: MutationCtx,
   args: { roomId: Id<"rooms">; title: string }
 ): Promise<Id<"issues">> {
@@ -146,6 +148,16 @@ export async function createIssue(
     createdAt: Date.now(),
     order: maxOrder + 1,
   });
+}
+
+/**
+ * Creates a new issue with an auto-incremented sequential ID
+ */
+export async function createIssue(
+  ctx: MutationCtx,
+  args: { roomId: Id<"rooms">; title: string }
+): Promise<Id<"issues">> {
+  return await createIssueInRoom(ctx, args);
 }
 
 /**

--- a/convex/model/roomAggregate.ts
+++ b/convex/model/roomAggregate.ts
@@ -1,0 +1,78 @@
+import { MutationCtx } from "../_generated/server";
+import { Doc, Id } from "../_generated/dataModel";
+
+/**
+ * The one inventory of what a room owns (derived from schema.ts).
+ *
+ * Every table keyed by `roomId` is a direct member. `issueLinks` is owned
+ * transitively through its issue — it has no `roomId` of its own — so the
+ * cascade expands it from the room's issues instead.
+ *
+ * Deliberately NOT room-owned: `integrationConnections` belongs to users,
+ * `webhookEvents` is a global dedup table, and `users` is global identity.
+ * There is no per-room presence/timer table — presence is connection-local
+ * and canvas timers are `canvasNodes` rows.
+ */
+export const ROOM_OWNED_TABLES = [
+  "issues",
+  "roomMemberships",
+  "votes",
+  "canvasNodes",
+  "votingTimestamps",
+  "individualVotes",
+  "integrationMappings",
+] as const;
+
+export type RoomOwnedTable = (typeof ROOM_OWNED_TABLES)[number];
+
+/**
+ * Deletes a room and everything it owns, per ROOM_OWNED_TABLES.
+ * Returns per-table deletion counts (including `issueLinks` and `rooms`).
+ */
+export async function deleteRoomAggregate(
+  ctx: MutationCtx,
+  roomId: Id<"rooms">
+): Promise<Record<RoomOwnedTable | "issueLinks" | "rooms", number>> {
+  // Collect every row the room owns, per inventory table, in parallel.
+  const rowsByTable = await Promise.all(
+    ROOM_OWNED_TABLES.map(async (table) => ({
+      table,
+      rows: await ctx.db
+        .query(table)
+        .withIndex("by_room", (q) => q.eq("roomId", roomId))
+        .collect(),
+    }))
+  );
+
+  // issueLinks are room-owned through their issue: expand from this room's issues.
+  const issueRows = rowsByTable.find((entry) => entry.table === "issues")!
+    .rows as Doc<"issues">[];
+  const issueLinks = (
+    await Promise.all(
+      issueRows.map((issue) =>
+        ctx.db
+          .query("issueLinks")
+          .withIndex("by_issue", (q) => q.eq("issueId", issue._id))
+          .collect()
+      )
+    )
+  ).flat();
+
+  const deletions: Promise<void>[] = [];
+  for (const { rows } of rowsByTable) {
+    deletions.push(...rows.map((row) => ctx.db.delete(row._id)));
+  }
+  deletions.push(...issueLinks.map((link) => ctx.db.delete(link._id)));
+  await Promise.all(deletions);
+
+  // Delete the room itself last.
+  await ctx.db.delete(roomId);
+
+  const deleted = {} as Record<RoomOwnedTable | "issueLinks" | "rooms", number>;
+  for (const { table, rows } of rowsByTable) {
+    deleted[table] = rows.length;
+  }
+  deleted.issueLinks = issueLinks.length;
+  deleted.rooms = 1;
+  return deleted;
+}

--- a/convex/model/roomAggregate.ts
+++ b/convex/model/roomAggregate.ts
@@ -1,5 +1,6 @@
 import { MutationCtx } from "../_generated/server";
 import { Doc, Id } from "../_generated/dataModel";
+import { scheduleWebhookDeregistration } from "./integrations";
 
 /**
  * The one inventory of what a room owns (derived from schema.ts).
@@ -26,53 +27,92 @@ export const ROOM_OWNED_TABLES = [
 export type RoomOwnedTable = (typeof ROOM_OWNED_TABLES)[number];
 
 /**
- * Deletes a room and everything it owns, per ROOM_OWNED_TABLES.
- * Returns per-table deletion counts (including `issueLinks` and `rooms`).
+ * Rows deleted per table per cascade step. Keeps every invocation well within
+ * per-transaction document limits; the registered wrapper reschedules itself
+ * until the step reports `done` (guideline: batch with .take + runAfter
+ * continuation rather than one unbounded collect-and-delete transaction).
  */
-export async function deleteRoomAggregate(
+export const ROOM_DELETE_BATCH_SIZE = 500;
+
+export interface RoomAggregateDeleteStep {
+  /** true once the room row itself is deleted — the cascade is complete. */
+  done: boolean;
+  /** Rows deleted by this step (the room row counts as one). */
+  deleted: number;
+}
+
+/**
+ * One bounded step of the room cascade, per ROOM_OWNED_TABLES. The caller
+ * (internal.maintenance.deleteRoomAggregateChunk) reschedules itself while
+ * the step returns `done: false`.
+ *
+ * Phase order is load-bearing:
+ * 1. issues + their issueLinks — links expand from the room's issues, so each
+ *    issue batch must go before its rows vanish (a deleted issue's links can
+ *    no longer be found by index).
+ * 2. the remaining by_room tables, one batch per table per step.
+ * 3. the room row itself, only once every owned table reads empty.
+ *
+ * integrationMappings rows schedule webhook deregistration BEFORE deletion:
+ * deleting the mapping alone would orphan the remote Jira webhook (it keeps
+ * POSTing until its 30-day expiry). Connections belong to users, not rooms,
+ * so the connection row survives the cascade and the scheduled action can
+ * still authenticate the remote delete.
+ */
+export async function deleteRoomAggregateChunk(
   ctx: MutationCtx,
-  roomId: Id<"rooms">
-): Promise<Record<RoomOwnedTable | "issueLinks" | "rooms", number>> {
-  // Collect every row the room owns, per inventory table, in parallel.
-  const rowsByTable = await Promise.all(
-    ROOM_OWNED_TABLES.map(async (table) => ({
-      table,
-      rows: await ctx.db
-        .query(table)
-        .withIndex("by_room", (q) => q.eq("roomId", roomId))
-        .collect(),
-    }))
-  );
+  roomId: Id<"rooms">,
+  batchSize: number = ROOM_DELETE_BATCH_SIZE
+): Promise<RoomAggregateDeleteStep> {
+  // Phase 1: issues + their links, one batch at a time.
+  const issueBatch = (await ctx.db
+    .query("issues")
+    .withIndex("by_room", (q) => q.eq("roomId", roomId))
+    .take(batchSize)) as Doc<"issues">[];
 
-  // issueLinks are room-owned through their issue: expand from this room's issues.
-  const issueRows = rowsByTable.find((entry) => entry.table === "issues")!
-    .rows as Doc<"issues">[];
-  const issueLinks = (
-    await Promise.all(
-      issueRows.map((issue) =>
-        ctx.db
-          .query("issueLinks")
-          .withIndex("by_issue", (q) => q.eq("issueId", issue._id))
-          .collect()
+  if (issueBatch.length > 0) {
+    const links = (
+      await Promise.all(
+        issueBatch.map((issue) =>
+          ctx.db
+            .query("issueLinks")
+            .withIndex("by_issue", (q) => q.eq("issueId", issue._id))
+            .collect()
+        )
       )
-    )
-  ).flat();
-
-  const deletions: Promise<void>[] = [];
-  for (const { rows } of rowsByTable) {
-    deletions.push(...rows.map((row) => ctx.db.delete(row._id)));
+    ).flat();
+    await Promise.all([
+      ...links.map((link) => ctx.db.delete(link._id)),
+      ...issueBatch.map((issue) => ctx.db.delete(issue._id)),
+    ]);
+    return { done: false, deleted: issueBatch.length + links.length };
   }
-  deletions.push(...issueLinks.map((link) => ctx.db.delete(link._id)));
-  await Promise.all(deletions);
 
-  // Delete the room itself last.
+  // Phase 2: the remaining room-owned tables, one batch per table per step.
+  let deleted = 0;
+  let anyFullBatch = false;
+  for (const table of ROOM_OWNED_TABLES) {
+    if (table === "issues") continue;
+    const rows = await ctx.db
+      .query(table)
+      .withIndex("by_room", (q) => q.eq("roomId", roomId))
+      .take(batchSize);
+
+    if (table === "integrationMappings") {
+      for (const mapping of rows as Doc<"integrationMappings">[]) {
+        await scheduleWebhookDeregistration(ctx, mapping);
+      }
+    }
+
+    await Promise.all(rows.map((row) => ctx.db.delete(row._id)));
+    deleted += rows.length;
+    if (rows.length === batchSize) anyFullBatch = true;
+  }
+  if (anyFullBatch) {
+    return { done: false, deleted };
+  }
+
+  // Phase 3: the room itself, last.
   await ctx.db.delete(roomId);
-
-  const deleted = {} as Record<RoomOwnedTable | "issueLinks" | "rooms", number>;
-  for (const { table, rows } of rowsByTable) {
-    deleted[table] = rows.length;
-  }
-  deleted.issueLinks = issueLinks.length;
-  deleted.rooms = 1;
-  return deleted;
+  return { done: true, deleted: deleted + 1 };
 }

--- a/convex/model/timer.ts
+++ b/convex/model/timer.ts
@@ -1,73 +1,17 @@
-import { QueryCtx, MutationCtx } from "../_generated/server";
+import { MutationCtx } from "../_generated/server";
 import { Id } from "../_generated/dataModel";
-import type { TimerNodeData } from "@/components/room/types";
-
-export interface TimerState {
-  currentSeconds: number;
-  isRunning: boolean;
-  displayTime: string;
-}
+import {
+  calculateCurrentTime,
+  validateTimerAction,
+  type TimerAction,
+  type TimerState,
+} from "../timerState";
 
 export interface UpdateTimerStateArgs {
   roomId: Id<"rooms">;
   nodeId: string;
-  action: "start" | "pause" | "reset";
+  action: TimerAction;
   userId: Id<"users">;
-}
-
-/**
- * Calculates the current timer time based on server timestamps
- */
-export function calculateCurrentTime(timerData: TimerNodeData): TimerState {
-  const now = Date.now();
-  let currentSeconds = timerData.elapsedSeconds;
-
-  if (timerData.isRunning && timerData.startedAt) {
-    // Add time since last start
-    const runningSince = (now - timerData.startedAt) / 1000;
-    currentSeconds += runningSince;
-  }
-
-  // Format time as MM:SS
-  const minutes = Math.floor(currentSeconds / 60);
-  const seconds = Math.floor(currentSeconds % 60);
-  const displayTime = `${minutes}:${seconds.toString().padStart(2, "0")}`;
-
-  return {
-    currentSeconds: Math.floor(currentSeconds),
-    isRunning: timerData.isRunning,
-    displayTime,
-  };
-}
-
-/**
- * Validates timer state transitions
- */
-function validateTimerAction(
-  currentData: TimerNodeData,
-  action: "start" | "pause" | "reset"
-): void {
-  if (!currentData) {
-    throw new Error("Timer node not found");
-  }
-
-  switch (action) {
-    case "start":
-      if (currentData.isRunning) {
-        throw new Error("Timer is already running");
-      }
-      break;
-    case "pause":
-      if (!currentData.isRunning) {
-        throw new Error("Timer is not running");
-      }
-      break;
-    case "reset":
-      // Reset is always allowed
-      break;
-    default:
-      throw new Error(`Invalid timer action: ${action}`);
-  }
 }
 
 /**
@@ -95,9 +39,9 @@ export async function updateTimerState(
   validateTimerAction(timerNode.data, args.action);
 
   // Calculate current elapsed time before updating
-  const currentState = calculateCurrentTime(timerNode.data);
-  
-  let newData: TimerNodeData;
+  const currentState = calculateCurrentTime(timerNode.data, now);
+
+  let newData: TimerState;
 
   switch (args.action) {
     case "start":
@@ -143,64 +87,6 @@ export async function updateTimerState(
   await ctx.db.patch(timerNode._id, {
     data: newData,
     lastUpdatedBy: args.userId,
-    lastUpdatedAt: now,
-  });
-}
-
-/**
- * Gets the current timer state for a room
- */
-export async function getTimerState(
-  ctx: QueryCtx,
-  args: { roomId: Id<"rooms">; nodeId: string }
-): Promise<TimerState | null> {
-  const timerNode = await ctx.db
-    .query("canvasNodes")
-    .withIndex("by_room_node", (q) =>
-      q.eq("roomId", args.roomId).eq("nodeId", args.nodeId)
-    )
-    .unique();
-
-  if (!timerNode || timerNode.type !== "timer") {
-    return null;
-  }
-
-  return calculateCurrentTime(timerNode.data);
-}
-
-/**
- * Resets timer state (used when game resets)
- */
-export async function resetTimerForGameReset(
-  ctx: MutationCtx,
-  args: { roomId: Id<"rooms"> }
-): Promise<void> {
-  const now = Date.now();
-
-  // Find the timer node
-  const timerNode = await ctx.db
-    .query("canvasNodes")
-    .withIndex("by_room_node", (q) =>
-      q.eq("roomId", args.roomId).eq("nodeId", "timer")
-    )
-    .unique();
-
-  if (!timerNode || timerNode.type !== "timer") {
-    return; // No timer node found, nothing to reset
-  }
-
-  // Reset timer data
-  const resetData = {
-    ...timerNode.data,
-    isRunning: false,
-    startedAt: null,
-    pausedAt: null,
-    elapsedSeconds: 0,
-    lastAction: "reset",
-  };
-
-  await ctx.db.patch(timerNode._id, {
-    data: resetData,
     lastUpdatedAt: now,
   });
 }

--- a/convex/model/tokenVault.ts
+++ b/convex/model/tokenVault.ts
@@ -1,0 +1,189 @@
+/**
+ * The token vault: the one owner of the token-field contract for
+ * integrationConnections.
+ *
+ * Provider-agnostic by construction — nothing here knows about Jira, so the
+ * future GitHub adapter encrypts and reads tokens through the same helpers.
+ * lib/encryption stays the pure AES-GCM primitive; this module is the policy
+ * owner: it validates the key (by default at every encrypt/decrypt, so the
+ * check runs wherever encryption runs rather than being re-implemented per
+ * provider), encrypts on write, decrypts on read, and single-sources the
+ * expiry rule.
+ *
+ * Plaintext is unrepresentable at the write boundary: `encryptTokens` is the
+ * only sanctioned producer of token fields, and the model writers in
+ * model/integrations.ts refuse to store a field that is not vault-shaped
+ * ciphertext (see `assertEncryptedTokenFields`).
+ */
+
+import { encryptToken, decryptToken } from "../lib/encryption";
+
+/** Token material exactly as a provider hands it over — never persisted. */
+export interface PlaintextTokens {
+  accessToken: string;
+  refreshToken?: string;
+}
+
+/**
+ * The encrypted token fields of an integrationConnections row, exactly as
+ * persisted. Produced only by `encryptTokens`.
+ */
+export interface EncryptedTokenFields {
+  encryptedAccessToken: string;
+  accessTokenIv: string;
+  accessTokenAuthTag: string;
+  encryptedRefreshToken?: string;
+  refreshTokenIv?: string;
+  refreshTokenAuthTag?: string;
+}
+
+/** Structural views a stored connection row satisfies — Doc works directly. */
+export type EncryptedAccessTokenFields = Pick<
+  EncryptedTokenFields,
+  "encryptedAccessToken" | "accessTokenIv" | "accessTokenAuthTag"
+>;
+export type EncryptedRefreshTokenFields = Pick<
+  EncryptedTokenFields,
+  "encryptedRefreshToken" | "refreshTokenIv" | "refreshTokenAuthTag"
+>;
+
+/**
+ * Reads and validates TOKEN_ENCRYPTION_KEY. This is the default key source
+ * for every vault operation, so key validation cannot be skipped by a call
+ * site. Tests inject the key explicitly instead.
+ */
+export function getTokenEncryptionKey(): string {
+  return assertValidEncryptionKey(process.env.TOKEN_ENCRYPTION_KEY);
+}
+
+/** The pure format check behind getTokenEncryptionKey — returns the key when valid. */
+export function assertValidEncryptionKey(key: string | undefined): string {
+  if (!key) {
+    throw new Error(
+      "Missing TOKEN_ENCRYPTION_KEY environment variable. Set a 32-byte hex key."
+    );
+  }
+  if (!/^[0-9a-fA-F]{64}$/.test(key)) {
+    throw new Error(
+      "Invalid TOKEN_ENCRYPTION_KEY. Expected 64 hex characters (32 bytes)."
+    );
+  }
+  return key;
+}
+
+const TOKEN_EXPIRY_BUFFER_MS = 60_000;
+
+/**
+ * The single source of the freshness rule: a token counts as valid only when
+ * it outlives now plus a 60-second buffer, so a remote call never starts with
+ * a token that expires mid-flight. `now` is injectable for tests.
+ */
+export function isAccessTokenFresh(
+  expiresAt: number,
+  now: number = Date.now()
+): boolean {
+  return expiresAt > now + TOKEN_EXPIRY_BUFFER_MS;
+}
+
+/**
+ * Encrypt-on-write: the only sanctioned producer of token fields. Every write
+ * site of the token columns (saveConnection, updateConnectionTokens) must be
+ * fed from here. Refresh-token fields are emitted only when a refresh token
+ * is given — and then always as a complete triple.
+ */
+export async function encryptTokens(
+  tokens: PlaintextTokens,
+  keyHex: string = getTokenEncryptionKey()
+): Promise<EncryptedTokenFields> {
+  const encAccess = await encryptToken(tokens.accessToken, keyHex);
+  const fields: EncryptedTokenFields = {
+    encryptedAccessToken: encAccess.ciphertext,
+    accessTokenIv: encAccess.iv,
+    accessTokenAuthTag: encAccess.authTag,
+  };
+  if (tokens.refreshToken !== undefined) {
+    const encRefresh = await encryptToken(tokens.refreshToken, keyHex);
+    fields.encryptedRefreshToken = encRefresh.ciphertext;
+    fields.refreshTokenIv = encRefresh.iv;
+    fields.refreshTokenAuthTag = encRefresh.authTag;
+  }
+  return fields;
+}
+
+/** Decrypt-on-read: the access token of a stored connection row. */
+export async function decryptAccessToken(
+  connection: EncryptedAccessTokenFields,
+  keyHex: string = getTokenEncryptionKey()
+): Promise<string> {
+  return decryptToken(
+    connection.encryptedAccessToken,
+    connection.accessTokenIv,
+    connection.accessTokenAuthTag,
+    keyHex
+  );
+}
+
+/**
+ * Decrypt-on-read: the refresh token of a stored connection row. The refresh
+ * fields are written all-or-nothing, so a missing piece means the connection
+ * simply has no refresh token.
+ */
+export async function decryptRefreshToken(
+  connection: EncryptedRefreshTokenFields,
+  keyHex: string = getTokenEncryptionKey()
+): Promise<string> {
+  if (
+    !connection.encryptedRefreshToken ||
+    !connection.refreshTokenIv ||
+    !connection.refreshTokenAuthTag
+  ) {
+    throw new Error("No refresh token available for this connection");
+  }
+  return decryptToken(
+    connection.encryptedRefreshToken,
+    connection.refreshTokenIv,
+    connection.refreshTokenAuthTag,
+    keyHex
+  );
+}
+
+/**
+ * The write-side tripwire. Token columns hold AES-GCM output, which
+ * lib/encryption always renders as even-length lowercase hex — a plaintext
+ * token (or a truncated ciphertext) fails this check, so a future writer
+ * cannot smuggle plaintext into encryptedAccessToken through the model
+ * writers. Refresh-token fields must additionally be all-or-nothing.
+ */
+export function assertEncryptedTokenFields(fields: EncryptedTokenFields): void {
+  const named: Array<[string, string | undefined]> = [
+    ["encryptedAccessToken", fields.encryptedAccessToken],
+    ["accessTokenIv", fields.accessTokenIv],
+    ["accessTokenAuthTag", fields.accessTokenAuthTag],
+    ["encryptedRefreshToken", fields.encryptedRefreshToken],
+    ["refreshTokenIv", fields.refreshTokenIv],
+    ["refreshTokenAuthTag", fields.refreshTokenAuthTag],
+  ];
+  for (const [name, value] of named) {
+    if (value !== undefined && !isHex(value)) {
+      throw new Error(
+        `${name} must be vault-produced ciphertext (lowercase hex); refusing to store possible plaintext`
+      );
+    }
+  }
+
+  const refreshFields = [
+    fields.encryptedRefreshToken,
+    fields.refreshTokenIv,
+    fields.refreshTokenAuthTag,
+  ];
+  const present = refreshFields.filter((f) => f !== undefined).length;
+  if (present !== 0 && present !== 3) {
+    throw new Error(
+      "Refresh token fields must be written all-or-nothing: encryptedRefreshToken, refreshTokenIv, refreshTokenAuthTag"
+    );
+  }
+}
+
+function isHex(value: string): boolean {
+  return value.length > 0 && value.length % 2 === 0 && /^[0-9a-f]+$/.test(value);
+}

--- a/convex/model/tokenVault.ts
+++ b/convex/model/tokenVault.ts
@@ -95,6 +95,16 @@ export async function encryptTokens(
   tokens: PlaintextTokens,
   keyHex: string = getTokenEncryptionKey()
 ): Promise<EncryptedTokenFields> {
+  // AES-GCM ciphertext length equals plaintext length, so an empty token
+  // would "encrypt" to an empty string and then fail the write-side tripwire
+  // as possible plaintext. Reject the degenerate input here, where the error
+  // names the real problem.
+  if (!tokens.accessToken) {
+    throw new Error("Cannot encrypt an empty access token");
+  }
+  if (tokens.refreshToken !== undefined && !tokens.refreshToken) {
+    throw new Error("Cannot encrypt an empty refresh token");
+  }
   const encAccess = await encryptToken(tokens.accessToken, keyHex);
   const fields: EncryptedTokenFields = {
     encryptedAccessToken: encAccess.ciphertext,

--- a/convex/model/votingRound.ts
+++ b/convex/model/votingRound.ts
@@ -294,6 +294,27 @@ export async function cancelCountdown(
   await cancel(ctx, roomId);
 }
 
+/**
+ * setAutoComplete — flip the room's auto-complete setting and reconcile the
+ * countdown in the same step, so the setting can't drift from the countdown it
+ * feeds (the "remember to reconcile" class ADR-0004 closed for roster exits).
+ * Disabling tears the countdown down as one unit; enabling re-evaluates so a
+ * fully-voted room arms immediately instead of waiting for the next vote.
+ */
+export async function setAutoComplete(
+  ctx: MutationCtx,
+  roomId: Id<"rooms">,
+  enabled: boolean
+): Promise<void> {
+  if (!enabled) {
+    await cancel(ctx, roomId);
+    await ctx.db.patch(roomId, { autoCompleteVoting: false });
+    return;
+  }
+  await ctx.db.patch(roomId, { autoCompleteVoting: true });
+  await evaluate(ctx, roomId);
+}
+
 // --- internal round helpers ---------------------------------------------
 
 /**

--- a/convex/presence.ts
+++ b/convex/presence.ts
@@ -3,7 +3,7 @@ import { components } from "./_generated/api";
 import { Id } from "./_generated/dataModel";
 import { v } from "convex/values";
 import { Presence } from "@convex-dev/presence";
-import { requireRoomMember } from "./model/auth";
+import { requireActingUser } from "./model/auth";
 
 export const presence = new Presence(components.presence);
 
@@ -19,10 +19,12 @@ export const heartbeat = mutation({
     // actually this room member before heartbeating as them — otherwise any
     // client could spoof another user's online status or inject phantom
     // presence into arbitrary rooms.
-    const { user } = await requireRoomMember(ctx, roomId as Id<"rooms">);
-    if (user._id !== userId) {
-      throw new Error("Cannot heartbeat as another user");
-    }
+    await requireActingUser(
+      ctx,
+      roomId as Id<"rooms">,
+      userId as Id<"users">,
+      "Cannot heartbeat as another user"
+    );
     return await presence.heartbeat(ctx, roomId, userId, sessionId, interval);
   },
 });

--- a/convex/requireCan.test.ts
+++ b/convex/requireCan.test.ts
@@ -1,0 +1,314 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect } from "vitest";
+import schema from "./schema";
+import { api, internal } from "./_generated/api";
+import type { Id } from "./_generated/dataModel";
+import { requireCan, requireCanForUser } from "./model/auth";
+import type { RequireCanSpec } from "./model/auth";
+import type { MemberRole, RoomPermissions } from "./permissions";
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+const EVERYWHERE_EVERYONE: RoomPermissions = {
+  revealCards: "everyone",
+  gameFlow: "everyone",
+  issueManagement: "everyone",
+  roomSettings: "everyone",
+};
+
+function permissions(overrides: Partial<RoomPermissions>): RoomPermissions {
+  return { ...EVERYWHERE_EVERYONE, ...overrides };
+}
+
+async function seedRoom(
+  t: T,
+  opts: { permissions?: RoomPermissions; ownerId?: Id<"users"> } = {}
+): Promise<Id<"rooms">> {
+  return t.run((ctx) =>
+    ctx.db.insert("rooms", {
+      name: "R",
+      autoCompleteVoting: false,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+      ...(opts.permissions ? { permissions: opts.permissions } : {}),
+      ...(opts.ownerId ? { ownerId: opts.ownerId } : {}),
+    })
+  );
+}
+
+async function addMember(
+  t: T,
+  roomId: Id<"rooms">,
+  authUserId: string,
+  role?: MemberRole
+): Promise<Id<"users">> {
+  return t.run(async (ctx) => {
+    const userId = await ctx.db.insert("users", {
+      authUserId,
+      name: "U",
+      createdAt: Date.now(),
+    });
+    await ctx.db.insert("roomMemberships", {
+      roomId,
+      userId,
+      isSpectator: false,
+      joinedAt: Date.now(),
+      ...(role ? { role } : {}),
+    });
+    return userId;
+  });
+}
+
+/** Simulates the owner explicitly leaving: the membership is deleted. */
+async function removeMembership(
+  t: T,
+  roomId: Id<"rooms">,
+  userId: Id<"users">
+): Promise<void> {
+  await t.run(async (ctx) => {
+    const membership = await ctx.db
+      .query("roomMemberships")
+      .withIndex("by_room_user", (q) =>
+        q.eq("roomId", roomId).eq("userId", userId)
+      )
+      .first();
+    if (membership) await ctx.db.delete(membership._id);
+  });
+}
+
+describe("permission guard (requireCan) — category actions through rooms.rename", () => {
+  it("participant may act when the category level is everyone", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t); // legacy room: defaults to everyone
+    await addMember(t, roomId, "auth-p");
+    const asP = t.withIdentity({ subject: "auth-p" });
+    await asP.mutation(api.rooms.rename, { roomId, name: "New name" });
+    const room = await t.run((ctx) => ctx.db.get(roomId));
+    expect(room!.name).toBe("New name");
+  });
+
+  it("participant is denied when the category requires facilitators", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      permissions: permissions({ roomSettings: "facilitators" }),
+    });
+    await addMember(t, roomId, "auth-p");
+    const asP = t.withIdentity({ subject: "auth-p" });
+    await expect(
+      asP.mutation(api.rooms.rename, { roomId, name: "New name" })
+    ).rejects.toThrow("Only facilitators and the owner can do this.");
+  });
+
+  it("facilitator may act when the category requires facilitators", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      permissions: permissions({ roomSettings: "facilitators" }),
+    });
+    await addMember(t, roomId, "auth-f", "facilitator");
+    const asF = t.withIdentity({ subject: "auth-f" });
+    await asF.mutation(api.rooms.rename, { roomId, name: "New name" });
+    const room = await t.run((ctx) => ctx.db.get(roomId));
+    expect(room!.name).toBe("New name");
+  });
+
+  it("facilitator is denied when the category requires the owner", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      permissions: permissions({ roomSettings: "owner" }),
+    });
+    await addMember(t, roomId, "auth-f", "facilitator");
+    const asF = t.withIdentity({ subject: "auth-f" });
+    await expect(
+      asF.mutation(api.rooms.rename, { roomId, name: "New name" })
+    ).rejects.toThrow("Only the owner can do this.");
+  });
+
+  it("owner may act when the category requires the owner", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      permissions: permissions({ roomSettings: "owner" }),
+    });
+    const ownerId = await addMember(t, roomId, "auth-o", "owner");
+    await t.run((ctx) => ctx.db.patch(roomId, { ownerId }));
+    const asO = t.withIdentity({ subject: "auth-o" });
+    await asO.mutation(api.rooms.rename, { roomId, name: "New name" });
+    const room = await t.run((ctx) => ctx.db.get(roomId));
+    expect(room!.name).toBe("New name");
+  });
+});
+
+describe("permission guard — lockdown (ADR-0001)", () => {
+  it("owner absent: owner-level action stays denied, reason refined to owner-absent", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      permissions: permissions({ roomSettings: "owner" }),
+    });
+    const ownerId = await addMember(t, roomId, "auth-o", "owner");
+    await t.run((ctx) => ctx.db.patch(roomId, { ownerId }));
+    await addMember(t, roomId, "auth-f", "facilitator");
+    // The owner explicitly leaves → lockdown.
+    await removeMembership(t, roomId, ownerId);
+
+    const asF = t.withIdentity({ subject: "auth-f" });
+    // Still denied (the role check alone denies it), but the message is the
+    // owner-absent refinement — the guard must not gate on lockdown.
+    await expect(
+      asF.mutation(api.rooms.rename, { roomId, name: "New name" })
+    ).rejects.toThrow(
+      "Room owner has left. Owner-level actions are disabled until the owner returns."
+    );
+  });
+
+  it("owner absent: facilitator-level actions still resolve correctly", async () => {
+    // The owner-absence read can only refine owner-level denials, so the guard
+    // skips it for anything else — behaviorally, lockdown must not leak into
+    // facilitator-level outcomes.
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      permissions: permissions({ roomSettings: "facilitators" }),
+    });
+    const ownerId = await addMember(t, roomId, "auth-o", "owner");
+    await t.run((ctx) => ctx.db.patch(roomId, { ownerId }));
+    await addMember(t, roomId, "auth-f", "facilitator");
+    await removeMembership(t, roomId, ownerId);
+
+    const asF = t.withIdentity({ subject: "auth-f" });
+    await asF.mutation(api.rooms.rename, { roomId, name: "New name" });
+    const room = await t.run((ctx) => ctx.db.get(roomId));
+    expect(room!.name).toBe("New name");
+  });
+});
+
+describe("permission guard — relationship actions through users.remove", () => {
+  it("facilitator cannot remove another facilitator (target-rank)", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addMember(t, roomId, "auth-f1", "facilitator");
+    const targetId = await addMember(t, roomId, "auth-f2", "facilitator");
+    const asF = t.withIdentity({ subject: "auth-f1" });
+    await expect(
+      asF.mutation(api.users.remove, { userId: targetId, roomId })
+    ).rejects.toThrow("Facilitators can only remove participants.");
+  });
+
+  it("facilitator cannot remove the owner (target-rank)", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const ownerId = await addMember(t, roomId, "auth-o", "owner");
+    await t.run((ctx) => ctx.db.patch(roomId, { ownerId }));
+    await addMember(t, roomId, "auth-f", "facilitator");
+    const asF = t.withIdentity({ subject: "auth-f" });
+    await expect(
+      asF.mutation(api.users.remove, { userId: ownerId, roomId })
+    ).rejects.toThrow("Facilitators can only remove participants.");
+  });
+
+  it("facilitator can remove a participant", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    await addMember(t, roomId, "auth-f", "facilitator");
+    const targetId = await addMember(t, roomId, "auth-p");
+    const asF = t.withIdentity({ subject: "auth-f" });
+    await asF.mutation(api.users.remove, { userId: targetId, roomId });
+    const membership = await t.run((ctx) =>
+      ctx.db
+        .query("roomMemberships")
+        .withIndex("by_room_user", (q) =>
+          q.eq("roomId", roomId).eq("userId", targetId)
+        )
+        .first()
+    );
+    expect(membership).toBeNull();
+  });
+});
+
+describe("explicit-user guard variant (requireCanForUser)", () => {
+  const spec: RequireCanSpec = { kind: "category", category: "roomSettings" };
+
+  it("allows with the same verdict and bundle as requireCan", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      permissions: permissions({ roomSettings: "facilitators" }),
+    });
+    const userId = await addMember(t, roomId, "auth-f", "facilitator");
+
+    const viaGuard = await t
+      .withIdentity({ subject: "auth-f" })
+      .run((ctx) => requireCan(ctx, roomId, spec));
+    const viaVariant = await t.run(async (ctx) => {
+      const user = await ctx.db.get(userId);
+      return requireCanForUser(ctx, user!, roomId, spec);
+    });
+
+    expect(viaVariant.user._id).toBe(viaGuard.user._id);
+    expect(viaVariant.membership._id).toBe(viaGuard.membership._id);
+    expect(viaVariant.room._id).toBe(viaGuard.room._id);
+  });
+
+  it("denies with the same message as requireCan", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      permissions: permissions({ roomSettings: "facilitators" }),
+    });
+    const userId = await addMember(t, roomId, "auth-p");
+
+    await expect(
+      t.withIdentity({ subject: "auth-p" }).run((ctx) => requireCan(ctx, roomId, spec))
+    ).rejects.toThrow("Only facilitators and the owner can do this.");
+    await expect(
+      t.run(async (ctx) => {
+        const user = await ctx.db.get(userId);
+        return requireCanForUser(ctx, user!, roomId, spec);
+      })
+    ).rejects.toThrow("Only facilitators and the owner can do this.");
+  });
+
+  it("requires room membership", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        authUserId: "auth-outsider",
+        name: "U",
+        createdAt: Date.now(),
+      })
+    );
+    await expect(
+      t.run(async (ctx) => {
+        const user = await ctx.db.get(userId);
+        return requireCanForUser(ctx, user!, roomId, spec);
+      })
+    ).rejects.toThrow("Not a member of this room");
+  });
+
+  it("drives the registered internal path (verifyCanManageIssues) for a facilitator", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      permissions: permissions({ issueManagement: "facilitators" }),
+    });
+    const userId = await addMember(t, roomId, "auth-f", "facilitator");
+    const result = await t.query(
+      internal.integrations.jira.verifyCanManageIssues,
+      { userId, roomId }
+    );
+    expect(result).toEqual({ userId });
+  });
+
+  it("denies a participant through verifyCanManageIssues with the guard's message", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, {
+      permissions: permissions({ issueManagement: "facilitators" }),
+    });
+    const userId = await addMember(t, roomId, "auth-p");
+    await expect(
+      t.query(internal.integrations.jira.verifyCanManageIssues, {
+        userId,
+        roomId,
+      })
+    ).rejects.toThrow("Only facilitators and the owner can do this.");
+  });
+});

--- a/convex/roomAggregate.test.ts
+++ b/convex/roomAggregate.test.ts
@@ -1,15 +1,27 @@
 /// <reference types="vite/client" />
 import { convexTest, type TestConvex } from "convex-test";
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { internal } from "./_generated/api";
 import schema from "./schema";
 import type { Id } from "./_generated/dataModel";
-import * as Cleanup from "./model/cleanup";
+import * as RoomAggregate from "./model/roomAggregate";
 import { ROOM_OWNED_TABLES, type RoomOwnedTable } from "./model/roomAggregate";
 
 const modules = import.meta.glob("./**/*.*s");
 
 type T = TestConvex<typeof schema>;
+
+// convex-test dispatches runAfter(0) jobs through a real setTimeout, which
+// can fire mid-test — racing the _scheduled_functions assertions and running
+// Jira actions that need env vars. Faking setTimeout keeps scheduled jobs
+// pending for the duration of each test.
+beforeEach(() => {
+  vi.useFakeTimers({ toFake: ["setTimeout"] });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 type CountedTable =
   | RoomOwnedTable
@@ -21,6 +33,55 @@ type CountedTable =
 
 async function countRows(t: T, table: CountedTable): Promise<number> {
   return t.run(async (ctx) => (await ctx.db.query(table).collect()).length);
+}
+
+async function scheduledByName(t: T, suffix: string) {
+  const scheduled = await t.run((ctx) =>
+    ctx.db.system.query("_scheduled_functions").collect()
+  );
+  return scheduled.filter((s) => s.name.endsWith(suffix));
+}
+
+async function seedConnection(
+  t: T,
+  userId: Id<"users">
+): Promise<Id<"integrationConnections">> {
+  return t.run((ctx) =>
+    ctx.db.insert("integrationConnections", {
+      userId,
+      provider: "jira",
+      encryptedAccessToken: "enc-access",
+      accessTokenIv: "iv",
+      accessTokenAuthTag: "tag",
+      expiresAt: Date.now() + 3_600_000,
+      cloudId: "cloud-1",
+      siteUrl: "https://team.atlassian.net",
+      scopes: ["read:jira-work"],
+      connectedAt: Date.now(),
+      lastRefreshedAt: Date.now(),
+    })
+  );
+}
+
+async function seedMappingWithWebhook(
+  t: T,
+  roomId: Id<"rooms">,
+  connectionId: Id<"integrationConnections">,
+  jiraWebhookId: string
+): Promise<Id<"integrationMappings">> {
+  return t.run((ctx) =>
+    ctx.db.insert("integrationMappings", {
+      roomId,
+      connectionId,
+      provider: "jira",
+      jiraProjectKey: "PROJ",
+      jiraWebhookId,
+      jiraWebhookRegisteredAt: Date.now(),
+      autoImport: false,
+      autoPushEstimates: true,
+      createdAt: Date.now(),
+    })
+  );
 }
 
 async function seedRoom(t: T): Promise<Id<"rooms">> {
@@ -158,20 +219,120 @@ async function seedFullRoom(
   });
 }
 
-describe("deleteRoomAggregate", () => {
-  it("deletes the room and one row in every room-owned table", async () => {
+describe("deleteRoomAggregateChunk (registered continuation)", () => {
+  it("deletes the room and one row in every room-owned table through the continuation loop", async () => {
     const t = convexTest(schema, modules);
     const { roomId } = await seedFullRoom(t);
 
-    await t.run((ctx) => Cleanup.cleanupRoom(ctx, roomId));
+    // Phase 1 deletes the issue batch first and asks for a continuation…
+    const first = await t.mutation(internal.maintenance.deleteRoomAggregateChunk, {
+      roomId,
+    });
+    expect(first.done).toBe(false);
+    // …which the scheduled follow-up mutations complete.
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
 
-    // Against the old cleanupRoom, `issues` was never deleted, so
-    // countRows("issues") would still be 1 and this test would fail.
     expect(await countRows(t, "rooms")).toBe(0);
     for (const table of ROOM_OWNED_TABLES) {
       expect(await countRows(t, table)).toBe(0);
     }
     expect(await countRows(t, "issueLinks")).toBe(0);
+    // The integration connection is user-owned, not room-owned: it survives.
+    expect(await countRows(t, "integrationConnections")).toBe(1);
+  });
+
+  it("schedules webhook deregistration before deleting a mapped integration row", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userId = await t.run((ctx) =>
+      ctx.db.insert("users", {
+        authUserId: `auth-${crypto.randomUUID()}`,
+        name: "U",
+        createdAt: Date.now(),
+      })
+    );
+    const connectionId = await seedConnection(t, userId);
+    await seedMappingWithWebhook(t, roomId, connectionId, "wh-room");
+
+    const step = await t.run((ctx) =>
+      RoomAggregate.deleteRoomAggregateChunk(ctx, roomId)
+    );
+
+    expect(step.done).toBe(true);
+    expect(await countRows(t, "integrationMappings")).toBe(0);
+    expect(await countRows(t, "rooms")).toBe(0);
+
+    // Deleting the mapping alone would orphan the remote webhook — the
+    // cascade must schedule the deregistration, and the user-owned
+    // connection row must survive so that action can still authenticate.
+    const deregistrations = await scheduledByName(t, ":deregisterWebhook");
+    expect(deregistrations).toHaveLength(1);
+    expect(
+      (deregistrations[0].args as [{ jiraWebhookId: string }])[0].jiraWebhookId
+    ).toBe("wh-room");
+    expect(await countRows(t, "integrationConnections")).toBe(1);
+  });
+});
+
+describe("deleteRoomAggregateChunk (batching)", () => {
+  it("deletes issues and their links in batches, the room row only once every table reads empty", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    for (const sequentialId of [1, 2, 3]) {
+      const issueId = await seedIssue(t, roomId, sequentialId);
+      await seedIssueLink(t, issueId);
+    }
+
+    // Batch size 1: each step deletes exactly one issue plus its one link.
+    for (const issuesLeft of [2, 1, 0]) {
+      const step = await t.run((ctx) =>
+        RoomAggregate.deleteRoomAggregateChunk(ctx, roomId, 1)
+      );
+      expect(step).toEqual({ done: false, deleted: 2 });
+      expect(await countRows(t, "issues")).toBe(issuesLeft);
+      expect(await countRows(t, "issueLinks")).toBe(issuesLeft);
+      // The room row survives until every owned table reads empty.
+      expect(await countRows(t, "rooms")).toBe(1);
+    }
+
+    const final = await t.run((ctx) =>
+      RoomAggregate.deleteRoomAggregateChunk(ctx, roomId, 1)
+    );
+    expect(final).toEqual({ done: true, deleted: 1 }); // the room row itself
+    expect(await countRows(t, "rooms")).toBe(0);
+  });
+});
+
+describe("removeInactiveRooms", () => {
+  it("schedules one cascade per inactive room and leaves active rooms alone", async () => {
+    const t = convexTest(schema, modules);
+    const inactiveId = await t.run((ctx) =>
+      ctx.db.insert("rooms", {
+        name: "Stale",
+        autoCompleteVoting: true,
+        isGameOver: false,
+        createdAt: Date.now() - 10 * 24 * 60 * 60 * 1000,
+        lastActivityAt: Date.now() - 10 * 24 * 60 * 60 * 1000,
+      })
+    );
+    const activeId = await seedRoom(t);
+
+    const result = await t.mutation(internal.cleanup.removeInactiveRooms, {});
+
+    expect(result.roomsScheduled).toBe(1);
+    const cascades = await scheduledByName(t, ":deleteRoomAggregateChunk");
+    expect(cascades).toHaveLength(1);
+    expect((cascades[0].args as [{ roomId: string }])[0].roomId).toBe(
+      inactiveId
+    );
+
+    // Nothing is deleted synchronously — each room's cascade is its own
+    // mutation, so one oversized room can neither blow the cron's
+    // transaction limits nor take the other rooms down with it.
+    expect(await countRows(t, "rooms")).toBe(2);
+    await t.finishAllScheduledFunctions(vi.runAllTimers);
+    expect(await countRows(t, "rooms")).toBe(1);
+    expect(await t.run((ctx) => ctx.db.get(activeId))).not.toBeNull();
   });
 });
 

--- a/convex/roomAggregate.test.ts
+++ b/convex/roomAggregate.test.ts
@@ -1,0 +1,247 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+import type { Id } from "./_generated/dataModel";
+import * as Cleanup from "./model/cleanup";
+import { ROOM_OWNED_TABLES, type RoomOwnedTable } from "./model/roomAggregate";
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+type CountedTable =
+  | RoomOwnedTable
+  | "issueLinks"
+  | "rooms"
+  | "users"
+  | "integrationConnections"
+  | "webhookEvents";
+
+async function countRows(t: T, table: CountedTable): Promise<number> {
+  return t.run(async (ctx) => (await ctx.db.query(table).collect()).length);
+}
+
+async function seedRoom(t: T): Promise<Id<"rooms">> {
+  return t.run((ctx) =>
+    ctx.db.insert("rooms", {
+      name: "R",
+      autoCompleteVoting: true,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    })
+  );
+}
+
+async function seedIssue(
+  t: T,
+  roomId: Id<"rooms">,
+  sequentialId = 1
+): Promise<Id<"issues">> {
+  return t.run((ctx) =>
+    ctx.db.insert("issues", {
+      roomId,
+      sequentialId,
+      title: `Issue ${sequentialId}`,
+      status: "pending",
+      createdAt: Date.now(),
+      order: sequentialId,
+    })
+  );
+}
+
+async function seedIssueLink(
+  t: T,
+  issueId: Id<"issues">
+): Promise<Id<"issueLinks">> {
+  return t.run((ctx) =>
+    ctx.db.insert("issueLinks", {
+      issueId,
+      provider: "jira",
+      externalId: `PROJ-${crypto.randomUUID()}`,
+      externalUrl: "https://example.atlassian.net/browse/PROJ-1",
+      lastSyncedAt: Date.now(),
+    })
+  );
+}
+
+/**
+ * Seeds one room with one row in EVERY room-owned table (plus the user and
+ * integration connection those rows reference).
+ */
+async function seedFullRoom(
+  t: T
+): Promise<{ roomId: Id<"rooms">; userId: Id<"users">; issueId: Id<"issues"> }> {
+  return t.run(async (ctx) => {
+    const roomId = await ctx.db.insert("rooms", {
+      name: "R",
+      autoCompleteVoting: true,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    });
+    const userId = await ctx.db.insert("users", {
+      authUserId: `auth-${crypto.randomUUID()}`,
+      name: "U",
+      createdAt: Date.now(),
+    });
+    await ctx.db.insert("roomMemberships", {
+      roomId,
+      userId,
+      isSpectator: false,
+      joinedAt: Date.now(),
+    });
+    await ctx.db.insert("votes", {
+      roomId,
+      userId,
+      cardLabel: "5",
+      cardValue: 5,
+    });
+    const issueId = await ctx.db.insert("issues", {
+      roomId,
+      sequentialId: 1,
+      title: "Issue 1",
+      status: "voting",
+      createdAt: Date.now(),
+      order: 0,
+    });
+    await ctx.db.insert("canvasNodes", {
+      roomId,
+      nodeId: "session-current",
+      type: "session",
+      position: { x: 0, y: 0 },
+      data: {},
+      lastUpdatedAt: Date.now(),
+    });
+    await ctx.db.insert("votingTimestamps", {
+      roomId,
+      issueId,
+      votingStartedAt: Date.now(),
+      roundNumber: 1,
+    });
+    await ctx.db.insert("individualVotes", {
+      roomId,
+      issueId,
+      userId,
+      cardLabel: "5",
+      votedAt: Date.now(),
+    });
+    const connectionId = await ctx.db.insert("integrationConnections", {
+      userId,
+      provider: "jira",
+      encryptedAccessToken: "token",
+      accessTokenIv: "iv",
+      accessTokenAuthTag: "tag",
+      expiresAt: Date.now(),
+      scopes: [],
+      connectedAt: Date.now(),
+      lastRefreshedAt: Date.now(),
+    });
+    await ctx.db.insert("integrationMappings", {
+      roomId,
+      connectionId,
+      provider: "jira",
+      autoImport: false,
+      autoPushEstimates: false,
+      createdAt: Date.now(),
+    });
+    await ctx.db.insert("issueLinks", {
+      issueId,
+      provider: "jira",
+      externalId: "PROJ-1",
+      externalUrl: "https://example.atlassian.net/browse/PROJ-1",
+      lastSyncedAt: Date.now(),
+    });
+    return { roomId, userId, issueId };
+  });
+}
+
+describe("deleteRoomAggregate", () => {
+  it("deletes the room and one row in every room-owned table", async () => {
+    const t = convexTest(schema, modules);
+    const { roomId } = await seedFullRoom(t);
+
+    await t.run((ctx) => Cleanup.cleanupRoom(ctx, roomId));
+
+    // Against the old cleanupRoom, `issues` was never deleted, so
+    // countRows("issues") would still be 1 and this test would fail.
+    expect(await countRows(t, "rooms")).toBe(0);
+    for (const table of ROOM_OWNED_TABLES) {
+      expect(await countRows(t, table)).toBe(0);
+    }
+    expect(await countRows(t, "issueLinks")).toBe(0);
+  });
+});
+
+describe("cleanupOrphanedData", () => {
+  it("sweeps an issue whose room was deleted out from under it", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const issueId = await seedIssue(t, roomId);
+    await seedIssueLink(t, issueId);
+
+    // Delete the room directly, bypassing the cascade — this is exactly how
+    // the old cleanupRoom used to leave issues behind.
+    await t.run((ctx) => ctx.db.delete(roomId));
+
+    const result = await t.mutation(internal.maintenance.cleanupOrphanedData, {});
+
+    expect(result.orphanedIssues).toBe(1);
+    // The orphaned issue's link is collected in the same sweep.
+    expect(result.orphanedIssueLinks).toBe(1);
+    expect(await countRows(t, "issues")).toBe(0);
+    expect(await countRows(t, "issueLinks")).toBe(0);
+  });
+
+  it("sweeps an issueLink whose issue is gone while its room lives", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const keptIssueId = await seedIssue(t, roomId, 1);
+    const goneIssueId = await seedIssue(t, roomId, 2);
+    await seedIssueLink(t, keptIssueId);
+    await seedIssueLink(t, goneIssueId);
+
+    await t.run((ctx) => ctx.db.delete(goneIssueId));
+
+    const result = await t.mutation(internal.maintenance.cleanupOrphanedData, {});
+
+    expect(result.orphanedIssues).toBe(0);
+    expect(result.orphanedIssueLinks).toBe(1);
+    // Live rows survive.
+    expect(await countRows(t, "rooms")).toBe(1);
+    expect(await countRows(t, "issues")).toBe(1);
+    expect(await countRows(t, "issueLinks")).toBe(1);
+  });
+});
+
+describe("dangerouslyDeleteAllData", () => {
+  it("still clears user-scoped tables and now clears every room-owned table", async () => {
+    const t = convexTest(schema, modules);
+    await seedFullRoom(t);
+    await t.run((ctx) =>
+      ctx.db.insert("webhookEvents", {
+        eventKey: "evt-1",
+        provider: "jira",
+        processedAt: Date.now(),
+      })
+    );
+
+    await t.mutation(internal.admin.dangerouslyDeleteAllData, {
+      confirm: "I understand this will delete all data permanently",
+    });
+
+    // User-scoped and global tables it cleared before.
+    expect(await countRows(t, "users")).toBe(0);
+    expect(await countRows(t, "integrationConnections")).toBe(0);
+    expect(await countRows(t, "webhookEvents")).toBe(0);
+    // Room-owned tables — including votingTimestamps and individualVotes,
+    // which the old hand-maintained list missed.
+    expect(await countRows(t, "rooms")).toBe(0);
+    for (const table of ROOM_OWNED_TABLES) {
+      expect(await countRows(t, table)).toBe(0);
+    }
+    expect(await countRows(t, "issueLinks")).toBe(0);
+  });
+});

--- a/convex/rooms.ts
+++ b/convex/rooms.ts
@@ -97,11 +97,7 @@ export const toggleAutoComplete = mutation({
   args: { roomId: v.id("rooms") },
   handler: async (ctx, args) => {
     const { room } = await requireCan(ctx, args.roomId, { kind: "category", category: "roomSettings" });
-    // Toggling cancels any active countdown (one seam), then flips the setting.
-    await VotingRound.cancelCountdown(ctx, args.roomId);
-    await ctx.db.patch(args.roomId, {
-      autoCompleteVoting: !room.autoCompleteVoting,
-    });
+    await VotingRound.setAutoComplete(ctx, args.roomId, !room.autoCompleteVoting);
   },
 });
 

--- a/convex/timer.ts
+++ b/convex/timer.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import * as Timer from "./model/timer";
-import { requireRoomMember } from "./model/auth";
+import { requireRoomMember, requireActingUser } from "./model/auth";
 
 // Start the timer
 export const startTimer = mutation({
@@ -11,10 +11,7 @@ export const startTimer = mutation({
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot act as another user");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId);
     await Timer.updateTimerState(ctx, {
       roomId: args.roomId,
       nodeId: args.nodeId,
@@ -32,10 +29,7 @@ export const pauseTimer = mutation({
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot act as another user");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId);
     await Timer.updateTimerState(ctx, {
       roomId: args.roomId,
       nodeId: args.nodeId,
@@ -53,10 +47,7 @@ export const resetTimer = mutation({
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot act as another user");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId);
     await Timer.updateTimerState(ctx, {
       roomId: args.roomId,
       nodeId: args.nodeId,
@@ -67,12 +58,14 @@ export const resetTimer = mutation({
 });
 
 // Get current timer state
+// Requires room membership: timer state is private to the room.
 export const getTimerState = query({
   args: {
     roomId: v.id("rooms"),
     nodeId: v.string(),
   },
   handler: async (ctx, args) => {
+    await requireRoomMember(ctx, args.roomId);
     return await Timer.getTimerState(ctx, args);
   },
 });

--- a/convex/timer.ts
+++ b/convex/timer.ts
@@ -1,7 +1,7 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import { mutation } from "./_generated/server";
 import * as Timer from "./model/timer";
-import { requireRoomMember, requireActingUser } from "./model/auth";
+import { requireActingUser } from "./model/auth";
 
 // Start the timer
 export const startTimer = mutation({
@@ -54,18 +54,5 @@ export const resetTimer = mutation({
       action: "reset",
       userId: args.userId,
     });
-  },
-});
-
-// Get current timer state
-// Requires room membership: timer state is private to the room.
-export const getTimerState = query({
-  args: {
-    roomId: v.id("rooms"),
-    nodeId: v.string(),
-  },
-  handler: async (ctx, args) => {
-    await requireRoomMember(ctx, args.roomId);
-    return await Timer.getTimerState(ctx, args);
   },
 });

--- a/convex/timerState.test.ts
+++ b/convex/timerState.test.ts
@@ -1,0 +1,315 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect, vi, afterEach } from "vitest";
+import schema from "./schema";
+import type { Id } from "./_generated/dataModel";
+import {
+  calculateCurrentTime,
+  formatTimerTime,
+  validateTimerAction,
+  type TimerState,
+} from "./timerState";
+import * as Timer from "./model/timer";
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+const NOW = new Date("2026-08-03T12:00:00Z").getTime();
+
+function stopped(overrides: Partial<TimerState> = {}): TimerState {
+  return {
+    startedAt: null,
+    pausedAt: null,
+    elapsedSeconds: 0,
+    isRunning: false,
+    lastUpdatedBy: null,
+    lastAction: null,
+    ...overrides,
+  };
+}
+
+describe("calculateCurrentTime", () => {
+  it("a stopped timer reads its accumulated elapsed seconds", () => {
+    const t = calculateCurrentTime(stopped({ elapsedSeconds: 42 }), NOW);
+    expect(t).toEqual({
+      currentSeconds: 42,
+      isRunning: false,
+      displayTime: "0:42",
+    });
+  });
+
+  it("a reset timer reads 0:00", () => {
+    const t = calculateCurrentTime(stopped(), NOW);
+    expect(t.currentSeconds).toBe(0);
+    expect(t.displayTime).toBe("0:00");
+  });
+
+  it("a running timer adds the time since startedAt to the accumulated elapsed", () => {
+    // Paused at 30s, restarted 90s ago: 30 + 90 = 120s.
+    const t = calculateCurrentTime(
+      stopped({
+        elapsedSeconds: 30,
+        isRunning: true,
+        startedAt: NOW - 90_000,
+        lastAction: "start",
+      }),
+      NOW
+    );
+    expect(t).toEqual({
+      currentSeconds: 120,
+      isRunning: true,
+      displayTime: "2:00",
+    });
+  });
+
+  it("floors fractional seconds from the running segment", () => {
+    const t = calculateCurrentTime(
+      stopped({ isRunning: true, startedAt: NOW - 65_900 }),
+      NOW
+    );
+    expect(t.currentSeconds).toBe(65);
+    expect(t.displayTime).toBe("1:05");
+  });
+
+  it("treats a missing isRunning (pre-sync rows) as stopped", () => {
+    const legacy: TimerState = stopped({ elapsedSeconds: 7 });
+    delete legacy.isRunning;
+    const t = calculateCurrentTime(legacy, NOW);
+    expect(t).toEqual({
+      currentSeconds: 7,
+      isRunning: false,
+      displayTime: "0:07",
+    });
+  });
+
+  it("a running flag without startedAt contributes nothing", () => {
+    const t = calculateCurrentTime(
+      stopped({ elapsedSeconds: 5, isRunning: true, startedAt: null }),
+      NOW
+    );
+    expect(t.currentSeconds).toBe(5);
+  });
+});
+
+describe("formatTimerTime", () => {
+  it("formats MM:SS with zero-padded seconds and unbounded minutes", () => {
+    expect(formatTimerTime(0)).toBe("0:00");
+    expect(formatTimerTime(9)).toBe("0:09");
+    expect(formatTimerTime(59)).toBe("0:59");
+    expect(formatTimerTime(60)).toBe("1:00");
+    expect(formatTimerTime(599)).toBe("9:59");
+    expect(formatTimerTime(600)).toBe("10:00");
+    expect(formatTimerTime(3600)).toBe("60:00");
+  });
+
+  it("floors fractional input", () => {
+    expect(formatTimerTime(65.9)).toBe("1:05");
+  });
+});
+
+describe("validateTimerAction", () => {
+  it("start requires a stopped timer", () => {
+    expect(() =>
+      validateTimerAction(stopped({ isRunning: true }), "start")
+    ).toThrow("Timer is already running");
+    expect(() => validateTimerAction(stopped(), "start")).not.toThrow();
+  });
+
+  it("pause requires a running timer", () => {
+    expect(() => validateTimerAction(stopped(), "pause")).toThrow(
+      "Timer is not running"
+    );
+    expect(() =>
+      validateTimerAction(stopped({ isRunning: true }), "pause")
+    ).not.toThrow();
+  });
+
+  it("reset is always allowed", () => {
+    expect(() => validateTimerAction(stopped(), "reset")).not.toThrow();
+    expect(() =>
+      validateTimerAction(stopped({ isRunning: true }), "reset")
+    ).not.toThrow();
+  });
+
+  it("rejects unknown actions", () => {
+    expect(() =>
+      validateTimerAction(stopped(), "bogus" as "start")
+    ).toThrow("Invalid timer action: bogus");
+  });
+});
+
+// --- Model transitions (convex-test, pattern: votingRound.test.ts) ---------
+
+async function seedRoom(t: T): Promise<Id<"rooms">> {
+  return t.run((ctx) =>
+    ctx.db.insert("rooms", {
+      name: "R",
+      autoCompleteVoting: false,
+      isGameOver: false,
+      createdAt: Date.now(),
+      lastActivityAt: Date.now(),
+    })
+  );
+}
+
+async function seedUser(t: T): Promise<Id<"users">> {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      authUserId: `auth-${crypto.randomUUID()}`,
+      name: "U",
+      createdAt: Date.now(),
+    })
+  );
+}
+
+async function seedTimerNode(
+  t: T,
+  roomId: Id<"rooms">,
+  data: TimerState = stopped(),
+  nodeId = "timer"
+): Promise<void> {
+  await t.run((ctx) =>
+    ctx.db.insert("canvasNodes", {
+      roomId,
+      nodeId,
+      type: "timer",
+      position: { x: 0, y: 0 },
+      data,
+      lastUpdatedAt: Date.now(),
+    })
+  );
+}
+
+async function readTimerData(
+  t: T,
+  roomId: Id<"rooms">,
+  nodeId = "timer"
+): Promise<TimerState> {
+  return t.run(async (ctx) => {
+    const node = await ctx.db
+      .query("canvasNodes")
+      .withIndex("by_room_node", (q) =>
+        q.eq("roomId", roomId).eq("nodeId", nodeId)
+      )
+      .unique();
+    return (node as { data: TimerState } | null)!.data;
+  });
+}
+
+describe("Timer.updateTimerState", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("start sets isRunning, startedAt, and the tracking fields", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(NOW);
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userId = await seedUser(t);
+    await seedTimerNode(t, roomId);
+
+    await t.run((ctx) =>
+      Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "start", userId })
+    );
+
+    expect(await readTimerData(t, roomId)).toEqual({
+      startedAt: NOW,
+      pausedAt: null,
+      elapsedSeconds: 0,
+      isRunning: true,
+      lastUpdatedBy: userId,
+      lastAction: "start",
+    });
+  });
+
+  it("start on a running timer throws through the model interface", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userId = await seedUser(t);
+    await seedTimerNode(t, roomId, stopped({ isRunning: true, startedAt: NOW }));
+
+    await expect(
+      t.run((ctx) =>
+        Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "start", userId })
+      )
+    ).rejects.toThrow("Timer is already running");
+  });
+
+  it("pause accumulates the running segment into elapsedSeconds", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userId = await seedUser(t);
+
+    vi.setSystemTime(NOW);
+    await seedTimerNode(t, roomId);
+    await t.run((ctx) =>
+      Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "start", userId })
+    );
+
+    vi.setSystemTime(NOW + 90_500);
+    await t.run((ctx) =>
+      Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "pause", userId })
+    );
+
+    expect(await readTimerData(t, roomId)).toEqual({
+      startedAt: null,
+      pausedAt: NOW + 90_500,
+      elapsedSeconds: 90, // floored from 90.5
+      isRunning: false,
+      lastUpdatedBy: userId,
+      lastAction: "pause",
+    });
+  });
+
+  it("pause on a stopped timer throws through the model interface", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userId = await seedUser(t);
+    await seedTimerNode(t, roomId);
+
+    await expect(
+      t.run((ctx) =>
+        Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "pause", userId })
+      )
+    ).rejects.toThrow("Timer is not running");
+  });
+
+  it("reset zeroes the accumulated time and stops the timer", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userId = await seedUser(t);
+    await seedTimerNode(
+      t,
+      roomId,
+      stopped({ elapsedSeconds: 300, isRunning: true, startedAt: NOW })
+    );
+
+    await t.run((ctx) =>
+      Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "reset", userId })
+    );
+
+    expect(await readTimerData(t, roomId)).toEqual({
+      startedAt: null,
+      pausedAt: null,
+      elapsedSeconds: 0,
+      isRunning: false,
+      lastUpdatedBy: userId,
+      lastAction: "reset",
+    });
+  });
+
+  it("throws when the timer node does not exist", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userId = await seedUser(t);
+
+    await expect(
+      t.run((ctx) =>
+        Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "start", userId })
+      )
+    ).rejects.toThrow("Timer node not found");
+  });
+});

--- a/convex/timerState.test.ts
+++ b/convex/timerState.test.ts
@@ -264,6 +264,47 @@ describe("Timer.updateTimerState", () => {
     });
   });
 
+  it("two full pause/resume cycles accumulate both running segments", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t);
+    const userId = await seedUser(t);
+
+    vi.setSystemTime(NOW);
+    await seedTimerNode(t, roomId);
+    await t.run((ctx) =>
+      Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "start", userId })
+    );
+
+    // First cycle: run 60s, pause.
+    vi.setSystemTime(NOW + 60_000);
+    await t.run((ctx) =>
+      Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "pause", userId })
+    );
+
+    // Second cycle: resume 90s later, run 30s, pause again.
+    vi.setSystemTime(NOW + 150_000);
+    await t.run((ctx) =>
+      Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "start", userId })
+    );
+    vi.setSystemTime(NOW + 180_000);
+    await t.run((ctx) =>
+      Timer.updateTimerState(ctx, { roomId, nodeId: "timer", action: "pause", userId })
+    );
+
+    const data = await readTimerData(t, roomId);
+    expect(data).toEqual({
+      startedAt: null,
+      pausedAt: NOW + 180_000,
+      elapsedSeconds: 90, // 60s first segment + 30s second segment
+      isRunning: false,
+      lastUpdatedBy: userId,
+      lastAction: "pause",
+    });
+    // And the reading matches the accumulated state.
+    expect(calculateCurrentTime(data, NOW + 180_000).displayTime).toBe("1:30");
+  });
+
   it("pause on a stopped timer throws through the model interface", async () => {
     const t = convexTest(schema, modules);
     const roomId = await seedRoom(t);

--- a/convex/timerState.ts
+++ b/convex/timerState.ts
@@ -1,0 +1,91 @@
+import type { Id } from "./_generated/dataModel";
+
+/**
+ * timerState — the ONE declaration of the canvas timer node's persisted state
+ * and its time math, kept at the Convex root (alongside `summarize`, `phase`,
+ * and the permission decision) so the backend model and the browser compute
+ * the same reading from the same shape. Pure: no IO, no Convex runtime.
+ */
+
+/** A control action on the timer (the transitions the model accepts). */
+export type TimerAction = "start" | "pause" | "reset";
+
+/**
+ * The persisted `data` payload of a timer canvas node (stored as `v.any()`,
+ * so this is the read-side contract). `isRunning` is optional only because
+ * rows written before it existed omit it — readers default it to `false`.
+ * Declared as an object-literal alias (not an interface) so view-side
+ * compositions stay assignable to xyflow's `Record<string, unknown>` node data.
+ */
+export type TimerState = {
+  startedAt: number | null; // server timestamp of the last start
+  pausedAt: number | null; // server timestamp of the last pause
+  elapsedSeconds: number; // accumulated seconds, excluding the current run
+  isRunning?: boolean;
+  lastUpdatedBy: Id<"users"> | null;
+  lastAction: TimerAction | null;
+};
+
+/** A point-in-time reading derived from the persisted state. */
+export type CurrentTimerTime = {
+  currentSeconds: number;
+  isRunning: boolean;
+  displayTime: string; // MM:SS
+};
+
+/** Formats a (possibly fractional) second count as MM:SS. */
+export function formatTimerTime(totalSeconds: number): string {
+  const seconds = Math.floor(totalSeconds);
+  const minutes = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
+}
+
+/**
+ * The current reading of a persisted timer: accumulated `elapsedSeconds` plus,
+ * while running, the time since `startedAt`. `now` is injectable for tests.
+ */
+export function calculateCurrentTime(
+  timer: TimerState,
+  now: number = Date.now()
+): CurrentTimerTime {
+  const isRunning = timer.isRunning ?? false;
+  let currentSeconds = timer.elapsedSeconds;
+
+  if (isRunning && timer.startedAt) {
+    currentSeconds += (now - timer.startedAt) / 1000;
+  }
+
+  return {
+    currentSeconds: Math.floor(currentSeconds),
+    isRunning,
+    displayTime: formatTimerTime(currentSeconds),
+  };
+}
+
+/**
+ * Validates a timer transition: start requires stopped, pause requires
+ * running, reset is always allowed. Throws on an invalid transition.
+ */
+export function validateTimerAction(
+  current: TimerState,
+  action: TimerAction
+): void {
+  switch (action) {
+    case "start":
+      if (current.isRunning) {
+        throw new Error("Timer is already running");
+      }
+      break;
+    case "pause":
+      if (!current.isRunning) {
+        throw new Error("Timer is not running");
+      }
+      break;
+    case "reset":
+      // Reset is always allowed
+      break;
+    default:
+      throw new Error(`Invalid timer action: ${action}`);
+  }
+}

--- a/convex/tokenVault.test.ts
+++ b/convex/tokenVault.test.ts
@@ -118,6 +118,21 @@ describe("encrypt/decrypt round-trip", () => {
       TokenVault.decryptAccessToken(tamperedTag, TEST_KEY)
     ).rejects.toThrow();
   });
+
+  it("rejects empty tokens up front instead of producing empty ciphertext", async () => {
+    // AES-GCM ciphertext length equals plaintext length, so an empty token
+    // would round-trip to "" and then fail the write-side tripwire as
+    // "possible plaintext" — the vault names the real problem instead.
+    await expect(
+      TokenVault.encryptTokens({ accessToken: "" }, TEST_KEY)
+    ).rejects.toThrow("Cannot encrypt an empty access token");
+    await expect(
+      TokenVault.encryptTokens(
+        { accessToken: PLAINTEXT_ACCESS, refreshToken: "" },
+        TEST_KEY
+      )
+    ).rejects.toThrow("Cannot encrypt an empty refresh token");
+  });
 });
 
 describe("isAccessTokenFresh", () => {

--- a/convex/tokenVault.test.ts
+++ b/convex/tokenVault.test.ts
@@ -1,0 +1,297 @@
+/// <reference types="vite/client" />
+import { convexTest, type TestConvex } from "convex-test";
+import { describe, it, expect } from "vitest";
+import { internal } from "./_generated/api";
+import schema from "./schema";
+import type { Id } from "./_generated/dataModel";
+import * as TokenVault from "./model/tokenVault";
+import * as Integrations from "./model/integrations";
+
+const modules = import.meta.glob("./**/*.*s");
+
+type T = TestConvex<typeof schema>;
+
+// 64 lowercase hex chars — a valid key, injected explicitly so the tests never
+// touch process.env.
+const TEST_KEY = "0123456789abcdef".repeat(4);
+
+// Plaintext fixtures deliberately contain non-hex characters so they can
+// never collide with ciphertext material.
+const PLAINTEXT_ACCESS = "plaintext-access-token!";
+const PLAINTEXT_REFRESH = "plaintext-refresh-token?";
+
+async function seedUser(t: T, authUserId: string): Promise<Id<"users">> {
+  return t.run((ctx) =>
+    ctx.db.insert("users", {
+      authUserId,
+      name: "U",
+      createdAt: Date.now(),
+    })
+  );
+}
+
+async function saveViaVault(
+  t: T,
+  userId: Id<"users">
+): Promise<Id<"integrationConnections">> {
+  const enc = await TokenVault.encryptTokens(
+    { accessToken: PLAINTEXT_ACCESS, refreshToken: PLAINTEXT_REFRESH },
+    TEST_KEY
+  );
+  return t.mutation(internal.integrations.jira.saveConnection, {
+    userId,
+    provider: "jira",
+    ...enc,
+    expiresAt: Date.now() + 3_600_000,
+    scopes: ["read:jira-work"],
+  });
+}
+
+describe("encrypt/decrypt round-trip", () => {
+  it("round-trips both tokens through the vault", async () => {
+    const enc = await TokenVault.encryptTokens(
+      { accessToken: PLAINTEXT_ACCESS, refreshToken: PLAINTEXT_REFRESH },
+      TEST_KEY
+    );
+
+    expect(await TokenVault.decryptAccessToken(enc, TEST_KEY)).toBe(
+      PLAINTEXT_ACCESS
+    );
+    expect(await TokenVault.decryptRefreshToken(enc, TEST_KEY)).toBe(
+      PLAINTEXT_REFRESH
+    );
+  });
+
+  it("emits only hex ciphertext fields", async () => {
+    const enc = await TokenVault.encryptTokens(
+      { accessToken: PLAINTEXT_ACCESS, refreshToken: PLAINTEXT_REFRESH },
+      TEST_KEY
+    );
+
+    expect(enc.encryptedAccessToken).toMatch(/^[0-9a-f]+$/);
+    expect(enc.accessTokenIv).toMatch(/^[0-9a-f]{24}$/);
+    expect(enc.accessTokenAuthTag).toMatch(/^[0-9a-f]{32}$/);
+    expect(enc.encryptedRefreshToken).toMatch(/^[0-9a-f]+$/);
+    expect(JSON.stringify(enc)).not.toContain(PLAINTEXT_ACCESS);
+    expect(JSON.stringify(enc)).not.toContain(PLAINTEXT_REFRESH);
+  });
+
+  it("omits refresh fields when no refresh token is given", async () => {
+    const enc = await TokenVault.encryptTokens(
+      { accessToken: PLAINTEXT_ACCESS },
+      TEST_KEY
+    );
+
+    expect(enc.encryptedRefreshToken).toBeUndefined();
+    expect(enc.refreshTokenIv).toBeUndefined();
+    expect(enc.refreshTokenAuthTag).toBeUndefined();
+    await expect(TokenVault.decryptRefreshToken(enc, TEST_KEY)).rejects.toThrow(
+      "No refresh token available for this connection"
+    );
+  });
+
+  it("rejects tampered ciphertext", async () => {
+    const enc = await TokenVault.encryptTokens(
+      { accessToken: PLAINTEXT_ACCESS },
+      TEST_KEY
+    );
+
+    // Flip one byte inside the ciphertext.
+    const tampered = {
+      ...enc,
+      encryptedAccessToken:
+        (enc.encryptedAccessToken[0] === "0" ? "1" : "0") +
+        enc.encryptedAccessToken.slice(1),
+    };
+    await expect(
+      TokenVault.decryptAccessToken(tampered, TEST_KEY)
+    ).rejects.toThrow();
+
+    // Flip one byte inside the auth tag.
+    const tamperedTag = {
+      ...enc,
+      accessTokenAuthTag:
+        (enc.accessTokenAuthTag[0] === "0" ? "1" : "0") +
+        enc.accessTokenAuthTag.slice(1),
+    };
+    await expect(
+      TokenVault.decryptAccessToken(tamperedTag, TEST_KEY)
+    ).rejects.toThrow();
+  });
+});
+
+describe("isAccessTokenFresh", () => {
+  const now = 1_000_000_000;
+
+  it("applies the expiresAt > now + 60s rule at the boundary", () => {
+    expect(TokenVault.isAccessTokenFresh(now + 60_001, now)).toBe(true);
+    expect(TokenVault.isAccessTokenFresh(now + 60_000, now)).toBe(false);
+    expect(TokenVault.isAccessTokenFresh(now + 1, now)).toBe(false);
+    expect(TokenVault.isAccessTokenFresh(now - 1, now)).toBe(false);
+  });
+});
+
+describe("key validation", () => {
+  it("accepts only a 64-char hex key", () => {
+    expect(TokenVault.assertValidEncryptionKey(TEST_KEY)).toBe(TEST_KEY);
+    expect(TokenVault.assertValidEncryptionKey("A".repeat(64))).toBe(
+      "A".repeat(64)
+    );
+
+    expect(() => TokenVault.assertValidEncryptionKey(undefined)).toThrow(
+      "Missing TOKEN_ENCRYPTION_KEY"
+    );
+    expect(() => TokenVault.assertValidEncryptionKey("")).toThrow(
+      "Missing TOKEN_ENCRYPTION_KEY"
+    );
+    expect(() => TokenVault.assertValidEncryptionKey("0".repeat(63))).toThrow(
+      "Invalid TOKEN_ENCRYPTION_KEY"
+    );
+    expect(() => TokenVault.assertValidEncryptionKey("z".repeat(64))).toThrow(
+      "Invalid TOKEN_ENCRYPTION_KEY"
+    );
+  });
+});
+
+describe("assertEncryptedTokenFields", () => {
+  it("accepts vault output and rejects plaintext or partial refresh triples", async () => {
+    const enc = await TokenVault.encryptTokens(
+      { accessToken: PLAINTEXT_ACCESS, refreshToken: PLAINTEXT_REFRESH },
+      TEST_KEY
+    );
+    expect(() => TokenVault.assertEncryptedTokenFields(enc)).not.toThrow();
+
+    expect(() =>
+      TokenVault.assertEncryptedTokenFields({
+        ...enc,
+        encryptedAccessToken: PLAINTEXT_ACCESS,
+      })
+    ).toThrow(/refusing to store possible plaintext/);
+
+    // Odd-length or empty hex is not AES-GCM output either.
+    expect(() =>
+      TokenVault.assertEncryptedTokenFields({ ...enc, accessTokenIv: "abc" })
+    ).toThrow(/refusing to store possible plaintext/);
+    expect(() =>
+      TokenVault.assertEncryptedTokenFields({ ...enc, accessTokenAuthTag: "" })
+    ).toThrow(/refusing to store possible plaintext/);
+
+    // Refresh fields are all-or-nothing.
+    expect(() =>
+      TokenVault.assertEncryptedTokenFields({
+        ...enc,
+        refreshTokenIv: undefined,
+      })
+    ).toThrow(/all-or-nothing/);
+  });
+});
+
+describe("vault write path (convex-test)", () => {
+  it("persists no plaintext and stores iv/tag-packed ciphertext", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+
+    const connectionId = await saveViaVault(t, userId);
+    const row = await t.run((ctx) => ctx.db.get(connectionId));
+
+    expect(row).not.toBeNull();
+    // No plaintext anywhere in the stored row.
+    expect(JSON.stringify(row)).not.toContain(PLAINTEXT_ACCESS);
+    expect(JSON.stringify(row)).not.toContain(PLAINTEXT_REFRESH);
+    // Ciphertext fields carry the packed hex format.
+    expect(row!.encryptedAccessToken).toMatch(/^[0-9a-f]+$/);
+    expect(row!.accessTokenIv).toMatch(/^[0-9a-f]{24}$/);
+    expect(row!.accessTokenAuthTag).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  it("read-then-decrypt through the model returns the original tokens", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+
+    const connectionId = await saveViaVault(t, userId);
+    const row = await t.run((ctx) => ctx.db.get(connectionId));
+
+    expect(await TokenVault.decryptAccessToken(row!, TEST_KEY)).toBe(
+      PLAINTEXT_ACCESS
+    );
+    expect(await TokenVault.decryptRefreshToken(row!, TEST_KEY)).toBe(
+      PLAINTEXT_REFRESH
+    );
+  });
+
+  it("toConnectionView leaks no ciphertext material", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+
+    const connectionId = await saveViaVault(t, userId);
+    const row = await t.run((ctx) => ctx.db.get(connectionId));
+    const view = Integrations.toConnectionView(row!);
+
+    expect(JSON.stringify(view)).not.toContain(row!.encryptedAccessToken);
+    expect(JSON.stringify(view)).not.toContain(row!.encryptedRefreshToken!);
+    expect(JSON.stringify(view)).not.toContain(row!.accessTokenIv);
+    expect(JSON.stringify(view)).not.toContain(PLAINTEXT_ACCESS);
+  });
+
+  it("updateTokens rewrites the tokens through the vault", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+    const connectionId = await saveViaVault(t, userId);
+    const before = await t.run((ctx) => ctx.db.get(connectionId));
+
+    const NEW_ACCESS = "rotated-access-token!";
+    const NEW_REFRESH = "rotated-refresh-token?";
+    const enc = await TokenVault.encryptTokens(
+      { accessToken: NEW_ACCESS, refreshToken: NEW_REFRESH },
+      TEST_KEY
+    );
+    const newExpiry = Date.now() + 7_200_000;
+    await t.mutation(internal.integrations.jira.updateTokens, {
+      connectionId,
+      ...enc,
+      expiresAt: newExpiry,
+    });
+
+    const after = await t.run((ctx) => ctx.db.get(connectionId));
+    expect(JSON.stringify(after)).not.toContain(NEW_ACCESS);
+    expect(JSON.stringify(after)).not.toContain(NEW_REFRESH);
+    expect(after!.expiresAt).toBe(newExpiry);
+    expect(after!.lastRefreshedAt).toBeGreaterThanOrEqual(
+      before!.lastRefreshedAt
+    );
+    expect(await TokenVault.decryptAccessToken(after!, TEST_KEY)).toBe(
+      NEW_ACCESS
+    );
+    expect(await TokenVault.decryptRefreshToken(after!, TEST_KEY)).toBe(
+      NEW_REFRESH
+    );
+  });
+
+  it("the registered write mutations refuse plaintext token fields", async () => {
+    const t = convexTest(schema, modules);
+    const userId = await seedUser(t, "auth-u");
+
+    await expect(
+      t.mutation(internal.integrations.jira.saveConnection, {
+        userId,
+        provider: "jira",
+        encryptedAccessToken: PLAINTEXT_ACCESS,
+        accessTokenIv: "aa",
+        accessTokenAuthTag: "bb",
+        expiresAt: Date.now(),
+        scopes: [],
+      })
+    ).rejects.toThrow(/refusing to store possible plaintext/);
+
+    const connectionId = await saveViaVault(t, userId);
+    await expect(
+      t.mutation(internal.integrations.jira.updateTokens, {
+        connectionId,
+        encryptedAccessToken: PLAINTEXT_ACCESS,
+        accessTokenIv: "aa",
+        accessTokenAuthTag: "bb",
+        expiresAt: Date.now(),
+      })
+    ).rejects.toThrow(/refusing to store possible plaintext/);
+  });
+});

--- a/convex/users.ts
+++ b/convex/users.ts
@@ -3,7 +3,7 @@ import { v } from "convex/values";
 import * as Users from "./model/users";
 import {
   requireAuth,
-  requireAuthUser,
+  requireActingUser,
   requireCan,
   getOptionalAuthUser,
 } from "./model/auth";
@@ -111,11 +111,8 @@ export const edit = mutation({
     isSpectator: v.optional(v.boolean()),
   },
   handler: async (ctx, args) => {
-    // Verify the caller owns this user
-    const { user } = await requireAuthUser(ctx);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot edit another user");
-    }
+    // Authenticated, in-room, and acting as this userId — the one guard.
+    await requireActingUser(ctx, args.roomId, args.userId, "Cannot edit another user");
 
     await Users.editUser(ctx, {
       userId: args.userId,
@@ -132,11 +129,8 @@ export const leave = mutation({
     roomId: v.id("rooms"),
   },
   handler: async (ctx, args) => {
-    // Verify the caller owns this user
-    const { user } = await requireAuthUser(ctx);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot remove another user");
-    }
+    // Authenticated, in-room, and acting as this userId — the one guard.
+    await requireActingUser(ctx, args.roomId, args.userId, "Cannot remove another user");
 
     await Users.leaveRoom(ctx, args.userId, args.roomId);
   },

--- a/convex/votes.ts
+++ b/convex/votes.ts
@@ -1,7 +1,7 @@
 import { mutation } from "./_generated/server";
 import { v } from "convex/values";
 import * as VotingRound from "./model/votingRound";
-import { requireRoomMember } from "./model/auth";
+import { requireActingUser } from "./model/auth";
 
 export const pickCard = mutation({
   args: {
@@ -14,10 +14,7 @@ export const pickCard = mutation({
     cardIcon: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot vote as another user");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId, "Cannot vote as another user");
     await VotingRound.castVote(ctx, args);
   },
 });
@@ -28,10 +25,7 @@ export const removeCard = mutation({
     userId: v.id("users"),
   },
   handler: async (ctx, args) => {
-    const { user } = await requireRoomMember(ctx, args.roomId);
-    if (user._id !== args.userId) {
-      throw new Error("Cannot remove another user's vote");
-    }
+    await requireActingUser(ctx, args.roomId, args.userId, "Cannot remove another user's vote");
     await VotingRound.retractVote(ctx, args);
   },
 });

--- a/convex/votingRound.test.ts
+++ b/convex/votingRound.test.ts
@@ -2,6 +2,7 @@
 import { convexTest, type TestConvex } from "convex-test";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import schema from "./schema";
+import { api } from "./_generated/api";
 import type { Id } from "./_generated/dataModel";
 import * as VotingRound from "./model/votingRound";
 import * as Issues from "./model/issues";
@@ -1045,5 +1046,139 @@ describe("linkAnonymousToPermanent — identity merge keeps spectators voteless 
         .collect()
     );
     expect(permVotes).toHaveLength(1);
+  });
+});
+
+
+// The round module owns the auto-complete setting: toggling it reconciles the
+// countdown in the same step, so disable can never leave an armed countdown
+// behind and enable arms a fully-voted room immediately (no next-vote wait).
+describe("VotingRound.setAutoComplete", () => {
+  const BASE = new Date("2026-05-23T12:00:00Z").getTime();
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("disable mid-countdown clears the countdown fields and cancels the scheduled reveal", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, { autoCompleteVoting: true });
+    const a = await addMember(t, roomId);
+    await armCountdown(t, roomId, [a]); // all in -> armed
+    const S1 = (await readRoom(t, roomId))!.autoRevealScheduledId!;
+    expect((await readRoom(t, roomId))!.autoRevealCountdownStartedAt).toEqual(
+      expect.any(Number)
+    );
+
+    await t.run((ctx) => VotingRound.setAutoComplete(ctx, roomId, false));
+
+    const room = await readRoom(t, roomId);
+    expect(room?.autoCompleteVoting).toBe(false);
+    expect(room?.autoRevealCountdownStartedAt).toBeUndefined();
+    expect(room?.autoRevealScheduledId).toBeUndefined();
+    const scheduled = await scheduledFns(t);
+    expect(scheduled.find((s) => s._id === S1)?.state.kind).toBe("canceled");
+  });
+
+  it("enable with all votes in arms the countdown immediately", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, { autoCompleteVoting: false });
+    const a = await addMember(t, roomId);
+    await rawVote(t, roomId, a); // fully voted, but the setting was off -> unarmed
+    expect(
+      (await readRoom(t, roomId))?.autoRevealCountdownStartedAt
+    ).toBeUndefined();
+
+    await t.run((ctx) => VotingRound.setAutoComplete(ctx, roomId, true));
+
+    const room = await readRoom(t, roomId);
+    expect(room?.autoCompleteVoting).toBe(true);
+    const token = room!.autoRevealCountdownStartedAt!;
+    expect(token).toEqual(expect.any(Number));
+    const scheduled = await scheduledFns(t);
+    const job = scheduled.find((s) => s._id === room!.autoRevealScheduledId);
+    expect(job?.state.kind).toBe("pending");
+    expect(job?.args[0]).toMatchObject({ roomId, token });
+  });
+
+  it("enable with votes outstanding stays unarmed", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, { autoCompleteVoting: false });
+    const a = await addMember(t, roomId);
+    await addMember(t, roomId); // a second non-spectator who has not voted
+    await rawVote(t, roomId, a);
+
+    await t.run((ctx) => VotingRound.setAutoComplete(ctx, roomId, true));
+
+    const room = await readRoom(t, roomId);
+    expect(room?.autoCompleteVoting).toBe(true);
+    expect(room?.autoRevealCountdownStartedAt).toBeUndefined();
+    expect(room?.autoRevealScheduledId).toBeUndefined();
+    expect(await scheduledFns(t)).toHaveLength(0);
+  });
+
+  it("enable -> disable -> enable re-arms with a fresh token and the stale job is inert", async () => {
+    const t = convexTest(schema, modules);
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(BASE);
+    const roomId = await seedRoom(t, { autoCompleteVoting: false });
+    const a = await addMember(t, roomId);
+    await rawVote(t, roomId, a);
+
+    await t.run((ctx) => VotingRound.setAutoComplete(ctx, roomId, true));
+    const armed = await readRoom(t, roomId);
+    const T1 = armed!.autoRevealCountdownStartedAt!;
+    const S1 = armed!.autoRevealScheduledId!;
+
+    await t.run((ctx) => VotingRound.setAutoComplete(ctx, roomId, false));
+    const scheduled = await scheduledFns(t);
+    expect(scheduled.find((s) => s._id === S1)?.state.kind).toBe("canceled");
+
+    // Re-arm at a later instant so the new token differs from the old one.
+    vi.setSystemTime(BASE + 10_000);
+    await t.run((ctx) => VotingRound.setAutoComplete(ctx, roomId, true));
+    const T2 = (await readRoom(t, roomId))!.autoRevealCountdownStartedAt!;
+    expect(T2).not.toBe(T1);
+
+    // The stale job (had it survived cancel) reveals nothing; the live
+    // countdown's own job still reveals normally.
+    await t.run((ctx) => VotingRound.autoReveal(ctx, { roomId, token: T1 }));
+    expect((await readRoom(t, roomId))?.isGameOver).toBe(false);
+    await t.run((ctx) => VotingRound.autoReveal(ctx, { roomId, token: T2 }));
+    expect((await readRoom(t, roomId))?.isGameOver).toBe(true);
+  });
+
+  it("registered toggleAutoComplete still enforces the room-settings permission", async () => {
+    const t = convexTest(schema, modules);
+    const roomId = await seedRoom(t, { autoCompleteVoting: true });
+    // A participant in a room whose settings category is owner-only.
+    await t.run(async (ctx) => {
+      const userId = await ctx.db.insert("users", {
+        authUserId: "auth-participant",
+        name: "U",
+        createdAt: Date.now(),
+      });
+      await ctx.db.insert("roomMemberships", {
+        roomId,
+        userId,
+        isSpectator: false,
+        joinedAt: Date.now(),
+      });
+      await ctx.db.patch(roomId, {
+        permissions: {
+          revealCards: "everyone",
+          gameFlow: "everyone",
+          issueManagement: "everyone",
+          roomSettings: "owner",
+        },
+      });
+    });
+
+    const asParticipant = t.withIdentity({ subject: "auth-participant" });
+    await expect(
+      asParticipant.mutation(api.rooms.toggleAutoComplete, { roomId })
+    ).rejects.toThrow("Only the owner can do this.");
+    // The denial ran no part of the toggle.
+    expect((await readRoom(t, roomId))?.autoCompleteVoting).toBe(true);
   });
 });

--- a/src/components/auth/auth-provider.tsx
+++ b/src/components/auth/auth-provider.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { createContext, useContext, useMemo, ReactNode } from "react";
+import { usePathname } from "next/navigation";
 import { useConvexAuth, useQuery } from "convex/react";
 import { authClient } from "@/lib/auth-client";
 import { api } from "@/convex/_generated/api";
@@ -38,9 +39,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   const { data: session } = authClient.useSession();
   const authUserId = session?.user?.id;
 
+  // Zero reads on /demo (ADR-0003): the demo is a client-side simulation with
+  // no backend participation, so even this root subscription must not open for a
+  // returning visitor with a live session. Route-based (not the
+  // DemoSimulationProvider seam) because AuthProvider sits at the root, above
+  // the provider. On /demo the session fallbacks below already supply email and
+  // accountType, so context consumers see the same values.
+  const pathname = usePathname();
+  const isDemoRoute = pathname === "/demo" || pathname.startsWith("/demo/");
+
   const globalUser = useQuery(
     api.users.getGlobalUser,
-    isAuthenticated ? {} : "skip"
+    isAuthenticated && !isDemoRoute ? {} : "skip"
   );
 
   // Memoize context value to prevent cascading re-renders in consumers

--- a/src/components/room/canvas-navigation.tsx
+++ b/src/components/room/canvas-navigation.tsx
@@ -31,7 +31,6 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useToast } from "@/hooks/use-toast";
-import { useRoomPresence } from "@/hooks/useRoomPresence";
 import { UserMenu } from "@/components/user-menu";
 import { ShinyButton } from "@/components/ui/shiny-button";
 import { cn } from "@/lib/utils";
@@ -60,7 +59,6 @@ const getFullscreenSupportedServer = () => false;
 
 interface CanvasNavigationProps {
   roomData: RoomWithRelatedData;
-  currentUserId: string;
   onToggleFullscreen?: () => void;
   isFullscreen?: boolean;
   isIssuesPanelOpen: boolean;
@@ -71,7 +69,6 @@ interface CanvasNavigationProps {
 
 export const CanvasNavigation: FC<CanvasNavigationProps> = ({
   roomData,
-  currentUserId,
   onToggleFullscreen,
   isFullscreen = false,
   isIssuesPanelOpen,
@@ -83,12 +80,6 @@ export const CanvasNavigation: FC<CanvasNavigationProps> = ({
   const { zoomIn, zoomOut, fitView } = useReactFlow();
   const router = useRouter();
 
-  // Track user presence inside navigation to avoid canvas re-renders
-  const usersWithPresence = useRoomPresence(
-    roomData.room._id,
-    currentUserId,
-    roomData.users,
-  );
   const { toast } = useToast();
   // Fullscreen support is a client-only capability resolved via the store
   // callbacks defined above — no hydration mismatch, no setState-in-effect.
@@ -189,13 +180,9 @@ export const CanvasNavigation: FC<CanvasNavigationProps> = ({
             </span>
           </div>
 
-          {/* User Presence Avatars */}
+          {/* User Presence Avatars (roster from RoomPresenceProvider) */}
           <div data-testid="mobile-user-avatars">
-            <UserPresenceAvatars
-              users={usersWithPresence}
-              maxVisible={3}
-              size="sm"
-            />
+            <UserPresenceAvatars maxVisible={3} size="sm" />
           </div>
 
           {/* Hamburger Menu */}
@@ -405,11 +392,7 @@ export const CanvasNavigation: FC<CanvasNavigationProps> = ({
             className="flex items-center gap-2 px-2"
             data-testid="desktop-user-avatars"
           >
-            <UserPresenceAvatars
-              users={usersWithPresence}
-              maxVisible={4}
-              size="sm"
-            />
+            <UserPresenceAvatars maxVisible={4} size="sm" />
           </div>
         </div>
       </div>

--- a/src/components/room/demo/zero-reads.test.ts
+++ b/src/components/room/demo/zero-reads.test.ts
@@ -4,8 +4,10 @@
  * Reducer unit tests cannot catch a subscription leaking through a hook or
  * component, so this guard renders the demo's canvas hooks inside the
  * DemoSimulationProvider with a mocked Convex client and asserts that none of
- * the demo/canvas/issues/timer/presence subscriptions are opened: every such
+ * the demo/canvas/issues/presence subscriptions are opened: every such
  * `useQuery` is passed `"skip"`, and `usePresence` is never called at all.
+ * (The timer opens no subscription at all anymore — its state arrives with the
+ * canvas node data — so it is probed for regressions but lists no query.)
  * Directly protects user stories 12/14/17 (ADR-0003).
  *
  * Single-channel sourcing (#214): the demo signal travels only through the
@@ -65,7 +67,6 @@ const SUBSCRIPTIONS = [
   getFunctionName(api.issues.getCurrent),
   getFunctionName(api.issues.list),
   getFunctionName(api.issues.getForEnhancedExport),
-  getFunctionName(api.timer.getTimerState),
 ];
 
 // Names + args of the captured subscription calls (ignoring queries we don't
@@ -89,6 +90,18 @@ function capturedSubscriptions(): { name: string; args: unknown }[] {
 //   - integration-settings (getConnections/getRoomMapping, both un-skipped) only
 //     mounts behind `{!isDemoMode && …}` in room-settings-panel.
 // If one of those gates regresses this Probe won't catch it — re-audit on change.
+// A stopped persisted timer, as a freshly created canvas node delivers it.
+// useTimerSync opens no subscription in either mode — it is probed so a
+// regression that reintroduces one fails the leak assertion above.
+const STOPPED_TIMER_STATE = {
+  startedAt: null,
+  pausedAt: null,
+  elapsedSeconds: 0,
+  isRunning: false,
+  lastUpdatedBy: null,
+  lastAction: null,
+};
+
 function useProbeHooks(roomId: Id<"rooms">, roomData: RoomWithRelatedData): void {
   // The hooks take no `isDemoMode` prop: they read the demo signal from the
   // provider seam, so what differs between the two cases is only whether the
@@ -101,7 +114,12 @@ function useProbeHooks(roomId: Id<"rooms">, roomData: RoomWithRelatedData): void
   });
   useIssues({ roomId });
   useRoomPresence(roomId, DEMO_VIEWER_ID, roomData.users);
-  useTimerSync({ roomId, nodeId: "timer", userId: undefined });
+  useTimerSync({
+    roomId,
+    nodeId: "timer",
+    userId: undefined,
+    timerState: STOPPED_TIMER_STATE,
+  });
 }
 
 function DemoProbe(): ReactNode {
@@ -134,7 +152,7 @@ describe("zero-reads guard: the demo signal is sourced from the provider seam", 
     spy.presenceCalled = false;
   });
 
-  it("skips every demo/canvas/issues/timer query and never subscribes to presence inside the provider", () => {
+  it("skips every demo/canvas/issues query and never subscribes to presence inside the provider", () => {
     renderToStaticMarkup(
       createElement(DemoSimulationProvider, null, createElement(DemoProbe)),
     );

--- a/src/components/room/demo/zero-reads.test.ts
+++ b/src/components/room/demo/zero-reads.test.ts
@@ -10,6 +10,12 @@
  * canvas node data — so it is probed for regressions but lists no query.)
  * Directly protects user stories 12/14/17 (ADR-0003).
  *
+ * The root-subscription case is covered too: the root AuthProvider subscribes
+ * `api.users.getGlobalUser` whenever a session is live, and AuthProvider sits
+ * above DemoSimulationProvider, so the provider seam cannot gate it. The probe
+ * renders AuthProvider over the demo tree with a live session and asserts the
+ * subscription is skipped on the /demo route — and opened on a non-demo route.
+ *
  * Single-channel sourcing (#214): the demo signal travels only through the
  * provider seam — the hooks take no `isDemoMode` prop and derive it from
  * context. So this guard renders them with NO `isDemoMode` prop and asserts the
@@ -27,6 +33,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 const spy = vi.hoisted(() => ({
   queries: [] as { query: unknown; args: unknown }[],
   presenceCalled: false,
+  pathname: "/demo",
 }));
 
 vi.mock("convex/react", () => ({
@@ -35,12 +42,26 @@ vi.mock("convex/react", () => ({
     return undefined; // demo data comes from context, not from Convex
   },
   useMutation: () => async () => undefined,
+  // A live session, so the AuthProvider probe exercises the authenticated case.
+  useConvexAuth: () => ({ isAuthenticated: true, isLoading: false }),
 }));
 
 vi.mock("@convex-dev/presence/react", () => ({
   default: () => {
     spy.presenceCalled = true;
     return undefined;
+  },
+}));
+
+vi.mock("next/navigation", () => ({
+  usePathname: () => spy.pathname,
+}));
+
+vi.mock("@/lib/auth-client", () => ({
+  authClient: {
+    useSession: () => ({
+      data: { user: { id: "user-1", isAnonymous: false, email: "u@example.com" } },
+    }),
   },
 }));
 
@@ -54,6 +75,7 @@ import {
   DemoSimulationProvider,
   useDemoSimulation,
 } from "./DemoSimulationProvider";
+import { AuthProvider } from "@/components/auth/auth-provider";
 import { useCanvasNodes } from "../hooks/useCanvasNodes";
 import { useIssues } from "../hooks/useIssues";
 import { useTimerSync } from "../hooks/use-timer-sync";
@@ -69,6 +91,10 @@ const SUBSCRIPTIONS = [
   getFunctionName(api.issues.getForEnhancedExport),
 ];
 
+// The root subscription mounted above the demo tree (AuthProvider). It is
+// route-gated, not provider-gated, so it gets its own probe below.
+const ROOT_SUBSCRIPTIONS = [getFunctionName(api.users.getGlobalUser)];
+
 // Names + args of the captured subscription calls (ignoring queries we don't
 // guard here, e.g. the integration queries owned by their own sites).
 function capturedSubscriptions(): { name: string; args: unknown }[] {
@@ -80,13 +106,24 @@ function capturedSubscriptions(): { name: string; args: unknown }[] {
     .filter((c) => SUBSCRIPTIONS.includes(c.name));
 }
 
+// Same, for the root AuthProvider subscription.
+function capturedRootSubscriptions(): { name: string; args: unknown }[] {
+  return spy.queries
+    .map((c) => ({
+      name: getFunctionName(c.query as Parameters<typeof getFunctionName>[0]),
+      args: c.args,
+    }))
+    .filter((c) => ROOT_SUBSCRIPTIONS.includes(c.name));
+}
+
 // Calls every always-mounted Convex-subscribing hook reachable from the demo
 // canvas. The other demo-reachable subscriptions are guarded at their own site,
-// so they are deliberately outside this Probe's scope (audited 2026-05-24):
+// so they are deliberately outside this Probe's scope (audited 2026-08-03):
 //   - RoomCanvas/PlayerNode/StoryNode read `roomData` (a prop) — api.rooms.get
 //     is never called in demo mode.
 //   - issues-panel skips its integration queries in demo (derives the signal
-//     from `useIsDemoMode()`).
+//     from `useIsDemoMode()`); its writes go through useIssueActions, which
+//     no-ops in demo (covered by useIssueActions.test.tsx).
 //   - integration-settings (getConnections/getRoomMapping, both un-skipped) only
 //     mounts behind `{!isDemoMode && …}` in room-settings-panel.
 // If one of those gates regresses this Probe won't catch it — re-audit on change.
@@ -150,6 +187,7 @@ describe("zero-reads guard: the demo signal is sourced from the provider seam", 
   beforeEach(() => {
     spy.queries.length = 0;
     spy.presenceCalled = false;
+    spy.pathname = "/demo";
   });
 
   it("skips every demo/canvas/issues query and never subscribes to presence inside the provider", () => {
@@ -174,5 +212,37 @@ describe("zero-reads guard: the demo signal is sourced from the provider seam", 
       expect(calls.every((c) => c.args !== "skip")).toBe(true);
     }
     expect(spy.presenceCalled).toBe(true);
+  });
+});
+
+describe("zero-reads guard: the root AuthProvider subscription is bypassed under /demo", () => {
+  beforeEach(() => {
+    spy.queries.length = 0;
+    spy.presenceCalled = false;
+  });
+
+  it("skips getGlobalUser on /demo even with a live session", () => {
+    spy.pathname = "/demo";
+    renderToStaticMarkup(
+      createElement(
+        AuthProvider,
+        null,
+        createElement(DemoSimulationProvider, null, createElement(DemoProbe)),
+      ),
+    );
+
+    const leaked = capturedRootSubscriptions().filter((c) => c.args !== "skip");
+    expect(leaked).toEqual([]);
+  });
+
+  it("opens getGlobalUser on a non-demo route with a live session", () => {
+    spy.pathname = "/room/real-room-id";
+    renderToStaticMarkup(
+      createElement(AuthProvider, null, createElement(RealRoomProbe)),
+    );
+
+    const opened = capturedRootSubscriptions();
+    expect(opened.length).toBeGreaterThan(0);
+    expect(opened.every((c) => c.args !== "skip")).toBe(true);
   });
 });

--- a/src/components/room/hooks/use-timer-sync.ts
+++ b/src/components/room/hooks/use-timer-sync.ts
@@ -1,15 +1,20 @@
 "use client";
 
-import { useQuery, useMutation } from "convex/react";
+import { useMutation } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import { Id } from "@/convex/_generated/dataModel";
-import { useCallback, useEffect, useState, useRef } from "react";
+import { useCallback, useEffect, useState } from "react";
+import {
+  calculateCurrentTime,
+  type TimerState,
+} from "@/convex/timerState";
 import { useDemoSimulation } from "../demo/DemoSimulationProvider";
 
 interface UseTimerSyncProps {
   roomId: Id<"rooms">;
   nodeId: string;
   userId?: Id<"users">;
+  timerState: TimerState;
 }
 
 interface UseTimerSyncReturn {
@@ -17,80 +22,48 @@ interface UseTimerSyncReturn {
   currentSeconds: number;
   isRunning: boolean;
   displayTime: string;
-  
+
   // Control functions
   onStart: () => void;
   onPause: () => void;
   onReset: () => void;
-  
-  // Loading states
-  isLoading: boolean;
+
+  // Error state
   error: string | null;
 }
 
+/**
+ * The timer's display derives entirely from the persisted state delivered with
+ * the canvas node (`api.canvas.getCanvasNodes` via buildCanvasNodes) — there is
+ * no second subscription. While the timer runs, a 100ms local interval re-reads
+ * the clock through the shared math (`@/convex/timerState`) so the display ticks
+ * smoothly between server snapshots; paused/reset states are static and re-derive
+ * whenever the node data changes.
+ */
 export function useTimerSync({
   roomId,
   nodeId,
   userId,
+  timerState,
 }: UseTimerSyncProps): UseTimerSyncReturn {
-  // In the Demo simulation the timer is local and stopped — never subscribe to
-  // `api.timer.getTimerState` (zero reads, ADR-0003). Real rooms subscribe.
+  // In the Demo simulation the timer is local and stopped — it renders 0:00
+  // from the demo provider and never touches Convex (zero reads, ADR-0003).
   const demo = useDemoSimulation();
 
   // Convex hooks
-  const serverTimerState = useQuery(
-    api.timer.getTimerState,
-    demo ? "skip" : { roomId, nodeId },
-  );
   const startTimerMutation = useMutation(api.timer.startTimer);
   const pauseTimerMutation = useMutation(api.timer.pauseTimer);
   const resetTimerMutation = useMutation(api.timer.resetTimer);
 
-  // Local state for smooth timer display
-  const [localSeconds, setLocalSeconds] = useState(0);
-  const [lastSyncTime, setLastSyncTime] = useState(() => Date.now());
+  // Local clock for smooth ticking while running
+  const [now, setNow] = useState(() => Date.now());
   const [error, setError] = useState<string | null>(null);
-  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-  // Sync local state with server state - intentional state sync pattern
   useEffect(() => {
-    if (serverTimerState) {
-      // eslint-disable-next-line react-hooks/set-state-in-effect
-      setLocalSeconds(serverTimerState.currentSeconds);
-      setLastSyncTime(Date.now());
-      setError(null);
-    }
-  }, [serverTimerState]);
-
-  // Handle local timer ticking for smooth display
-  useEffect(() => {
-    if (serverTimerState?.isRunning) {
-      intervalRef.current = setInterval(() => {
-        const now = Date.now();
-        const elapsedSinceSync = (now - lastSyncTime) / 1000;
-        setLocalSeconds(serverTimerState.currentSeconds + elapsedSinceSync);
-      }, 100); // Update more frequently for smooth display
-    } else {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-        intervalRef.current = null;
-      }
-    }
-
-    return () => {
-      if (intervalRef.current) {
-        clearInterval(intervalRef.current);
-      }
-    };
-  }, [serverTimerState?.isRunning, serverTimerState?.currentSeconds, lastSyncTime]);
-
-  // Format time display
-  const formatTime = useCallback((totalSeconds: number): string => {
-    const seconds = Math.floor(totalSeconds);
-    const minutes = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return `${minutes}:${secs.toString().padStart(2, "0")}`;
-  }, []);
+    if (demo || !timerState.isRunning) return;
+    const interval = setInterval(() => setNow(Date.now()), 100);
+    return () => clearInterval(interval);
+  }, [demo, timerState.isRunning]);
 
   // Control functions
   const onStart = useCallback(async () => {
@@ -138,12 +111,11 @@ export function useTimerSync({
     }
   }, [resetTimerMutation, roomId, nodeId, userId]);
 
-  // Calculate current display values. In demo mode the timer is a local,
-  // stopped 0:00 (no server state, never loading).
-  const currentSeconds = demo ? 0 : Math.floor(localSeconds);
-  const isRunning = demo ? false : (serverTimerState?.isRunning ?? false);
-  const displayTime = demo ? "0:00" : formatTime(localSeconds);
-  const isLoading = demo ? false : serverTimerState === undefined;
+  // Current display values, computed via the shared math. In demo mode the
+  // timer is a local, stopped 0:00 regardless of the fixture state.
+  const { currentSeconds, isRunning, displayTime } = demo
+    ? { currentSeconds: 0, isRunning: false, displayTime: "0:00" }
+    : calculateCurrentTime(timerState, now);
 
   return {
     currentSeconds,
@@ -152,7 +124,6 @@ export function useTimerSync({
     onStart,
     onPause,
     onReset,
-    isLoading,
     error,
   };
 }

--- a/src/components/room/hooks/useIssueActions.test.tsx
+++ b/src/components/room/hooks/useIssueActions.test.tsx
@@ -1,0 +1,105 @@
+/**
+ * useIssueActions — the seam that owns every issues-panel backend write, shaped
+ * like useCanvasActions. Two contracts are tested through the returned actions
+ * object, never the internal ref bookkeeping:
+ *
+ *  1. Demo no-op (ADR-0003): inside a demo context every method must issue zero
+ *     backend writes. One adapter, not a guard per control.
+ *  2. Identity stability: the object and each method keep referential identity
+ *     across re-renders, including input changes.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createElement, type ReactNode } from "react";
+import { renderHook, act } from "@testing-library/react";
+import type { Id } from "@/convex/_generated/dataModel";
+
+// Hoisted recorder shared with the (hoisted) vi.mock factory below. Every
+// useMutation returns a recording function, so any backend write is observable.
+const writes = vi.hoisted(() => ({
+  calls: [] as { args: unknown }[],
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => (args: unknown) => {
+    writes.calls.push({ args });
+    return Promise.resolve(undefined);
+  },
+  useQuery: () => undefined,
+}));
+
+import { DemoSimulationProvider } from "../demo/DemoSimulationProvider";
+import { useIssueActions } from "./useIssueActions";
+
+const ROOM_ID = "room-1" as Id<"rooms">;
+const ISSUE_ID = "issue-1" as Id<"issues">;
+
+/** Invokes every action method, with throwaway args where required. */
+function invokeAll(actions: ReturnType<typeof useIssueActions>) {
+  actions.createIssue("New issue");
+  actions.startVoting(ISSUE_ID);
+  actions.switchToQuickVote();
+  actions.updateTitle(ISSUE_ID, "Renamed");
+  actions.updateEstimate(ISSUE_ID, "5");
+  actions.deleteIssue(ISSUE_ID);
+  actions.reorderIssues([ISSUE_ID]);
+}
+
+beforeEach(() => {
+  writes.calls = [];
+});
+
+describe("useIssueActions — demo no-op", () => {
+  it("issues zero backend writes for every method under a demo context", async () => {
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(DemoSimulationProvider, null, children);
+
+    const { result } = renderHook(() => useIssueActions({ roomId: ROOM_ID }), {
+      wrapper,
+    });
+
+    await act(async () => {
+      invokeAll(result.current);
+    });
+
+    expect(writes.calls).toEqual([]);
+  });
+});
+
+describe("useIssueActions — identity stability", () => {
+  it("keeps the actions object and every method stable across re-renders", () => {
+    const { result, rerender } = renderHook(
+      ({ roomId }: { roomId: Id<"rooms"> }) => useIssueActions({ roomId }),
+      { initialProps: { roomId: ROOM_ID } },
+    );
+
+    const first = result.current;
+    const firstMethods = { ...first };
+
+    // Re-render with no change, then with a changed input.
+    rerender({ roomId: ROOM_ID });
+    rerender({ roomId: "room-2" as Id<"rooms"> });
+
+    expect(result.current).toBe(first);
+    for (const key of Object.keys(firstMethods) as (keyof typeof first)[]) {
+      expect(result.current[key]).toBe(firstMethods[key]);
+    }
+  });
+});
+
+describe("useIssueActions — real mode pass-through", () => {
+  it("invokes the latest closure through the stable method and writes", async () => {
+    const { result, rerender } = renderHook(
+      ({ roomId }: { roomId: Id<"rooms"> }) => useIssueActions({ roomId }),
+      { initialProps: { roomId: ROOM_ID } },
+    );
+
+    rerender({ roomId: "room-2" as Id<"rooms"> });
+    await act(async () => result.current.startVoting(ISSUE_ID));
+
+    expect(writes.calls).toHaveLength(1);
+    expect(writes.calls[0].args).toMatchObject({
+      roomId: "room-2",
+      issueId: ISSUE_ID,
+    });
+  });
+});

--- a/src/components/room/hooks/useIssueActions.ts
+++ b/src/components/room/hooks/useIssueActions.ts
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import { useDemoSimulation } from "../demo/DemoSimulationProvider";
+
+/**
+ * Every backend write the issues panel can trigger, behind one frozen-identity
+ * object — the same seam shape as useCanvasActions.
+ */
+export interface IssueActions {
+  /** Resolves to the new issue's id; in demo mode the write no-ops to `undefined`. */
+  createIssue: (title: string) => Promise<Id<"issues"> | undefined>;
+  startVoting: (issueId: Id<"issues">) => Promise<void>;
+  switchToQuickVote: () => Promise<void>;
+  updateTitle: (issueId: Id<"issues">, title: string) => Promise<void>;
+  updateEstimate: (issueId: Id<"issues">, estimate: string) => Promise<void>;
+  deleteIssue: (issueId: Id<"issues">) => Promise<void>;
+  reorderIssues: (issueIds: Id<"issues">[]) => Promise<void>;
+}
+
+interface UseIssueActionsProps {
+  roomId: Id<"rooms">;
+}
+
+/**
+ * Owns the demo-vs-real decision once, at the action seam: inside a demo context
+ * every method is a no-op, so "the demo never writes to the backend" (ADR-0003)
+ * is one adapter rather than a guard at every control. Unlike useCanvasActions
+ * the methods propagate failures instead of swallowing them — the panel owns the
+ * failure toast. The single ref-backed stabilizer lives here too (see
+ * useCanvasActions for the full rationale): the wrapper is built once and always
+ * invokes the latest closure, so method identity never churns.
+ */
+export function useIssueActions({ roomId }: UseIssueActionsProps): IssueActions {
+  const isDemo = useDemoSimulation() !== null;
+
+  const createMutation = useMutation(api.issues.create);
+  const startVotingMutation = useMutation(api.issues.startVoting);
+  const clearCurrentIssueMutation = useMutation(api.issues.clearCurrentIssue);
+  const updateTitleMutation = useMutation(api.issues.updateTitle);
+  const updateEstimateMutation = useMutation(api.issues.updateEstimate);
+  const deleteMutation = useMutation(api.issues.remove);
+  const reorderMutation = useMutation(api.issues.reorder);
+
+  // The live implementations, recreated each render so they always close over
+  // the latest roomId/mutations — no per-field refs needed.
+  const impl: IssueActions = {
+    createIssue: async (title) => {
+      if (isDemo) return undefined;
+      return await createMutation({ roomId, title });
+    },
+    startVoting: async (issueId) => {
+      if (isDemo) return;
+      await startVotingMutation({ roomId, issueId });
+    },
+    switchToQuickVote: async () => {
+      if (isDemo) return;
+      await clearCurrentIssueMutation({ roomId });
+    },
+    updateTitle: async (issueId, title) => {
+      if (isDemo) return;
+      await updateTitleMutation({ issueId, title });
+    },
+    updateEstimate: async (issueId, estimate) => {
+      if (isDemo) return;
+      await updateEstimateMutation({ issueId, finalEstimate: estimate });
+    },
+    deleteIssue: async (issueId) => {
+      if (isDemo) return;
+      await deleteMutation({ issueId });
+    },
+    reorderIssues: async (issueIds) => {
+      if (isDemo) return;
+      await reorderMutation({ roomId, issueIds });
+    },
+  };
+
+  // The single stabilizer, identical to useCanvasActions: the ref always points
+  // at the latest closures (updated after every commit — no dependency array is
+  // intentional), and the wrapper is built once via a lazy `useState`
+  // initializer so its methods keep a frozen identity while always invoking the
+  // latest closure.
+  const implRef = useRef(impl);
+  useEffect(() => {
+    implRef.current = impl;
+  });
+
+  const [stableActions] = useState<IssueActions>(() => ({
+    createIssue: (title) => implRef.current.createIssue(title),
+    startVoting: (issueId) => implRef.current.startVoting(issueId),
+    switchToQuickVote: () => implRef.current.switchToQuickVote(),
+    updateTitle: (issueId, title) => implRef.current.updateTitle(issueId, title),
+    updateEstimate: (issueId, estimate) =>
+      implRef.current.updateEstimate(issueId, estimate),
+    deleteIssue: (issueId) => implRef.current.deleteIssue(issueId),
+    reorderIssues: (issueIds) => implRef.current.reorderIssues(issueIds),
+  }));
+
+  return stableActions;
+}

--- a/src/components/room/hooks/useIssues.ts
+++ b/src/components/room/hooks/useIssues.ts
@@ -1,7 +1,6 @@
 "use client";
 
-import { useQuery, useMutation } from "convex/react";
-import { useCallback } from "react";
+import { useQuery } from "convex/react";
 import { api } from "@/convex/_generated/api";
 import type { Id, Doc } from "@/convex/_generated/dataModel";
 import type { EnhancedExportableIssue } from "@/convex/model/issues";
@@ -16,20 +15,18 @@ interface UseIssuesReturn {
   currentIssue: Doc<"issues"> | null;
   isQuickVoteMode: boolean;
   isLoading: boolean;
-  createIssue: (title: string) => Promise<Id<"issues">>;
-  startVoting: (issueId: Id<"issues">) => Promise<void>;
-  switchToQuickVote: () => Promise<void>;
-  updateTitle: (issueId: Id<"issues">, title: string) => Promise<void>;
-  updateEstimate: (issueId: Id<"issues">, estimate: string) => Promise<void>;
-  deleteIssue: (issueId: Id<"issues">) => Promise<void>;
-  reorderIssues: (issueIds: Id<"issues">[]) => Promise<void>;
   exportData: EnhancedExportableIssue[] | undefined;
 }
 
+/**
+ * The read half of the issues panel. The write half lives behind the
+ * useIssueActions seam, which owns the demo no-op internally (ADR-0003).
+ *
+ * In the Demo simulation, the issues list and current issue come from context
+ * — never from Convex (zero reads, ADR-0003). Real rooms subscribe as before.
+ * The demo signal is derived from that same context (#214), not a prop.
+ */
 export function useIssues({ roomId }: UseIssuesProps): UseIssuesReturn {
-  // In the Demo simulation, the issues list and current issue come from context
-  // — never from Convex (zero reads, ADR-0003). Real rooms subscribe as before.
-  // The demo signal is derived from that same context (#214), not a prop.
   const demo = useDemoSimulation();
 
   // Queries (skipped in demo mode; data is served from context below)
@@ -48,73 +45,11 @@ export function useIssues({ roomId }: UseIssuesProps): UseIssuesReturn {
     ? (demo.issues.find((i) => i._id === demo.currentIssue._id) ?? null)
     : (currentIssueQuery ?? null);
 
-  // Mutations
-  const createMutation = useMutation(api.issues.create);
-  const startVotingMutation = useMutation(api.issues.startVoting);
-  const clearCurrentIssueMutation = useMutation(api.issues.clearCurrentIssue);
-  const updateTitleMutation = useMutation(api.issues.updateTitle);
-  const updateEstimateMutation = useMutation(api.issues.updateEstimate);
-  const deleteMutation = useMutation(api.issues.remove);
-  const reorderMutation = useMutation(api.issues.reorder);
-
-  const createIssue = useCallback(
-    async (title: string) => {
-      return await createMutation({ roomId, title });
-    },
-    [createMutation, roomId]
-  );
-
-  const startVoting = useCallback(
-    async (issueId: Id<"issues">) => {
-      await startVotingMutation({ roomId, issueId });
-    },
-    [startVotingMutation, roomId]
-  );
-
-  const switchToQuickVote = useCallback(async () => {
-    await clearCurrentIssueMutation({ roomId });
-  }, [clearCurrentIssueMutation, roomId]);
-
-  const updateTitle = useCallback(
-    async (issueId: Id<"issues">, title: string) => {
-      await updateTitleMutation({ issueId, title });
-    },
-    [updateTitleMutation]
-  );
-
-  const updateEstimate = useCallback(
-    async (issueId: Id<"issues">, estimate: string) => {
-      await updateEstimateMutation({ issueId, finalEstimate: estimate });
-    },
-    [updateEstimateMutation]
-  );
-
-  const deleteIssue = useCallback(
-    async (issueId: Id<"issues">) => {
-      await deleteMutation({ issueId });
-    },
-    [deleteMutation]
-  );
-
-  const reorderIssues = useCallback(
-    async (issueIds: Id<"issues">[]) => {
-      await reorderMutation({ roomId, issueIds });
-    },
-    [reorderMutation, roomId]
-  );
-
   return {
     issues,
     currentIssue,
     isQuickVoteMode: !currentIssue,
     isLoading: demo ? false : issuesQuery === undefined,
-    createIssue,
-    startVoting,
-    switchToQuickVote,
-    updateTitle,
-    updateEstimate,
-    deleteIssue,
-    reorderIssues,
     exportData,
   };
 }

--- a/src/components/room/hooks/useRoomSettingsActions.test.tsx
+++ b/src/components/room/hooks/useRoomSettingsActions.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * useRoomSettingsActions — the seam that owns every room-settings backend
+ * write, shaped like useCanvasActions. Two contracts are tested through the
+ * returned actions object, never the internal ref bookkeeping:
+ *
+ *  1. Demo no-op (ADR-0003): inside a demo context every method must issue zero
+ *     backend writes. One adapter, not a guard per control.
+ *  2. Identity stability: the object and each method keep referential identity
+ *     across re-renders, including input changes.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createElement, type ReactNode } from "react";
+import { renderHook, act } from "@testing-library/react";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { RoomPermissions } from "@/convex/permissions";
+
+// Hoisted recorder shared with the (hoisted) vi.mock factory below. Every
+// useMutation returns a recording function, so any backend write is observable.
+const writes = vi.hoisted(() => ({
+  calls: [] as { args: unknown }[],
+}));
+
+vi.mock("convex/react", () => ({
+  useMutation: () => (args: unknown) => {
+    writes.calls.push({ args });
+    return Promise.resolve(undefined);
+  },
+  useQuery: () => undefined,
+}));
+
+import { DemoSimulationProvider } from "../demo/DemoSimulationProvider";
+import { useRoomSettingsActions } from "./useRoomSettingsActions";
+
+const ROOM_ID = "room-1" as Id<"rooms">;
+const USER_ID = "user-1" as Id<"users">;
+const EVERYONE_PERMISSIONS: RoomPermissions = {
+  revealCards: "everyone",
+  gameFlow: "everyone",
+  issueManagement: "everyone",
+  roomSettings: "everyone",
+};
+
+/** Invokes every action method, with throwaway args where required. */
+function invokeAll(actions: ReturnType<typeof useRoomSettingsActions>) {
+  actions.rename("New name");
+  actions.toggleAutoComplete();
+  actions.removeUser(USER_ID);
+  actions.promoteFacilitator(USER_ID);
+  actions.demoteFacilitator(USER_ID);
+  actions.transferOwnership(USER_ID);
+  actions.updatePermissions(EVERYONE_PERMISSIONS);
+}
+
+beforeEach(() => {
+  writes.calls = [];
+});
+
+describe("useRoomSettingsActions — demo no-op", () => {
+  it("issues zero backend writes for every method under a demo context", async () => {
+    const wrapper = ({ children }: { children: ReactNode }) =>
+      createElement(DemoSimulationProvider, null, children);
+
+    const { result } = renderHook(
+      () => useRoomSettingsActions({ roomId: ROOM_ID }),
+      { wrapper },
+    );
+
+    await act(async () => {
+      invokeAll(result.current);
+    });
+
+    expect(writes.calls).toEqual([]);
+  });
+});
+
+describe("useRoomSettingsActions — identity stability", () => {
+  it("keeps the actions object and every method stable across re-renders", () => {
+    const { result, rerender } = renderHook(
+      ({ roomId }: { roomId: Id<"rooms"> }) =>
+        useRoomSettingsActions({ roomId }),
+      { initialProps: { roomId: ROOM_ID } },
+    );
+
+    const first = result.current;
+    const firstMethods = { ...first };
+
+    // Re-render with no change, then with a changed input.
+    rerender({ roomId: ROOM_ID });
+    rerender({ roomId: "room-2" as Id<"rooms"> });
+
+    expect(result.current).toBe(first);
+    for (const key of Object.keys(firstMethods) as (keyof typeof first)[]) {
+      expect(result.current[key]).toBe(firstMethods[key]);
+    }
+  });
+});
+
+describe("useRoomSettingsActions — real mode pass-through", () => {
+  it("invokes the latest closure through the stable method and writes", async () => {
+    const { result, rerender } = renderHook(
+      ({ roomId }: { roomId: Id<"rooms"> }) =>
+        useRoomSettingsActions({ roomId }),
+      { initialProps: { roomId: ROOM_ID } },
+    );
+
+    rerender({ roomId: "room-2" as Id<"rooms"> });
+    await act(async () => result.current.rename("New name"));
+
+    expect(writes.calls).toHaveLength(1);
+    expect(writes.calls[0].args).toMatchObject({
+      roomId: "room-2",
+      name: "New name",
+    });
+  });
+});

--- a/src/components/room/hooks/useRoomSettingsActions.ts
+++ b/src/components/room/hooks/useRoomSettingsActions.ts
@@ -1,0 +1,105 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useMutation } from "convex/react";
+import { api } from "@/convex/_generated/api";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { RoomPermissions } from "@/convex/permissions";
+import { useDemoSimulation } from "../demo/DemoSimulationProvider";
+
+/**
+ * Every backend write the room-settings panel can trigger, behind one
+ * frozen-identity object — the same seam shape as useCanvasActions.
+ */
+export interface RoomSettingsActions {
+  rename: (name: string) => Promise<void>;
+  toggleAutoComplete: () => Promise<void>;
+  removeUser: (userId: Id<"users">) => Promise<void>;
+  promoteFacilitator: (userId: Id<"users">) => Promise<void>;
+  demoteFacilitator: (userId: Id<"users">) => Promise<void>;
+  transferOwnership: (userId: Id<"users">) => Promise<void>;
+  updatePermissions: (permissions: RoomPermissions) => Promise<void>;
+}
+
+interface UseRoomSettingsActionsProps {
+  roomId: Id<"rooms">;
+}
+
+/**
+ * Owns the demo-vs-real decision once, at the action seam: inside a demo context
+ * every method is a no-op, so "the demo never writes to the backend" (ADR-0003)
+ * is one adapter rather than a guard at every control. Unlike useCanvasActions
+ * the methods propagate failures instead of swallowing them — the panel owns the
+ * failure toast. The single ref-backed stabilizer lives here too (see
+ * useCanvasActions for the full rationale): the wrapper is built once and always
+ * invokes the latest closure, so method identity never churns.
+ */
+export function useRoomSettingsActions({
+  roomId,
+}: UseRoomSettingsActionsProps): RoomSettingsActions {
+  const isDemo = useDemoSimulation() !== null;
+
+  const renameMutation = useMutation(api.rooms.rename);
+  const toggleAutoCompleteMutation = useMutation(api.rooms.toggleAutoComplete);
+  const removeUserMutation = useMutation(api.users.remove);
+  const promoteFacilitatorMutation = useMutation(api.roles.promoteFacilitator);
+  const demoteFacilitatorMutation = useMutation(api.roles.demoteFacilitator);
+  const transferOwnershipMutation = useMutation(api.roles.transferOwnership);
+  const updatePermissionsMutation = useMutation(api.roles.updatePermissions);
+
+  // The live implementations, recreated each render so they always close over
+  // the latest roomId/mutations — no per-field refs needed.
+  const impl: RoomSettingsActions = {
+    rename: async (name) => {
+      if (isDemo) return;
+      await renameMutation({ roomId, name });
+    },
+    toggleAutoComplete: async () => {
+      if (isDemo) return;
+      await toggleAutoCompleteMutation({ roomId });
+    },
+    removeUser: async (userId) => {
+      if (isDemo) return;
+      await removeUserMutation({ userId, roomId });
+    },
+    promoteFacilitator: async (userId) => {
+      if (isDemo) return;
+      await promoteFacilitatorMutation({ roomId, targetUserId: userId });
+    },
+    demoteFacilitator: async (userId) => {
+      if (isDemo) return;
+      await demoteFacilitatorMutation({ roomId, targetUserId: userId });
+    },
+    transferOwnership: async (userId) => {
+      if (isDemo) return;
+      await transferOwnershipMutation({ roomId, targetUserId: userId });
+    },
+    updatePermissions: async (permissions) => {
+      if (isDemo) return;
+      await updatePermissionsMutation({ roomId, permissions });
+    },
+  };
+
+  // The single stabilizer, identical to useCanvasActions: the ref always points
+  // at the latest closures (updated after every commit — no dependency array is
+  // intentional), and the wrapper is built once via a lazy `useState`
+  // initializer so its methods keep a frozen identity while always invoking the
+  // latest closure.
+  const implRef = useRef(impl);
+  useEffect(() => {
+    implRef.current = impl;
+  });
+
+  const [stableActions] = useState<RoomSettingsActions>(() => ({
+    rename: (name) => implRef.current.rename(name),
+    toggleAutoComplete: () => implRef.current.toggleAutoComplete(),
+    removeUser: (userId) => implRef.current.removeUser(userId),
+    promoteFacilitator: (userId) => implRef.current.promoteFacilitator(userId),
+    demoteFacilitator: (userId) => implRef.current.demoteFacilitator(userId),
+    transferOwnership: (userId) => implRef.current.transferOwnership(userId),
+    updatePermissions: (permissions) =>
+      implRef.current.updatePermissions(permissions),
+  }));
+
+  return stableActions;
+}

--- a/src/components/room/issue-item.test.tsx
+++ b/src/components/room/issue-item.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * IssueItem — denial copy on the title and the actions menu comes from the
+ * resolved decisions, not from the component's own text: a game-flow denial
+ * turns the (non-clickable) title's tooltip into the denial message instead
+ * of falling back to the plain title, and an issue-management denial renders
+ * the menu button disabled with the message as tooltip and accessible label.
+ * Decisions come from the real computePermissions.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { computePermissions } from "@/hooks/usePermissions";
+import type { RoomWithRelatedData } from "@/convex/model/rooms";
+import type { Doc, Id } from "@/convex/_generated/dataModel";
+import {
+  denialMessage,
+  RESOLVED_ALLOWED,
+  type ResolvedDecision,
+  type RoomPermissions,
+} from "@/convex/permissions";
+import { IssueItem } from "./issue-item";
+
+const allEveryone: RoomPermissions = {
+  revealCards: "everyone",
+  gameFlow: "everyone",
+  issueManagement: "everyone",
+  roomSettings: "everyone",
+};
+
+/** Minimal RoomWithRelatedData fixture — only the fields the mapping reads. */
+function roomData(permissions: RoomPermissions): RoomWithRelatedData {
+  return {
+    room: { permissions },
+    users: [{ _id: "u1", role: "participant" }],
+    isOwnerAbsent: false,
+  } as unknown as RoomWithRelatedData;
+}
+
+const ISSUE = {
+  _id: "issue-1",
+  title: "Write tests",
+  status: "pending",
+} as unknown as Doc<"issues">;
+
+function renderItem(opts: {
+  canManageIssues?: ResolvedDecision;
+  canControlGameFlow?: ResolvedDecision;
+  onStartVoting?: (id: Id<"issues">) => void;
+}) {
+  return render(
+    <IssueItem
+      issue={ISSUE}
+      isCurrent={false}
+      onStartVoting={opts.onStartVoting ?? (() => {})}
+      onUpdateTitle={() => {}}
+      onUpdateEstimate={() => {}}
+      onDelete={() => {}}
+      canManageIssues={opts.canManageIssues ?? RESOLVED_ALLOWED}
+      canControlGameFlow={opts.canControlGameFlow ?? RESOLVED_ALLOWED}
+    />
+  );
+}
+
+afterEach(cleanup);
+
+describe("IssueItem — start-voting denial copy", () => {
+  it("game-flow denied: the title stays a span but its tooltip is the denial message", () => {
+    const perms = computePermissions(
+      roomData({ ...allEveryone, gameFlow: "facilitators" }),
+      "u1"
+    );
+    renderItem({ canControlGameFlow: perms.gameFlow });
+
+    const title = screen.getByText("Write tests");
+    expect(title.tagName).toBe("SPAN");
+    expect(title.getAttribute("title")).toBe(
+      denialMessage(
+        { kind: "category", category: "gameFlow", level: "facilitators" },
+        "insufficient-role"
+      )
+    );
+  });
+
+  it("game-flow allowed: the title is a button with the start-voting tooltip", () => {
+    const onStartVoting = vi.fn();
+    renderItem({ onStartVoting });
+
+    const title = screen.getByRole("button", {
+      name: "Write tests",
+    });
+    expect(title.getAttribute("title")).toBe("Click to vote on: Write tests");
+
+    fireEvent.click(title);
+    expect(onStartVoting).toHaveBeenCalledWith("issue-1");
+  });
+});
+
+describe("IssueItem — issue-management denial", () => {
+  it("renders the actions button disabled with the denial message as tooltip and label", () => {
+    const perms = computePermissions(
+      roomData({ ...allEveryone, issueManagement: "facilitators" }),
+      "u1"
+    );
+    renderItem({ canManageIssues: perms.issueManagement });
+
+    const message = denialMessage(
+      { kind: "category", category: "issueManagement", level: "facilitators" },
+      "insufficient-role"
+    );
+    const actions = screen.getByRole("button", { name: message });
+    expect(actions).toHaveProperty("disabled", true);
+    expect(actions.getAttribute("title")).toBe(message);
+  });
+});

--- a/src/components/room/issue-item.tsx
+++ b/src/components/room/issue-item.tsx
@@ -14,6 +14,7 @@ import {
 import { cn } from "@/lib/utils";
 import type { Doc, Id } from "@/convex/_generated/dataModel";
 import { type ResolvedDecision, RESOLVED_ALLOWED } from "@/convex/permissions";
+import { denialTooltip, permissionProps } from "@/hooks/usePermissions";
 import { useIsDemoMode } from "./demo/DemoSimulationProvider";
 
 interface IssueLink {
@@ -51,9 +52,6 @@ export const IssueItem: FC<IssueItemProps> = ({
   // denial copy comes from the resolved decision's message (single source).
   const canManageIssues = canManageIssuesDecision.allowed;
   const canControlGameFlow = canControlGameFlowDecision.allowed;
-  const manageIssuesDenial = canManageIssuesDecision.allowed
-    ? undefined
-    : canManageIssuesDecision.message;
   const [isEditingTitle, setIsEditingTitle] = useState(false);
   const [isEditingEstimate, setIsEditingEstimate] = useState(false);
   const [editedTitle, setEditedTitle] = useState(issue.title);
@@ -115,9 +113,15 @@ export const IssueItem: FC<IssueItemProps> = ({
   const isVoting = issue.status === "voting";
 
   const canStartVote = !isVoting && !isDemoMode && canControlGameFlow;
+  // Only a game-flow denial turns the fallback tooltip into the denial copy;
+  // the already-voting and demo states keep the plain title.
+  const startVotingDenial =
+    !isVoting && !isDemoMode
+      ? denialTooltip(canControlGameFlowDecision)
+      : undefined;
   const titleTooltip = canStartVote
     ? `Click to vote on: ${issue.title}`
-    : issue.title;
+    : (startVotingDenial ?? issue.title);
 
   return (
     <div
@@ -218,9 +222,8 @@ export const IssueItem: FC<IssueItemProps> = ({
             <Button
               variant="ghost"
               size="icon-sm"
-              disabled={true}
               className="opacity-40 cursor-not-allowed text-gray-400"
-              title={manageIssuesDenial}
+              {...permissionProps(canManageIssuesDecision)}
             >
               <MoreHorizontal className="h-4 w-4" />
               <span className="sr-only">Issue actions unavailable</span>

--- a/src/components/room/issues-panel.test.tsx
+++ b/src/components/room/issues-panel.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * IssuesPanel — the Quick Vote switch consumes the game-flow decision it is
+ * handed: denied renders the switch disabled with the decision's denial copy
+ * (and no onClick that would let the backend throw); allowed keeps it live.
+ * Convex reads/writes, toast, and the mobile branch are mocked at the seams;
+ * the decision itself comes from the real computePermissions.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { computePermissions } from "@/hooks/usePermissions";
+import type { RoomWithRelatedData } from "@/convex/model/rooms";
+import type { Id } from "@/convex/_generated/dataModel";
+import {
+  denialMessage,
+  RESOLVED_ALLOWED,
+  type ResolvedDecision,
+  type RoomPermissions,
+} from "@/convex/permissions";
+
+// Hoisted recorder shared with the (hoisted) vi.mock factories below.
+const mocks = vi.hoisted(() => ({
+  switchToQuickVote: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: () => undefined,
+  useMutation: () => () => Promise.resolve(undefined),
+  useAction: () => () => Promise.resolve(undefined),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+
+// Desktop branch of SidePanel — jsdom has no matchMedia.
+vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => false }));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: () => {} }),
+}));
+
+vi.mock("./hooks/useIssues", () => ({
+  useIssues: () => ({
+    issues: [],
+    currentIssue: null,
+    isQuickVoteMode: false,
+    isLoading: false,
+    exportData: undefined,
+  }),
+}));
+
+vi.mock("./hooks/useIssueActions", () => ({
+  useIssueActions: () => ({
+    createIssue: () => Promise.resolve(undefined),
+    startVoting: () => Promise.resolve(undefined),
+    switchToQuickVote: mocks.switchToQuickVote,
+    updateTitle: () => Promise.resolve(undefined),
+    updateEstimate: () => Promise.resolve(undefined),
+    deleteIssue: () => Promise.resolve(undefined),
+  }),
+}));
+
+import { IssuesPanel } from "./issues-panel";
+
+const allEveryone: RoomPermissions = {
+  revealCards: "everyone",
+  gameFlow: "everyone",
+  issueManagement: "everyone",
+  roomSettings: "everyone",
+};
+
+/** Minimal RoomWithRelatedData fixture — only the fields the mapping reads. */
+function roomData(permissions: RoomPermissions): RoomWithRelatedData {
+  return {
+    room: { permissions },
+    users: [{ _id: "u1", role: "participant" }],
+    isOwnerAbsent: false,
+  } as unknown as RoomWithRelatedData;
+}
+
+const GAME_FLOW_DENIAL = denialMessage(
+  { kind: "category", category: "gameFlow", level: "facilitators" },
+  "insufficient-role"
+);
+
+function renderPanel(canControlGameFlow: ResolvedDecision) {
+  return render(
+    <IssuesPanel
+      roomId={"room-1" as Id<"rooms">}
+      roomName="Test Room"
+      isOpen={true}
+      onClose={() => {}}
+      canManageIssues={RESOLVED_ALLOWED}
+      canControlGameFlow={canControlGameFlow}
+    />
+  );
+}
+
+afterEach(() => {
+  cleanup();
+  mocks.switchToQuickVote.mockClear();
+});
+
+describe("IssuesPanel — Quick Vote switch and the game-flow decision", () => {
+  it("denied: disabled with the denial copy as tooltip, and no onClick that would throw", () => {
+    const perms = computePermissions(
+      roomData({ ...allEveryone, gameFlow: "facilitators" }),
+      "u1"
+    );
+    expect(perms.gameFlow.allowed).toBe(false);
+
+    renderPanel(perms.gameFlow);
+
+    const quickVote = screen.getByRole("button", { name: GAME_FLOW_DENIAL });
+    expect(quickVote).toHaveProperty("disabled", true);
+    expect(quickVote.getAttribute("title")).toBe(GAME_FLOW_DENIAL);
+
+    fireEvent.click(quickVote);
+    expect(mocks.switchToQuickVote).not.toHaveBeenCalled();
+  });
+
+  it("allowed: the switch stays live and switching works", () => {
+    renderPanel(RESOLVED_ALLOWED);
+
+    const quickVote = screen.getByRole("button", { name: /quick vote/i });
+    expect(quickVote).toHaveProperty("disabled", false);
+    expect(quickVote.getAttribute("title")).toBeNull();
+
+    fireEvent.click(quickVote);
+    expect(mocks.switchToQuickVote).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/room/issues-panel.tsx
+++ b/src/components/room/issues-panel.tsx
@@ -32,6 +32,7 @@ import { exportIssuesToCSV } from "@/utils/export-issues-csv";
 import { exportIssuesToJSON } from "@/utils/export-issues-json";
 import type { Id } from "@/convex/_generated/dataModel";
 import { type ResolvedDecision, RESOLVED_ALLOWED } from "@/convex/permissions";
+import { denialTooltip, permissionProps } from "@/hooks/usePermissions";
 
 interface IssuesPanelProps {
   roomId: Id<"rooms">;
@@ -51,11 +52,10 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
   canControlGameFlow: canControlGameFlowDecision = RESOLVED_ALLOWED,
 }) => {
   const isDemoMode = useIsDemoMode();
-  // Resolved decisions in; booleans for gating and a message for denial copy.
+  // Resolved decisions in; booleans for gating and decision copy for denials.
   const canManageIssues = canManageIssuesDecision.allowed;
-  const manageIssuesDenial = canManageIssuesDecision.allowed
-    ? undefined
-    : canManageIssuesDecision.message;
+  const canControlGameFlow = canControlGameFlowDecision.allowed;
+  const manageIssuesDenial = denialTooltip(canManageIssuesDecision);
   const { toast } = useToast();
 
   const [newIssueTitle, setNewIssueTitle] = useState("");
@@ -297,15 +297,17 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
           {/* Quick Vote Section - Always pinned to top of scroll */}
           <div className="p-6 pb-2 shrink-0">
             <button
-              onClick={handleSwitchToQuickVote}
+              onClick={canControlGameFlow ? handleSwitchToQuickVote : undefined}
               disabled={isDemoMode}
               className={cn(
                 "w-full flex items-center justify-between p-4 rounded-xl border bg-white dark:bg-surface-2 transition-all group shadow-sm",
                 isQuickVoteMode
                   ? "border-blue-200 ring-1 ring-blue-500/20 bg-blue-50/50 dark:bg-blue-900/10 dark:border-blue-900/50"
                   : "border-gray-200/50 dark:border-border hover:border-gray-300 dark:hover:border-gray-600 hover:shadow-md",
-                isDemoMode && "cursor-default opacity-70"
+                isDemoMode && "cursor-default opacity-70",
+                !canControlGameFlow && "cursor-not-allowed opacity-70"
               )}
+              {...permissionProps(canControlGameFlowDecision)}
             >
               <div className="flex items-center gap-3">
                 <div className={cn(

--- a/src/components/room/issues-panel.tsx
+++ b/src/components/room/issues-panel.tsx
@@ -24,6 +24,7 @@ import { Badge } from "@/components/ui/badge";
 import { useToast } from "@/hooks/use-toast";
 import { cn } from "@/lib/utils";
 import { useIssues } from "./hooks/useIssues";
+import { useIssueActions } from "./hooks/useIssueActions";
 import { useIsDemoMode } from "./demo/DemoSimulationProvider";
 import { IssueItem } from "./issue-item";
 import { JiraImportModal } from "./jira-import-modal";
@@ -70,14 +71,19 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
     currentIssue,
     isQuickVoteMode,
     isLoading,
+    exportData,
+  } = useIssues({ roomId });
+  // Writes come from the action seam, which no-ops internally in demo mode
+  // (ADR-0003) — the remaining `isDemoMode` branches below are presentation only
+  // (hide/disable controls), never write guards.
+  const {
     createIssue,
     startVoting,
     switchToQuickVote,
     updateTitle,
     updateEstimate,
     deleteIssue,
-    exportData,
-  } = useIssues({ roomId });
+  } = useIssueActions({ roomId });
 
   const handleAddIssue = async () => {
     if (!newIssueTitle.trim()) return;
@@ -291,7 +297,7 @@ export const IssuesPanel: FC<IssuesPanelProps> = ({
           {/* Quick Vote Section - Always pinned to top of scroll */}
           <div className="p-6 pb-2 shrink-0">
             <button
-              onClick={isDemoMode ? undefined : handleSwitchToQuickVote}
+              onClick={handleSwitchToQuickVote}
               disabled={isDemoMode}
               className={cn(
                 "w-full flex items-center justify-between p-4 rounded-xl border bg-white dark:bg-surface-2 transition-all group shadow-sm",

--- a/src/components/room/nodes/TimerNode.tsx
+++ b/src/components/room/nodes/TimerNode.tsx
@@ -13,7 +13,8 @@ export const TimerNode = memo(
     // Extract required data for useTimerSync hook
     const { roomId, userId, nodeId } = data;
 
-    // Use the synchronized timer hook instead of local state
+    // Timer state comes from the node data itself (delivered by
+    // api.canvas.getCanvasNodes); the hook adds local ticking and controls.
     const {
       displayTime,
       isRunning,
@@ -21,12 +22,12 @@ export const TimerNode = memo(
       onStart,
       onPause,
       onReset,
-      isLoading,
       error,
     } = useTimerSync({
       roomId,
       nodeId: nodeId || "timer", // fallback to default timer nodeId
       userId,
+      timerState: data,
     });
 
     // Handle toggle between start and pause
@@ -42,43 +43,6 @@ export const TimerNode = memo(
     const handleReset = useCallback(() => {
       onReset();
     }, [onReset]);
-
-    // Show loading state if timer data is not yet available
-    if (isLoading) {
-      return (
-        <div className="relative">
-          <Handle
-            type="source"
-            position={Position.Right}
-            id="right"
-            className="bg-gray-400! dark:bg-surface-3!"
-            aria-hidden="true"
-          />
-          <div className={cn(
-            "p-3 bg-white dark:bg-surface-1 rounded-lg shadow-md border border-gray-200 dark:border-border",
-            selected && "ring-2 ring-blue-500 dark:ring-blue-400 ring-offset-2 ring-offset-white dark:ring-offset-surface-1"
-          )}>
-            <div className="flex items-center gap-3">
-              <div
-                className="w-2 h-2 rounded-full bg-gray-400 animate-pulse"
-                aria-hidden="true"
-              />
-              <span className="text-lg font-mono font-medium text-gray-400 min-w-16">
-                --:--
-              </span>
-              <div className="flex items-center gap-1">
-                <div className="p-1.5 rounded bg-gray-100 dark:bg-surface-3">
-                  <Play className="h-4 w-4 text-gray-400" />
-                </div>
-                <div className="p-1.5 rounded bg-gray-100 dark:bg-surface-3">
-                  <RotateCcw className="h-4 w-4 text-gray-400" />
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-      );
-    }
 
     return (
       <div className="relative">

--- a/src/components/room/room-canvas.tsx
+++ b/src/components/room/room-canvas.tsx
@@ -19,6 +19,7 @@ import type { NodeChange, EdgeChange } from "@xyflow/react";
 
 import { useLatest } from "@/hooks/use-latest";
 import { CanvasNavigation } from "./canvas-navigation";
+import { RoomPresenceProvider } from "./room-presence";
 import { RoomSettingsPanel } from "./room-settings-panel";
 import { IssuesPanel } from "./issues-panel";
 import { DemoExplainer } from "./demo-explainer";
@@ -259,7 +260,6 @@ function RoomCanvasInner({ roomData, currentUserId, isEmbedded = false }: RoomCa
         {(isDemoMode || currentUserId) && !(isDemoMode && isEmbedded) && (
           <CanvasNavigation
             roomData={roomData}
-            currentUserId={currentUserId ?? DEMO_VIEWER_ID}
             isIssuesPanelOpen={isIssuesPanelOpen}
             onIssuesPanelChange={(open) => (open ? openIssues() : closeAll())}
             isSettingsOpen={isSettingsOpen}
@@ -375,9 +375,30 @@ function RoomCanvasInner({ roomData, currentUserId, isEmbedded = false }: RoomCa
 }
 
 export function RoomCanvas(props: RoomCanvasProps): ReactElement {
+  const isDemoMode = useIsDemoMode();
+  const { roomData, currentUserId } = props;
+  // One presence subscription per viewer: RoomPresenceProvider owns the single
+  // usePresence instance for both consumers (nav avatars + settings roster).
+  // It wraps RoomCanvasInner from out here — RoomCanvas does not re-render on
+  // presence ticks, so the RoomCanvasInner element stays reference-identical
+  // and a tick re-renders only the context consumers, never the ReactFlow
+  // subtree (see room-presence.tsx). Mount it only when a consumer can exist:
+  // in real rooms that needs a resolved currentUserId (matching
+  // RoomCanvasInner's loading gate); in demo it subscribes to nothing anyway.
+  const withPresence = roomData && (isDemoMode || currentUserId);
   return (
     <ReactFlowProvider>
-      <RoomCanvasInner {...props} />
+      {withPresence ? (
+        <RoomPresenceProvider
+          roomId={roomData.room._id}
+          userId={currentUserId ?? DEMO_VIEWER_ID}
+          users={roomData.users}
+        >
+          <RoomCanvasInner {...props} />
+        </RoomPresenceProvider>
+      ) : (
+        <RoomCanvasInner {...props} />
+      )}
     </ReactFlowProvider>
   );
 }

--- a/src/components/room/room-presence.test.tsx
+++ b/src/components/room/room-presence.test.tsx
@@ -1,0 +1,245 @@
+/**
+ * RoomPresenceProvider — one presence subscription per viewer (candidate C12).
+ *
+ * Pins the four properties of the room presence module:
+ *   1. A single `usePresence` instantiation per mounted room tree, no matter
+ *      how many consumers read the roster (previously each of the two
+ *      always-mounted consumers subscribed and heartbeated on its own).
+ *   2. The one roster ordering rule: online-first with joinedAt tiebreak, plus
+ *      the settings panel's current-user-first variant.
+ *   3. Demo (ADR-0003): under DemoSimulationProvider the roster is derived
+ *      locally (all online) and `usePresence` is never called — zero
+ *      subscriptions at the new seam, same as the old one.
+ *   4. Re-render isolation: a presence tick re-renders only the context
+ *      consumers — never a sibling stand-in for the ReactFlow subtree. The
+ *      mock drives the tick the way Convex would: a state update INSIDE the
+ *      provider's `usePresence` hook, so the provider re-renders while the
+ *      canvas element (created by the non-re-rendering parent) stays
+ *      reference-identical and React bails out of that subtree.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+interface PresenceEntry {
+  userId: string;
+  online: boolean;
+  lastDisconnected: number;
+}
+
+// Hoisted capture buffers — referenced inside the (hoisted) vi.mock factory.
+const spy = vi.hoisted(() => ({
+  calls: [] as { roomId: unknown; userId: unknown }[],
+  data: undefined as PresenceEntry[] | undefined,
+  emitTick: null as null | (() => void),
+}));
+
+vi.mock("@convex-dev/presence/react", async () => {
+  const { useEffect, useState } = await import("react");
+  return {
+    default: function usePresenceMock(
+      _presenceApi: unknown,
+      roomId: unknown,
+      userId: unknown,
+    ) {
+      spy.calls.push({ roomId, userId });
+      // A presence tick, fired the way the real hook delivers one: new list
+      // data arrives and the hook's own state bumps, re-rendering exactly the
+      // component that called it (the provider) — nothing above it.
+      const [, setVersion] = useState(0);
+      useEffect(() => {
+        spy.emitTick = () => setVersion((v) => v + 1);
+        return () => {
+          spy.emitTick = null;
+        };
+      }, []);
+      return spy.data;
+    },
+  };
+});
+
+import { act, render } from "@testing-library/react";
+import { createElement, type ReactNode } from "react";
+import type { Id } from "@/convex/_generated/dataModel";
+import type { RoomUserData } from "@/convex/model/users";
+import {
+  orderUsersByPresence,
+  type UserWithPresence,
+} from "@/hooks/useRoomPresence";
+import {
+  RoomPresenceProvider,
+  usePresenceRoster,
+} from "./room-presence";
+import { DemoSimulationProvider } from "./demo/DemoSimulationProvider";
+
+function makeUser(id: string, name: string, joinedAt: number): RoomUserData {
+  return {
+    _id: id as Id<"users">,
+    name,
+    isSpectator: false,
+    role: "participant",
+    joinedAt,
+    membershipId: `${id}-membership` as Id<"roomMemberships">,
+  };
+}
+
+const USERS = [
+  makeUser("u1", "Ada", 100),
+  makeUser("u2", "Boris", 200),
+  makeUser("u3", "Cleo", 300),
+];
+
+/** Captures the roster a consumer sees, and counts renders (spy calls). */
+const observed = {
+  consumerRender: vi.fn(),
+  canvasRender: vi.fn(),
+};
+
+function lastRoster(): UserWithPresence[] {
+  const calls = observed.consumerRender.mock.calls;
+  return calls[calls.length - 1][0] as UserWithPresence[];
+}
+
+function RosterConsumer({
+  currentUserId,
+}: {
+  currentUserId?: string;
+}): ReactNode {
+  observed.consumerRender(usePresenceRoster(currentUserId));
+  return null;
+}
+
+/** Stand-in for the ReactFlow subtree: a sibling that never reads presence. */
+function CanvasStandIn(): ReactNode {
+  observed.canvasRender();
+  return createElement("div", { "data-testid": "canvas-stand-in" });
+}
+
+function renderRoomTree(children?: ReactNode): void {
+  render(
+    createElement(
+      RoomPresenceProvider,
+      { roomId: "room-1", userId: "u1", users: USERS },
+      children ?? createElement(RosterConsumer),
+    ),
+  );
+}
+
+beforeEach(() => {
+  spy.calls.length = 0;
+  spy.data = undefined;
+  spy.emitTick = null;
+  observed.consumerRender.mockClear();
+  observed.canvasRender.mockClear();
+});
+
+describe("RoomPresenceProvider — one subscription per viewer", () => {
+  it("instantiates usePresence once per mounted room tree regardless of consumer count", () => {
+    render(
+      createElement(
+        RoomPresenceProvider,
+        { roomId: "room-1", userId: "u1", users: USERS },
+        // The two real consumers: nav avatars (plain ordering) and the
+        // settings roster (current-user-first variant).
+        createElement(RosterConsumer),
+        createElement(RosterConsumer, { currentUserId: "u1" }),
+      ),
+    );
+
+    expect(spy.calls).toHaveLength(1);
+    expect(spy.calls[0]).toEqual({ roomId: "room-1", userId: "u1" });
+  });
+});
+
+describe("orderUsersByPresence — the one ordering rule", () => {
+  const withPresence = (
+    user: RoomUserData,
+    isOnline: boolean,
+  ): UserWithPresence => ({ ...user, isOnline, lastSeen: null });
+
+  it("orders online-first with joinedAt tiebreak", () => {
+    const roster = [
+      withPresence(USERS[2], false), // Cleo, offline
+      withPresence(USERS[1], true), // Boris, online, joined 200
+      withPresence(USERS[0], true), // Ada, online, joined 100
+    ];
+
+    expect(orderUsersByPresence(roster).map((u) => u._id)).toEqual([
+      "u1",
+      "u2",
+      "u3",
+    ]);
+  });
+
+  it("pins the current user first in the current-user-first variant", () => {
+    const roster = [
+      withPresence(USERS[0], true), // Ada online
+      withPresence(USERS[1], false), // Boris offline — but current
+      withPresence(USERS[2], true), // Cleo online
+    ];
+
+    expect(orderUsersByPresence(roster, "u2").map((u) => u._id)).toEqual([
+      "u2",
+      "u1",
+      "u3",
+    ]);
+  });
+
+  it("merges presence state into the roster (online flag + lastSeen)", () => {
+    spy.data = [
+      { userId: "u2", online: true, lastDisconnected: 0 },
+      { userId: "u3", online: false, lastDisconnected: 1234 },
+    ];
+    renderRoomTree();
+
+    const byId = new Map(lastRoster().map((u) => [u._id as string, u]));
+    expect(byId.get("u1")).toMatchObject({ isOnline: false, lastSeen: null });
+    expect(byId.get("u2")).toMatchObject({ isOnline: true, lastSeen: null });
+    expect(byId.get("u3")).toMatchObject({ isOnline: false, lastSeen: 1234 });
+  });
+});
+
+describe("RoomPresenceProvider in demo — subscription-free (ADR-0003)", () => {
+  it("derives the all-online roster locally without calling usePresence", () => {
+    render(
+      createElement(
+        DemoSimulationProvider,
+        null,
+        createElement(
+          RoomPresenceProvider,
+          { roomId: "demo-room", userId: "viewer", users: USERS },
+          createElement(RosterConsumer),
+        ),
+      ),
+    );
+
+    expect(spy.calls).toHaveLength(0);
+    expect(lastRoster()).toHaveLength(USERS.length);
+    expect(lastRoster().every((u) => u.isOnline && u.lastSeen === null)).toBe(
+      true,
+    );
+  });
+});
+
+describe("RoomPresenceProvider — re-render isolation", () => {
+  it("a presence tick re-renders only the roster consumers, not the canvas subtree", () => {
+    render(
+      createElement(
+        RoomPresenceProvider,
+        { roomId: "room-1", userId: "u1", users: USERS },
+        createElement(CanvasStandIn),
+        createElement(RosterConsumer),
+      ),
+    );
+    expect(observed.canvasRender).toHaveBeenCalledTimes(1);
+    expect(observed.consumerRender).toHaveBeenCalledTimes(1);
+
+    // Boris comes online — the presence list changes and the tick fires.
+    act(() => {
+      spy.data = [{ userId: "u2", online: true, lastDisconnected: 0 }];
+      spy.emitTick!();
+    });
+
+    expect(observed.consumerRender).toHaveBeenCalledTimes(2);
+    expect(lastRoster()[0]._id).toBe("u2"); // new data reached the consumer
+    expect(observed.canvasRender).toHaveBeenCalledTimes(1); // canvas untouched
+  });
+});

--- a/src/components/room/room-presence.tsx
+++ b/src/components/room/room-presence.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+/**
+ * RoomPresenceProvider — one presence subscription per viewer.
+ *
+ * Previously both always-mounted consumers (CanvasNavigation and
+ * RoomSettingsPanel) instantiated `usePresence` themselves: every viewer
+ * heartbeated twice and held two presence list subscriptions. This module
+ * hoists the single `useRoomPresence` call into a provider mounted by
+ * `RoomCanvas` above both consumers; they read the merged roster from context.
+ *
+ * Re-render isolation (the reason presence was pushed down into the nav in
+ * the first place — ReactFlow re-renders are expensive): the provider wraps
+ * `RoomCanvasInner` from OUTSIDE, in the `RoomCanvas` component, which does
+ * not itself re-render on presence updates. So when a presence tick
+ * re-renders this provider, the `RoomCanvasInner` element it received as
+ * `children` is reference-identical and React bails out of the whole canvas
+ * subtree; only context consumers (the avatar list, the settings roster) are
+ * re-rendered by context propagation. The context value identity is also
+ * stabilized (`useMemo` over the memoized roster), so unrelated provider
+ * re-renders don't fan out either.
+ *
+ * Demo (ADR-0003): the demo branch lives in `useRoomPresence` — under
+ * DemoSimulationProvider it derives all-bots-online locally and never calls
+ * `usePresence`, so this provider stays subscription-free there and consumers
+ * need no demo branching of their own.
+ */
+import { createContext, useContext, useMemo, type ReactNode } from "react";
+import type { RoomUserData } from "@/convex/model/users";
+import {
+  orderUsersByPresence,
+  useRoomPresence,
+  type UserWithPresence,
+} from "@/hooks/useRoomPresence";
+
+interface RoomPresenceContextValue {
+  users: UserWithPresence[];
+}
+
+const RoomPresenceContext = createContext<RoomPresenceContextValue | null>(
+  null,
+);
+
+interface RoomPresenceProviderProps {
+  roomId: string;
+  /** The current user's ID (used for heartbeats; ignored in demo). */
+  userId: string;
+  users: RoomUserData[];
+  children?: ReactNode;
+}
+
+export function RoomPresenceProvider({
+  roomId,
+  userId,
+  users,
+  children,
+}: RoomPresenceProviderProps): ReactNode {
+  const usersWithPresence = useRoomPresence(roomId, userId, users);
+  const value = useMemo(
+    () => ({ users: usersWithPresence }),
+    [usersWithPresence],
+  );
+  return (
+    <RoomPresenceContext.Provider value={value}>
+      {children}
+    </RoomPresenceContext.Provider>
+  );
+}
+
+/** The merged roster (users + online status), unordered. */
+export function useRoomPresenceUsers(): UserWithPresence[] {
+  const ctx = useContext(RoomPresenceContext);
+  if (!ctx) {
+    throw new Error(
+      "useRoomPresenceUsers must be used within RoomPresenceProvider",
+    );
+  }
+  return ctx.users;
+}
+
+/**
+ * The roster with the one ordering rule applied (online-first, joinedAt
+ * tiebreak). Pass `currentUserId` for the settings panel's
+ * current-user-first variant.
+ */
+export function usePresenceRoster(currentUserId?: string): UserWithPresence[] {
+  const users = useRoomPresenceUsers();
+  return useMemo(
+    () => orderUsersByPresence(users, currentUserId),
+    [users, currentUserId],
+  );
+}

--- a/src/components/room/room-settings-panel.test.tsx
+++ b/src/components/room/room-settings-panel.test.tsx
@@ -1,0 +1,298 @@
+/**
+ * RoomSettingsPanel — the roster wiring between the permission decision layer
+ * and the per-row promote/demote/transfer/remove controls. The decisions enter
+ * through the real usePermissions hook (computePermissions over the roomData
+ * prop) and the real rosterControls, so a denied actor sees every control
+ * visible-but-disabled with the decision's denial copy as its accessible label
+ * — and no onClick that would reach a mutation — while an allowed actor gets
+ * live controls that reach the action seam. Convex IO, toast, presence, demo
+ * mode, and the write seam (useRoomSettingsActions) are mocked; the decisions
+ * are not.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  within,
+  act,
+} from "@testing-library/react";
+import type { ReactNode } from "react";
+import { computePermissions } from "@/hooks/usePermissions";
+import type { RoomWithRelatedData } from "@/convex/model/rooms";
+import type { UserWithPresence } from "@/hooks/useRoomPresence";
+import type { Id } from "@/convex/_generated/dataModel";
+import {
+  denialMessage,
+  type MemberRole,
+  type RoomPermissions,
+} from "@/convex/permissions";
+
+// Hoisted recorders shared with the (hoisted) vi.mock factories below.
+const mocks = vi.hoisted(() => ({
+  roster: vi.fn((): UserWithPresence[] => []),
+  removeUser: vi.fn(() => Promise.resolve(undefined)),
+  promoteFacilitator: vi.fn(() => Promise.resolve(undefined)),
+  demoteFacilitator: vi.fn(() => Promise.resolve(undefined)),
+  transferOwnership: vi.fn(() => Promise.resolve(undefined)),
+}));
+
+vi.mock("convex/react", () => ({
+  useQuery: () => undefined,
+  useMutation: () => () => Promise.resolve(undefined),
+  useAction: () => () => Promise.resolve(undefined),
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children }: { children: ReactNode }) => <a>{children}</a>,
+}));
+
+// Desktop branch of SidePanel — jsdom has no matchMedia.
+vi.mock("@/hooks/use-mobile", () => ({ useIsMobile: () => false }));
+
+vi.mock("@/hooks/use-toast", () => ({
+  useToast: () => ({ toast: () => {} }),
+}));
+
+vi.mock("./demo/DemoSimulationProvider", () => ({
+  useIsDemoMode: () => false,
+  useDemoSimulation: () => null,
+}));
+
+// The roster comes from presence; the tests own it directly.
+vi.mock("./room-presence", () => ({
+  usePresenceRoster: () => mocks.roster(),
+}));
+
+// The write seam: record the four roster mutations, no-op the rest.
+vi.mock("./hooks/useRoomSettingsActions", () => ({
+  useRoomSettingsActions: () => ({
+    rename: () => Promise.resolve(undefined),
+    toggleAutoComplete: () => Promise.resolve(undefined),
+    removeUser: mocks.removeUser,
+    promoteFacilitator: mocks.promoteFacilitator,
+    demoteFacilitator: mocks.demoteFacilitator,
+    transferOwnership: mocks.transferOwnership,
+    updatePermissions: () => Promise.resolve(undefined),
+  }),
+}));
+
+import { RoomSettingsPanel } from "./room-settings-panel";
+
+const allEveryone: RoomPermissions = {
+  revealCards: "everyone",
+  gameFlow: "everyone",
+  issueManagement: "everyone",
+  roomSettings: "everyone",
+};
+
+const ME = "u1" as Id<"users">;
+const BOB = "u2" as Id<"users">;
+const CAROL = "u3" as Id<"users">;
+
+/** Minimal RoomWithRelatedData fixture — only the fields the mapping reads. */
+function roomDataFor(actorRole: MemberRole): RoomWithRelatedData {
+  return {
+    room: {
+      _id: "room-1",
+      name: "Test Room",
+      autoCompleteVoting: false,
+      permissions: allEveryone,
+    },
+    users: [{ _id: ME, role: actorRole }],
+    isOwnerAbsent: false,
+  } as unknown as RoomWithRelatedData;
+}
+
+function rosterUser(
+  id: Id<"users">,
+  name: string,
+  role: MemberRole
+): UserWithPresence {
+  return {
+    _id: id,
+    name,
+    role,
+    isSpectator: false,
+    isOnline: true,
+    lastSeen: null,
+    joinedAt: 1,
+    membershipId: `m-${id}`,
+  } as unknown as UserWithPresence;
+}
+
+function renderPanel(actorRole: MemberRole) {
+  return render(
+    <RoomSettingsPanel
+      roomData={roomDataFor(actorRole)}
+      currentUserId={ME}
+      isOpen={true}
+      onClose={() => {}}
+    />
+  );
+}
+
+function rowFor(name: string): HTMLElement {
+  const row = screen
+    .getAllByTestId("participant-row")
+    .find((el) => el.getAttribute("data-user-name") === name);
+  if (!row) throw new Error(`no roster row rendered for ${name}`);
+  return row;
+}
+
+// Exact denial copy from the decision layer. remove/promote are
+// facilitator-level verbs; demote/transfer are owner-level verbs.
+const FACILITATOR_LEVEL_DENIAL = denialMessage(
+  { kind: "relationship", verb: "remove", targetRole: "participant" },
+  "insufficient-role"
+);
+const OWNER_LEVEL_DENIAL = denialMessage(
+  { kind: "relationship", verb: "transfer" },
+  "insufficient-role"
+);
+const PROMOTE_TARGET_DENIAL = denialMessage(
+  { kind: "relationship", verb: "promote", targetRole: "facilitator" },
+  "target-rank"
+);
+
+afterEach(() => {
+  cleanup();
+  mocks.roster.mockReset();
+  mocks.removeUser.mockClear();
+  mocks.promoteFacilitator.mockClear();
+  mocks.demoteFacilitator.mockClear();
+  mocks.transferOwnership.mockClear();
+});
+
+describe("RoomSettingsPanel — roster denied for a participant actor", () => {
+  it("all four controls render disabled with the decision's denial copy, and no click reaches a mutation", () => {
+    // The fixture really does deny every relationship verb for this actor.
+    const perms = computePermissions(roomDataFor("participant"), ME);
+    expect(perms.removeTarget("participant").allowed).toBe(false);
+    expect(perms.promoteTarget("participant").allowed).toBe(false);
+    expect(perms.demoteTarget("participant").allowed).toBe(false);
+    expect(perms.transfer.allowed).toBe(false);
+
+    mocks.roster.mockReturnValue([
+      rosterUser(ME, "Me", "participant"),
+      rosterUser(BOB, "Bob", "participant"),
+    ]);
+    renderPanel("participant");
+
+    // Render order in the row: promote, demote, transfer, remove.
+    const buttons = within(rowFor("Bob")).getAllByRole("button");
+    expect(buttons).toHaveLength(4);
+    const [promote, demote, transfer, remove] = buttons;
+
+    for (const button of buttons) {
+      expect(button).toHaveProperty("disabled", true);
+    }
+    expect(promote.getAttribute("aria-label")).toBe(FACILITATOR_LEVEL_DENIAL);
+    expect(demote.getAttribute("aria-label")).toBe(OWNER_LEVEL_DENIAL);
+    expect(transfer.getAttribute("aria-label")).toBe(OWNER_LEVEL_DENIAL);
+    expect(remove.getAttribute("aria-label")).toBe(FACILITATOR_LEVEL_DENIAL);
+
+    for (const button of buttons) {
+      fireEvent.click(button);
+    }
+    expect(mocks.promoteFacilitator).not.toHaveBeenCalled();
+    expect(mocks.demoteFacilitator).not.toHaveBeenCalled();
+    expect(mocks.transferOwnership).not.toHaveBeenCalled();
+    expect(mocks.removeUser).not.toHaveBeenCalled();
+  });
+});
+
+describe("RoomSettingsPanel — roster allowed for the owner", () => {
+  it("promote on a participant is enabled and reaches promoteFacilitator", () => {
+    mocks.roster.mockReturnValue([
+      rosterUser(ME, "Me", "owner"),
+      rosterUser(BOB, "Bob", "participant"),
+    ]);
+    renderPanel("owner");
+
+    const promote = within(rowFor("Bob")).getByRole("button", {
+      name: "Promote Bob to facilitator",
+    });
+    expect(promote).toHaveProperty("disabled", false);
+
+    fireEvent.click(promote);
+    expect(mocks.promoteFacilitator).toHaveBeenCalledWith(BOB);
+  });
+
+  it("demote on a facilitator is enabled and reaches demoteFacilitator", () => {
+    mocks.roster.mockReturnValue([
+      rosterUser(ME, "Me", "owner"),
+      rosterUser(CAROL, "Carol", "facilitator"),
+    ]);
+    renderPanel("owner");
+
+    const demote = within(rowFor("Carol")).getByRole("button", {
+      name: "Demote Carol to participant",
+    });
+    expect(demote).toHaveProperty("disabled", false);
+
+    fireEvent.click(demote);
+    expect(mocks.demoteFacilitator).toHaveBeenCalledWith(CAROL);
+  });
+
+  it("transfer on a participant is enabled and reaches transferOwnership after confirming", async () => {
+    mocks.roster.mockReturnValue([
+      rosterUser(ME, "Me", "owner"),
+      rosterUser(BOB, "Bob", "participant"),
+    ]);
+    renderPanel("owner");
+
+    const transfer = within(rowFor("Bob")).getByRole("button", {
+      name: "Transfer ownership to Bob",
+    });
+    expect(transfer).toHaveProperty("disabled", false);
+
+    fireEvent.click(transfer);
+    expect(mocks.transferOwnership).not.toHaveBeenCalled();
+
+    const confirm = await screen.findByRole("button", { name: "Transfer" });
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+    expect(mocks.transferOwnership).toHaveBeenCalledWith(BOB);
+  });
+
+  it("remove on a participant is enabled and reaches removeUser after confirming", async () => {
+    mocks.roster.mockReturnValue([
+      rosterUser(ME, "Me", "owner"),
+      rosterUser(BOB, "Bob", "participant"),
+    ]);
+    renderPanel("owner");
+
+    const remove = within(rowFor("Bob")).getByRole("button", {
+      name: "Remove Bob",
+    });
+    expect(remove).toHaveProperty("disabled", false);
+
+    fireEvent.click(remove);
+    expect(mocks.removeUser).not.toHaveBeenCalled();
+
+    const confirm = await screen.findByRole("button", { name: "Remove" });
+    await act(async () => {
+      fireEvent.click(confirm);
+    });
+    expect(mocks.removeUser).toHaveBeenCalledWith(BOB);
+  });
+
+  it("target-rank denials still surface per target: promote on a facilitator stays disabled", () => {
+    mocks.roster.mockReturnValue([
+      rosterUser(ME, "Me", "owner"),
+      rosterUser(CAROL, "Carol", "facilitator"),
+    ]);
+    renderPanel("owner");
+
+    const promote = within(rowFor("Carol")).getByRole("button", {
+      name: PROMOTE_TARGET_DENIAL,
+    });
+    expect(promote).toHaveProperty("disabled", true);
+
+    fireEvent.click(promote);
+    expect(mocks.promoteFacilitator).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/room/room-settings-panel.tsx
+++ b/src/components/room/room-settings-panel.tsx
@@ -53,7 +53,12 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { usePermissions } from "@/hooks/usePermissions";
+import {
+  usePermissions,
+  permissionProps,
+  permissionInputProps,
+  rosterControls,
+} from "@/hooks/usePermissions";
 import { IntegrationSettingsSection } from "./integration-settings";
 import { useRoomSettingsActions } from "./hooks/useRoomSettingsActions";
 import type { Id } from "@/convex/_generated/dataModel";
@@ -277,11 +282,6 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
 
   const currentPermissions = getEffectivePermissions(roomData.room);
 
-  // Tooltip for the room-name controls, read straight from the resolved decision.
-  const roomSettingsTooltip = perms.roomSettings.allowed
-    ? undefined
-    : perms.roomSettings.message;
-
   return (
     <>
     <SidePanel isOpen={isOpen} onClose={onClose} data-testid="room-settings-panel">
@@ -343,21 +343,20 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                   }}
                   placeholder="Enter room name"
                   className="h-10 text-sm bg-gray-50 dark:bg-surface-2"
-                  readOnly={isDemoMode || !perms.roomSettings.allowed}
-                  title={roomSettingsTooltip}
+                  readOnly={isDemoMode}
+                  {...permissionInputProps(perms.roomSettings)}
                 />
                 {!isDemoMode && (
                   <Button
                     size="default"
                     onClick={handleSaveRoomName}
                     disabled={
-                      !perms.roomSettings.allowed ||
                       isSaving ||
                       !roomName.trim() ||
                       roomName === roomData.room.name
                     }
                     className="h-10 px-4 whitespace-nowrap"
-                    title={roomSettingsTooltip}
+                    {...permissionProps(perms.roomSettings)}
                   >
                     {isSaving ? "Saving..." : "Save"}
                   </Button>
@@ -382,8 +381,9 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                 id="auto-reveal"
                 checked={roomData.room.autoCompleteVoting}
                 onCheckedChange={perms.roomSettings.allowed ? handleToggleAutoReveal : undefined}
-                disabled={isDemoMode || !perms.roomSettings.allowed}
+                disabled={isDemoMode}
                 className="data-[state=checked]:bg-primary"
+                {...permissionProps(perms.roomSettings)}
               />
             </div>
 
@@ -572,11 +572,15 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                   sortedUsers.map((u) => {
                     const userRole = u.role ?? "participant";
                     const isMe = u._id === currentUserId;
-                    const removeDecision = perms.removeTarget(userRole);
-                    const canRemoveThis = removeDecision.allowed;
-                    const canPromoteThis = perms.promoteTarget(userRole).allowed;
-                    const canDemoteThis = perms.demoteTarget(userRole).allowed;
-                    const canTransfer = perms.transfer.allowed;
+                    // Per-action control state from the four relationship
+                    // decisions against this target — denied actions render
+                    // visible-but-disabled with the denial copy, never vanish.
+                    const roster = rosterControls({
+                      remove: perms.removeTarget(userRole),
+                      promote: perms.promoteTarget(userRole),
+                      demote: perms.demoteTarget(userRole),
+                      transfer: perms.transfer,
+                    });
 
                     return (
                       <div
@@ -633,65 +637,92 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                         </div>
                         {!isDemoMode && !isMe && (
                           <div className="flex items-center gap-1 shrink-0 opacity-100 sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100 transition-opacity">
-                            {/* Promote button (for participants) */}
-                            {canPromoteThis && (
-                              <Tooltip>
-                                <TooltipTrigger render={
-                                  <Button
-                                    variant="ghost"
-                                    size="icon-sm"
-                                    onClick={() => handlePromote(u._id, u.name)}
-                                    className="hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
-                                    aria-label={`Promote ${u.name} to facilitator`}
-                                  >
-                                    <ChevronUp className="h-4 w-4" />
-                                  </Button>
-                                } />
-                                <TooltipContent>
-                                  <p>Promote to facilitator</p>
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
+                            {/* Promote button */}
+                            <Tooltip>
+                              <TooltipTrigger render={
+                                <Button
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  onClick={roster.promote.enabled ? () => handlePromote(u._id, u.name) : undefined}
+                                  disabled={!roster.promote.enabled}
+                                  className={cn(
+                                    roster.promote.enabled
+                                      ? "hover:bg-blue-50 hover:text-blue-600 dark:hover:bg-blue-500/10 dark:hover:text-blue-400"
+                                      : "opacity-40 cursor-not-allowed",
+                                  )}
+                                  aria-label={
+                                    roster.promote.enabled
+                                      ? `Promote ${u.name} to facilitator`
+                                      : roster.promote.denial
+                                  }
+                                >
+                                  <ChevronUp className="h-4 w-4" />
+                                </Button>
+                              } />
+                              <TooltipContent>
+                                <p>
+                                  {roster.promote.enabled ? "Promote to facilitator" : roster.promote.denial}
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
 
-                            {/* Demote button (for facilitators, owner only) */}
-                            {canDemoteThis && (
-                              <Tooltip>
-                                <TooltipTrigger render={
-                                  <Button
-                                    variant="ghost"
-                                    size="icon-sm"
-                                    onClick={() => handleDemote(u._id, u.name)}
-                                    className="hover:bg-amber-50 hover:text-amber-600 dark:hover:bg-amber-500/10 dark:hover:text-amber-400"
-                                    aria-label={`Demote ${u.name} to participant`}
-                                  >
-                                    <ChevronDown className="h-4 w-4" />
-                                  </Button>
-                                } />
-                                <TooltipContent>
-                                  <p>Demote to participant</p>
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
+                            {/* Demote button */}
+                            <Tooltip>
+                              <TooltipTrigger render={
+                                <Button
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  onClick={roster.demote.enabled ? () => handleDemote(u._id, u.name) : undefined}
+                                  disabled={!roster.demote.enabled}
+                                  className={cn(
+                                    roster.demote.enabled
+                                      ? "hover:bg-amber-50 hover:text-amber-600 dark:hover:bg-amber-500/10 dark:hover:text-amber-400"
+                                      : "opacity-40 cursor-not-allowed",
+                                  )}
+                                  aria-label={
+                                    roster.demote.enabled
+                                      ? `Demote ${u.name} to participant`
+                                      : roster.demote.denial
+                                  }
+                                >
+                                  <ChevronDown className="h-4 w-4" />
+                                </Button>
+                              } />
+                              <TooltipContent>
+                                <p>
+                                  {roster.demote.enabled ? "Demote to participant" : roster.demote.denial}
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
 
-                            {/* Transfer ownership button (owner only, on non-owners) */}
-                            {canTransfer && userRole !== "owner" && (
-                              <Tooltip>
-                                <TooltipTrigger render={
-                                  <Button
-                                    variant="ghost"
-                                    size="icon-sm"
-                                    onClick={() => setPendingTransferUser({ id: u._id, name: u.name })}
-                                    className="hover:bg-purple-50 hover:text-purple-600 dark:hover:bg-purple-500/10 dark:hover:text-purple-400"
-                                    aria-label={`Transfer ownership to ${u.name}`}
-                                  >
-                                    <ArrowRightLeft className="h-4 w-4" />
-                                  </Button>
-                                } />
-                                <TooltipContent>
-                                  <p>Transfer ownership</p>
-                                </TooltipContent>
-                              </Tooltip>
-                            )}
+                            {/* Transfer ownership button */}
+                            <Tooltip>
+                              <TooltipTrigger render={
+                                <Button
+                                  variant="ghost"
+                                  size="icon-sm"
+                                  onClick={roster.transfer.enabled ? () => setPendingTransferUser({ id: u._id, name: u.name }) : undefined}
+                                  disabled={!roster.transfer.enabled}
+                                  className={cn(
+                                    roster.transfer.enabled
+                                      ? "hover:bg-purple-50 hover:text-purple-600 dark:hover:bg-purple-500/10 dark:hover:text-purple-400"
+                                      : "opacity-40 cursor-not-allowed",
+                                  )}
+                                  aria-label={
+                                    roster.transfer.enabled
+                                      ? `Transfer ownership to ${u.name}`
+                                      : roster.transfer.denial
+                                  }
+                                >
+                                  <ArrowRightLeft className="h-4 w-4" />
+                                </Button>
+                              } />
+                              <TooltipContent>
+                                <p>
+                                  {roster.transfer.enabled ? "Transfer ownership" : roster.transfer.denial}
+                                </p>
+                              </TooltipContent>
+                            </Tooltip>
 
                             {/* Remove button */}
                             <Tooltip>
@@ -699,17 +730,17 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                                 <Button
                                   variant="ghost"
                                   size="icon-sm"
-                                  onClick={canRemoveThis ? () => handleRemoveUser(u._id, u.name) : undefined}
-                                  disabled={removingUserId === u._id || !canRemoveThis}
+                                  onClick={roster.remove.enabled ? () => handleRemoveUser(u._id, u.name) : undefined}
+                                  disabled={removingUserId === u._id || !roster.remove.enabled}
                                   className={cn(
-                                    canRemoveThis
+                                    roster.remove.enabled
                                       ? "hover:bg-red-50 hover:text-red-600 dark:hover:bg-red-500/10 dark:hover:text-red-400"
                                       : "opacity-40 cursor-not-allowed",
                                   )}
                                   aria-label={
-                                    canRemoveThis
+                                    roster.remove.enabled
                                       ? `Remove ${u.name}`
-                                      : removeDecision.message
+                                      : roster.remove.denial
                                   }
                                 >
                                   <UserMinus className="h-4 w-4" />
@@ -717,7 +748,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                               } />
                               <TooltipContent>
                                 <p>
-                                  {canRemoveThis ? "Remove user" : removeDecision.message}
+                                  {roster.remove.enabled ? "Remove user" : roster.remove.denial}
                                 </p>
                               </TooltipContent>
                             </Tooltip>

--- a/src/components/room/room-settings-panel.tsx
+++ b/src/components/room/room-settings-panel.tsx
@@ -69,7 +69,7 @@ import { getEffectivePermissions } from "@/convex/permissions";
 import { UserAvatar } from "@/components/user-menu/user-avatar";
 import { formatLastSeen } from "./user-presence-avatars";
 
-import { useRoomPresence } from "@/hooks/useRoomPresence";
+import { usePresenceRoster } from "./room-presence";
 import { useIsDemoMode } from "./demo/DemoSimulationProvider";
 
 interface RoomSettingsPanelProps {
@@ -118,11 +118,9 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
   const { toast } = useToast();
   const { theme, setTheme } = useTheme();
 
-  const usersWithPresence = useRoomPresence(
-    roomData.room._id,
-    currentUserId ?? "",
-    roomData.users
-  );
+  // Roster from the single presence module, ordered current-user-first, then
+  // online-first, then by join time.
+  const sortedUsers = usePresenceRoster(currentUserId);
 
   const [roomName, setRoomName] = useState(roomData.room.name);
   const [isSaving, setIsSaving] = useState(false);
@@ -265,20 +263,6 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
       toast({ title: "Failed to update permissions", variant: "destructive" });
     }
   };
-
-  // Filter users: sort online first, then by join time
-  const sortedUsers = [...usersWithPresence].sort((a, b) => {
-    // Current user always first
-    if (a._id === currentUserId) return -1;
-    if (b._id === currentUserId) return 1;
-    
-    // Online users next
-    if (a.isOnline !== b.isOnline) {
-      return a.isOnline ? -1 : 1;
-    }
-    // Then by join time (earliest first)
-    return a.joinedAt - b.joinedAt;
-  });
 
   const currentPermissions = getEffectivePermissions(roomData.room);
 
@@ -553,7 +537,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                   Participants
                 </h3>
                 <Badge variant="secondary" className="bg-white dark:bg-surface-2 text-xs font-medium px-2.5 py-0.5 rounded-full border border-gray-200 dark:border-border">
-                  {usersWithPresence.length} Total
+                  {sortedUsers.length} Total
                 </Badge>
               </div>
               

--- a/src/components/room/room-settings-panel.tsx
+++ b/src/components/room/room-settings-panel.tsx
@@ -22,7 +22,6 @@ import {
   Settings,
 } from "lucide-react";
 import { useTheme } from "next-themes";
-import { useMutation } from "convex/react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -56,7 +55,7 @@ import {
 } from "@/components/ui/select";
 import { usePermissions } from "@/hooks/usePermissions";
 import { IntegrationSettingsSection } from "./integration-settings";
-import { api } from "@/convex/_generated/api";
+import { useRoomSettingsActions } from "./hooks/useRoomSettingsActions";
 import type { Id } from "@/convex/_generated/dataModel";
 import { cn } from "@/lib/utils";
 import type { RoomWithRelatedData } from "@/convex/model/rooms";
@@ -127,13 +126,10 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
   const [pendingTransferUser, setPendingTransferUser] = useState<{id: Id<"users">, name: string} | null>(null);
   const openSelectCountRef = useRef(0);
 
-  const renameRoom = useMutation(api.rooms.rename);
-  const toggleAutoComplete = useMutation(api.rooms.toggleAutoComplete);
-  const removeUser = useMutation(api.users.remove);
-  const promoteFacilitator = useMutation(api.roles.promoteFacilitator);
-  const demoteFacilitator = useMutation(api.roles.demoteFacilitator);
-  const transferOwnership = useMutation(api.roles.transferOwnership);
-  const updatePermissions = useMutation(api.roles.updatePermissions);
+  // Writes come from the action seam, which no-ops internally in demo mode
+  // (ADR-0003) — the remaining `isDemoMode` branches below are presentation only
+  // (hide/disable/read-only controls), never write guards.
+  const settingsActions = useRoomSettingsActions({ roomId: roomData.room._id });
 
   const perms = usePermissions(roomData, currentUserId);
 
@@ -155,7 +151,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
 
     setIsSaving(true);
     try {
-      await renameRoom({ roomId: roomData.room._id, name: roomName.trim() });
+      await settingsActions.rename(roomName.trim());
       toast({
         title: "Room renamed",
         description: `Room is now called "${roomName.trim()}"`,
@@ -174,7 +170,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
 
   const handleToggleAutoReveal = async () => {
     try {
-      await toggleAutoComplete({ roomId: roomData.room._id });
+      await settingsActions.toggleAutoComplete();
     } catch (error) {
       console.error("Failed to toggle auto-reveal:", error);
       toast({
@@ -192,7 +188,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
     if (!pendingDeleteUser) return;
     setRemovingUserId(pendingDeleteUser.id);
     try {
-      await removeUser({ userId: pendingDeleteUser.id, roomId: roomData.room._id });
+      await settingsActions.removeUser(pendingDeleteUser.id);
       toast({
         title: "User removed",
         description: `${pendingDeleteUser.name} has been removed from the room.`,
@@ -211,7 +207,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
 
   const handlePromote = async (userId: Id<"users">, userName: string) => {
     try {
-      await promoteFacilitator({ roomId: roomData.room._id, targetUserId: userId });
+      await settingsActions.promoteFacilitator(userId);
       toast({
         title: "User promoted",
         description: `${userName} is now a facilitator.`,
@@ -224,7 +220,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
 
   const handleDemote = async (userId: Id<"users">, userName: string) => {
     try {
-      await demoteFacilitator({ roomId: roomData.room._id, targetUserId: userId });
+      await settingsActions.demoteFacilitator(userId);
       toast({
         title: "User demoted",
         description: `${userName} is now a participant.`,
@@ -238,7 +234,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
   const handleConfirmTransfer = async () => {
     if (!pendingTransferUser) return;
     try {
-      await transferOwnership({ roomId: roomData.room._id, targetUserId: pendingTransferUser.id });
+      await settingsActions.transferOwnership(pendingTransferUser.id);
       toast({
         title: "Ownership transferred",
         description: `${pendingTransferUser.name} is now the room owner.`,
@@ -258,7 +254,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
       [category]: value,
     };
     try {
-      await updatePermissions({ roomId: roomData.room._id, permissions: newPermissions });
+      await settingsActions.updatePermissions(newPermissions);
     } catch (error) {
       console.error("Failed to update permissions:", error);
       toast({ title: "Failed to update permissions", variant: "destructive" });
@@ -341,9 +337,9 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
                 <Input
                   id="room-name"
                   value={roomName}
-                  onChange={(e) => !isDemoMode && perms.roomSettings.allowed && setRoomName(e.target.value)}
+                  onChange={(e) => perms.roomSettings.allowed && setRoomName(e.target.value)}
                   onKeyDown={(e) => {
-                    if (e.key === "Enter" && !isDemoMode && perms.roomSettings.allowed) handleSaveRoomName();
+                    if (e.key === "Enter" && perms.roomSettings.allowed) handleSaveRoomName();
                   }}
                   placeholder="Enter room name"
                   className="h-10 text-sm bg-gray-50 dark:bg-surface-2"
@@ -385,7 +381,7 @@ export const RoomSettingsPanel: FC<RoomSettingsPanelProps> = ({
               <Switch
                 id="auto-reveal"
                 checked={roomData.room.autoCompleteVoting}
-                onCheckedChange={isDemoMode || !perms.roomSettings.allowed ? undefined : handleToggleAutoReveal}
+                onCheckedChange={perms.roomSettings.allowed ? handleToggleAutoReveal : undefined}
                 disabled={isDemoMode || !perms.roomSettings.allowed}
                 className="data-[state=checked]:bg-primary"
               />

--- a/src/components/room/types.ts
+++ b/src/components/room/types.ts
@@ -4,6 +4,7 @@ import type { SanitizedVote } from "@/convex/model/rooms";
 import type { RoomUserData } from "@/convex/model/users";
 import type { MemberRole, ResolvedDecision } from "@/convex/permissions";
 import type { Phase } from "@/convex/phase";
+import type { TimerState } from "@/convex/timerState";
 
 // Demo mode constants
 export const DEMO_VIEWER_ID = "demo-viewer" as const;
@@ -55,21 +56,13 @@ export type SessionNodeData = {
   onOpenIssuesPanel?: () => void;
 };
 
-export type TimerNodeData = {
-  // Synchronized timer state fields
-  startedAt: number | null; // Server timestamp when started
-  pausedAt: number | null; // Server timestamp when paused
-  elapsedSeconds: number; // Total elapsed seconds
-  isRunning: boolean; // Current running state (derived from timestamps)
-  
-  // Tracking fields
-  lastUpdatedBy: Id<"users"> | null; // User who last changed timer
-  lastAction: "start" | "pause" | "reset" | null; // Last action performed
-  
-  // Required fields for timer synchronization
-  roomId: Id<"rooms">; // Room ID for timer sync
+// Persisted fields come from the single declaration in @/convex/timerState;
+// this adds only the view-side extras the node needs to render and control.
+export type TimerNodeData = TimerState & {
+  isRunning: boolean; // required in the view — buildTimerNode defaults the persisted optional
+  roomId: Id<"rooms">; // Room ID for timer controls
   userId?: Id<"users">; // Current user ID for timer controls
-  nodeId: string; // Node ID for timer sync
+  nodeId: string; // Node ID for timer controls
 };
 
 export type VotingCardNodeData = {

--- a/src/components/room/user-presence-avatars.tsx
+++ b/src/components/room/user-presence-avatars.tsx
@@ -15,7 +15,7 @@ import {
 } from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { getColorFromName, getInitial } from "@/lib/avatar-utils";
-import type { UserWithPresence } from "@/hooks/useRoomPresence";
+import { usePresenceRoster } from "./room-presence";
 
 // Format relative time for "last seen" display
 export function formatLastSeen(timestamp: number | null): string {
@@ -36,23 +36,17 @@ export function formatLastSeen(timestamp: number | null): string {
 }
 
 interface UserPresenceAvatarsProps {
-  users: UserWithPresence[];
   maxVisible?: number;
   size?: "sm" | "default";
 }
 
 export const UserPresenceAvatars: FC<UserPresenceAvatarsProps> = ({
-  users,
   maxVisible = 4,
   size = "sm",
 }) => {
-  // Sort users: online first, then by join time
-  const sortedUsers = [...users].sort((a, b) => {
-    if (a.isOnline !== b.isOnline) {
-      return a.isOnline ? -1 : 1;
-    }
-    return a.joinedAt - b.joinedAt;
-  });
+  // Roster + ordering come from the single presence module (online first,
+  // then by join time) — no per-consumer sorting here.
+  const sortedUsers = usePresenceRoster();
 
   const visibleUsers = sortedUsers.slice(0, maxVisible);
   const remainingCount = sortedUsers.length - maxVisible;

--- a/src/hooks/permissionProps.test.ts
+++ b/src/hooks/permissionProps.test.ts
@@ -1,6 +1,18 @@
 import { describe, it, expect } from "vitest";
-import { permissionProps } from "./usePermissions";
-import { RESOLVED_ALLOWED } from "@/convex/permissions";
+import {
+  permissionProps,
+  permissionInputProps,
+  denialTooltip,
+  rosterControls,
+  computePermissions,
+} from "./usePermissions";
+import type { RoomWithRelatedData } from "@/convex/model/rooms";
+import {
+  denialMessage,
+  RESOLVED_ALLOWED,
+  type MemberRole,
+  type RoomPermissions,
+} from "@/convex/permissions";
 
 describe("permissionProps — allowed", () => {
   it("returns an empty overlay so the control keeps its own state and label", () => {
@@ -27,5 +39,222 @@ describe("permissionProps — denied", () => {
     const overlay = permissionProps({ allowed: false, message });
     expect(overlay).toHaveProperty("title", message);
     expect(overlay).toHaveProperty("aria-label", message);
+  });
+});
+
+describe("permissionInputProps — the input-kind overlay", () => {
+  const message = "Only the owner can do this.";
+
+  it("returns an empty overlay when allowed", () => {
+    expect(permissionInputProps(RESOLVED_ALLOWED)).toEqual({});
+  });
+
+  it("denies via readOnly (not disabled) so the value stays focusable", () => {
+    const overlay = permissionInputProps({ allowed: false, message });
+    expect(overlay).toEqual({
+      readOnly: true,
+      title: message,
+      "aria-label": message,
+    });
+    expect(overlay).not.toHaveProperty("disabled");
+  });
+});
+
+describe("denialTooltip", () => {
+  it("is undefined when allowed", () => {
+    expect(denialTooltip(RESOLVED_ALLOWED)).toBeUndefined();
+  });
+
+  it("is the decision's message when denied", () => {
+    expect(denialTooltip({ allowed: false, message: "Only the owner can do this." }))
+      .toBe("Only the owner can do this.");
+  });
+});
+
+describe("rosterControls — shape", () => {
+  it("enabled controls carry no denial copy", () => {
+    const controls = rosterControls({
+      remove: RESOLVED_ALLOWED,
+      promote: RESOLVED_ALLOWED,
+      demote: RESOLVED_ALLOWED,
+      transfer: RESOLVED_ALLOWED,
+    });
+    expect(controls.remove).toEqual({ enabled: true });
+    expect(controls.remove).not.toHaveProperty("denial");
+  });
+
+  it("disabled controls carry the decision's message as the denial tooltip", () => {
+    const denied = { allowed: false, message: "Only the owner can do this." } as const;
+    const controls = rosterControls({
+      remove: denied,
+      promote: denied,
+      demote: denied,
+      transfer: denied,
+    });
+    expect(controls.demote).toEqual({ enabled: false, denial: denied.message });
+    expect(controls.transfer).toEqual({ enabled: false, denial: denied.message });
+  });
+});
+
+// --- Matrix over real decisions (computePermissions), per actor × target role ---
+
+const allEveryone: RoomPermissions = {
+  revealCards: "everyone",
+  gameFlow: "everyone",
+  issueManagement: "everyone",
+  roomSettings: "everyone",
+};
+
+/** Minimal RoomWithRelatedData fixture — only the fields the mapping reads. */
+function roomData(opts: {
+  role?: MemberRole;
+  permissions?: RoomPermissions;
+  isOwnerAbsent?: boolean;
+}): RoomWithRelatedData {
+  return {
+    room: { permissions: opts.permissions ?? allEveryone },
+    users: [{ _id: "u1", role: opts.role ?? "participant" }],
+    isOwnerAbsent: opts.isOwnerAbsent ?? false,
+  } as unknown as RoomWithRelatedData;
+}
+
+/** The per-action control bundle a roster row gets for one target role. */
+function row(
+  actorRole: MemberRole,
+  targetRole: MemberRole,
+  isOwnerAbsent = false
+) {
+  const perms = computePermissions(
+    roomData({ role: actorRole, isOwnerAbsent }),
+    "u1"
+  );
+  return rosterControls({
+    remove: perms.removeTarget(targetRole),
+    promote: perms.promoteTarget(targetRole),
+    demote: perms.demoteTarget(targetRole),
+    transfer: perms.transfer,
+  });
+}
+
+const ENABLED = { enabled: true };
+const facilitatorLevel = (verb: "remove" | "promote", targetRole: MemberRole) =>
+  denialMessage({ kind: "relationship", verb, targetRole }, "insufficient-role");
+const ownerOnlyDemote = (targetRole: MemberRole) =>
+  denialMessage(
+    { kind: "relationship", verb: "demote", targetRole },
+    "insufficient-role"
+  );
+const OWNER_ONLY_TRANSFER = denialMessage(
+  { kind: "relationship", verb: "transfer" },
+  "insufficient-role"
+);
+const targetRank = (verb: "remove" | "promote" | "demote", targetRole: MemberRole) =>
+  denialMessage({ kind: "relationship", verb, targetRole }, "target-rank");
+
+describe("rosterControls — owner actor", () => {
+  it("participant target: remove/promote/transfer enabled, demote denied (target-rank)", () => {
+    expect(row("owner", "participant")).toEqual({
+      remove: ENABLED,
+      promote: ENABLED,
+      demote: { enabled: false, denial: targetRank("demote", "participant") },
+      transfer: ENABLED,
+    });
+  });
+
+  it("facilitator target: remove/demote/transfer enabled, promote denied (target-rank)", () => {
+    expect(row("owner", "facilitator")).toEqual({
+      remove: ENABLED,
+      promote: { enabled: false, denial: targetRank("promote", "facilitator") },
+      demote: ENABLED,
+      transfer: ENABLED,
+    });
+  });
+
+  it("owner target: remove/transfer enabled, promote/demote denied (target-rank)", () => {
+    expect(row("owner", "owner")).toEqual({
+      remove: ENABLED,
+      promote: { enabled: false, denial: targetRank("promote", "owner") },
+      demote: { enabled: false, denial: targetRank("demote", "owner") },
+      transfer: ENABLED,
+    });
+  });
+});
+
+describe("rosterControls — facilitator actor", () => {
+  it("participant target: remove/promote enabled, demote/transfer denied (owner-only)", () => {
+    expect(row("facilitator", "participant")).toEqual({
+      remove: ENABLED,
+      promote: ENABLED,
+      demote: { enabled: false, denial: ownerOnlyDemote("participant") },
+      transfer: { enabled: false, denial: OWNER_ONLY_TRANSFER },
+    });
+  });
+
+  it("facilitator target: remove/promote denied (target-rank), demote/transfer denied", () => {
+    expect(row("facilitator", "facilitator")).toEqual({
+      remove: { enabled: false, denial: targetRank("remove", "facilitator") },
+      promote: { enabled: false, denial: targetRank("promote", "facilitator") },
+      demote: { enabled: false, denial: ownerOnlyDemote("facilitator") },
+      transfer: { enabled: false, denial: OWNER_ONLY_TRANSFER },
+    });
+  });
+
+  it("owner target: everything denied", () => {
+    expect(row("facilitator", "owner")).toEqual({
+      remove: { enabled: false, denial: targetRank("remove", "owner") },
+      promote: { enabled: false, denial: targetRank("promote", "owner") },
+      demote: { enabled: false, denial: ownerOnlyDemote("owner") },
+      transfer: { enabled: false, denial: OWNER_ONLY_TRANSFER },
+    });
+  });
+
+  it("lockdown refines owner-level denials to the owner-absent copy", () => {
+    const controls = row("facilitator", "participant", true);
+    expect(controls.demote).toEqual({
+      enabled: false,
+      denial: denialMessage(
+        { kind: "relationship", verb: "demote", targetRole: "participant" },
+        "owner-absent"
+      ),
+    });
+    expect(controls.transfer).toEqual({
+      enabled: false,
+      denial: denialMessage({ kind: "relationship", verb: "transfer" }, "owner-absent"),
+    });
+    // Facilitator-level verbs are unaffected by lockdown.
+    expect(controls.remove).toEqual(ENABLED);
+    expect(controls.promote).toEqual(ENABLED);
+  });
+});
+
+describe("rosterControls — participant actor", () => {
+  it("every action denied, each with its own verb's copy", () => {
+    expect(row("participant", "participant")).toEqual({
+      remove: { enabled: false, denial: facilitatorLevel("remove", "participant") },
+      promote: { enabled: false, denial: facilitatorLevel("promote", "participant") },
+      demote: { enabled: false, denial: ownerOnlyDemote("participant") },
+      transfer: { enabled: false, denial: OWNER_ONLY_TRANSFER },
+    });
+  });
+});
+
+describe("adapter applied to a real game-flow decision (Quick Vote regression)", () => {
+  it("participant's overlay disables the switch and carries the game-flow denial copy", () => {
+    const perms = computePermissions(
+      roomData({
+        role: "participant",
+        permissions: { ...allEveryone, gameFlow: "facilitators" },
+      }),
+      "u1"
+    );
+    const message = denialMessage(
+      { kind: "category", category: "gameFlow", level: "facilitators" },
+      "insufficient-role"
+    );
+    expect(permissionProps(perms.gameFlow)).toEqual({
+      disabled: true,
+      title: message,
+      "aria-label": message,
+    });
   });
 });

--- a/src/hooks/usePermissions.ts
+++ b/src/hooks/usePermissions.ts
@@ -33,6 +33,66 @@ export function permissionProps(rd: ResolvedDecision): PermissionOverlay {
   return { disabled: true, title: rd.message, "aria-label": rd.message };
 }
 
+/**
+ * The input-kind overlay: like `permissionProps`, but denies via `readOnly`
+ * instead of `disabled` so the field stays focusable and its value copyable.
+ * Allowed yields an empty overlay; spread it AFTER the input's own attributes.
+ */
+export type PermissionInputOverlay =
+  | Record<string, never>
+  | { readOnly: true; title: string; "aria-label": string };
+
+/**
+ * Maps a ResolvedDecision to the denial overlay an input composes by spreading
+ * it last. Pure — the input-kind counterpart of `permissionProps`.
+ */
+export function permissionInputProps(
+  rd: ResolvedDecision
+): PermissionInputOverlay {
+  if (rd.allowed) return {};
+  return { readOnly: true, title: rd.message, "aria-label": rd.message };
+}
+
+/**
+ * The denial tooltip copy for a resolved decision: the message when denied,
+ * undefined when allowed. For controls that keep their own attributes (spans,
+ * inputs already disabled by other state) but still read the copy from the
+ * decision rather than embedding their own.
+ */
+export function denialTooltip(rd: ResolvedDecision): string | undefined {
+  return rd.allowed ? undefined : rd.message;
+}
+
+/** The four relationship actions a roster row can take against one target. */
+export type RosterAction = "remove" | "promote" | "demote" | "transfer";
+
+/**
+ * One roster action's control state: `enabled` when its decision allows, else
+ * disabled with the decision's denial tooltip copy — so a denied action
+ * renders visible-but-disabled instead of vanishing.
+ */
+export type RosterActionControl =
+  | { enabled: true; denial?: never }
+  | { enabled: false; denial: string };
+
+/**
+ * Bundles a roster row's four relationship decisions against one target into
+ * per-action control state. Pure — the row keeps its own onClick, className,
+ * and per-action labels; this owns only the enabled/denial wiring.
+ */
+export function rosterControls(
+  decisions: Record<RosterAction, ResolvedDecision>
+): Record<RosterAction, RosterActionControl> {
+  const toControl = (rd: ResolvedDecision): RosterActionControl =>
+    rd.allowed ? { enabled: true } : { enabled: false, denial: rd.message };
+  return {
+    remove: toControl(decisions.remove),
+    promote: toControl(decisions.promote),
+    demote: toControl(decisions.demote),
+    transfer: toControl(decisions.transfer),
+  };
+}
+
 export interface UsePermissionsReturn {
   role: MemberRole;
   isOwner: boolean;

--- a/src/hooks/useRoomPresence.ts
+++ b/src/hooks/useRoomPresence.ts
@@ -12,6 +12,27 @@ export interface UserWithPresence extends RoomUserData {
 }
 
 /**
+ * The one roster ordering rule: online first, then by join time (earliest
+ * first). Pass `currentUserId` for the settings-panel variant, which pins the
+ * current user to the top before the online-first rule applies to the rest.
+ */
+export function orderUsersByPresence(
+  users: UserWithPresence[],
+  currentUserId?: string,
+): UserWithPresence[] {
+  return [...users].sort((a, b) => {
+    if (currentUserId) {
+      if (a._id === currentUserId) return -1;
+      if (b._id === currentUserId) return 1;
+    }
+    if (a.isOnline !== b.isOnline) {
+      return a.isOnline ? -1 : 1;
+    }
+    return a.joinedAt - b.joinedAt;
+  });
+}
+
+/**
  * Hook that combines room user data with presence information.
  * Returns users with their online status and last seen timestamp.
  *
@@ -36,8 +57,9 @@ export function useRoomPresence(
   // or never), so the branch — and thus the hook-call order — can never change
   // between renders, including under StrictMode/concurrent re-renders. The
   // zero-reads guard test backstops this by asserting `usePresence` is never
-  // called in demo mode. Centralizing here covers every caller
-  // (canvas-navigation, room-settings-panel) at once.
+  // called in demo mode. Centralizing here covers the one caller,
+  // `RoomPresenceProvider` — which is mounted once per room tree, so each
+  // viewer holds exactly one presence subscription.
   // eslint-disable-next-line react-hooks/rules-of-hooks
   return demo ? useDemoPresence(users) : useConvexPresence(roomId, userId, users);
 }


### PR DESCRIPTION
## What this is

Implements all 12 deepening candidates from the latest architecture review (deep/shallow module analysis across the Convex backend and the room frontend). Each candidate lands as its own commit with tests at the deepened module's interface. One PR, as requested.

## Candidates

**Strong**

- `76336ab` **One acting-user guard** — `requireActingUser` in `model/auth.ts` replaces 12 copy-pasted "authenticated ∧ member ∧ acting as this userId" checks across canvas/timer/votes/presence handlers. **Also closes a read gap**: `getCanvasNodes` had no membership check — note contents marked "private to the room" were returned to any caller. (Timer state is a `canvasNodes` row, so this one check covers both readings.)
- `5d770cd` **One permission guard, two authentication modes** — `requireCanForUser` joins `requireCan` behind one shared IO assembly; deletes `verifyRoomAccess`, a drifted hand-copy (always paid the owner-absence read, one hardcoded category). Seven Jira actions stop hand-rolling identity resolution.
- `b30ecfd` **One room-aggregate deletion inventory** — new `model/roomAggregate.ts`. **Fixes a live leak**: the daily `cleanupRoom` never deleted `issues`, orphaning rows permanently; the admin wipe and orphan sweep now derive from the same inventory (gains `votingTimestamps`, `individualVotes`, `issueLinks` coverage).
- `3e41150` **One owner for issue creation** — `Issues.createIssueInRoom`. **Fixes a live bug**: the Jira import allocated sequential IDs pre-increment, so importing after N local issues reused PP-N. The import now also enforces the 500-issue cap.
- `96cd5e6` **Split the Jira mega-module** — db invariants (connection upsert, sanitized projection, mapping writes, webhook dedup/apply, event sweep) move into `model/integrations.ts`; `jira.ts` keeps fetch orchestration only. **Owns a new invariant**: mapping/connection deletion now schedules webhook deregistration (previously orphaned until remote expiry).

**Worth exploring**

- `d88fdce` **Round owns the auto-complete setting** — `VotingRound.setAutoComplete`: disable cancels the countdown, enable re-evaluates. Removes the last reconcile-by-convention site (the ADR-0004 failure class); enabling with all votes in now arms immediately.
- `b3cd9ee` **Analytics: one scan, pure projections** — `completedIssueHistory` aggregate + pure `convex/analyticsMath.ts`. **Two correctness fixes that change dashboard numbers**: `getVoteDistribution` honors date ranges uniformly; `totalVotesCast` counts real votes from `individualVotes` instead of echoing the issue count.
- `f26c61b` **Timer state as one pure shared module** — `convex/timerState.ts` owns the persisted shape, elapsed math, MM:SS format, and transition rules. Removes the backend→frontend type import inversion and the second per-client timer subscription (`getTimerState` deleted); dead `resetTimerForGameReset` removed.
- `c2fb5a7` **Demo write-bypass seam for issues/settings** — `useIssueActions`/`useRoomSettingsActions` mirror the accepted `useCanvasActions` shape; ~15 scattered `isDemoMode` write guards reduce to presentation-only branches. **Closes the ADR-0003 zero-reads hole**: the root `AuthProvider` no longer opens a `getGlobalUser` subscription on `/demo` for returning visitors; probe extended.
- `3d874de` **One decision-application adapter** — `permissionProps` gains an input variant, `denialTooltip`, and the `rosterControls` bundle. **UX change per the CONTEXT.md resolved-decision rule**: denied roster actions render disabled-with-reason instead of vanishing; the Quick Vote switch shows its denial tooltip instead of letting the backend throw a generic toast.
- `acd1ec5` **Token vault** — `model/tokenVault.ts` owns key validation, encrypt-on-write/decrypt-on-read, and the expiry predicate; plaintext is unrepresentable through the model interface. No migration needed (rows already hold ciphertext). Provider-agnostic for the planned GitHub adapter (spec 07).

**Speculative**

- `32e6ff9` **One presence subscription per viewer** — `RoomPresenceProvider` hoists the single `usePresence` above both consumers (was two sessions + **two heartbeat loops per viewer**). Presence ticks no longer re-render the canvas subtree or nav chrome (render-isolation test included); one roster ordering rule.

Plus `71bf0c4` — CONTEXT.md/CLAUDE.md vocabulary updates for the new guards and modules.

## Review round (bot review addressed)

- `30078ad` **Disconnect tail serialized** — `disconnectConnection` scheduled the deregistrations and the connection-row delete as independent `runAfter(0)` jobs with no ordering guarantee (the delete could win, orphaning the remote webhooks). One `finalizeDisconnect` action now deregisters each webhook and deletes the row last, ordering enforced by its own awaits. `deregisterWebhook` also gains one bounded retry instead of warn-and-forget.
- `db87747` **Chunked room cascade + cron fan-out** — the cascade no longer deletes a room's rows in one unbounded transaction: `deleteRoomAggregateChunk` deletes in `.take()`-bounded batches and reschedules itself until done (per the project's own Convex guidelines), and `removeInactiveRooms` schedules one cascade per room. **The room cascade now also schedules webhook deregistration for mapped rows** — the follow-up gap below is closed. `cleanupOrphanedData` is wired into `crons.ts` (daily).
- `5eebb4c` **users edit/leave on the acting-user guard** — the two handlers that hand-rolled the exact `requireActingUser` shape now use it.
- `590f3ce` **Vault rejects empty tokens** — an empty token would AES-GCM to empty ciphertext and then fail the tripwire as "possible plaintext"; the vault now names the real problem at encrypt time.
- `45da1e6` **Test gaps closed** — timer double pause/resume cycle, concurrent `createIssueInRoom` uniqueness, roster denial UI component test (real `usePermissions`→`rosterControls` wiring).

Declined from the review, with reason: switching the Quick Vote denial copy from native `title` to the shadcn `Tooltip`. The `Tooltip` instances in `issues-panel.tsx` are static action hints (Import/Export/Close); permission-denial copy across the whole codebase flows through `permissionProps` → native `title` (SessionNode, issue-item, room-settings-panel, issues-panel). Changing one button would introduce the inconsistency it claims to fix. A system-wide move to tooltip-based denial copy (touch-device concern is real) is a UX decision better tracked as its own issue.

## Verification

- `npm test`: **385/385 pass** (35 files; was 212/20 on main) — new coverage at each deepened interface
- `npm run ts:check`: clean
- `npm run lint`: clean
- `npm run build`: clean, all routes compile
- `npm run test:e2e:headless` (Playwright, live dev + Convex servers): **83 passed, 1 skipped** (2.6m). The skip is pre-existing and documented (`home.spec.ts` room-creation-error case — Convex WebSocket calls can't be route-mocked).

## Behavior changes reviewers should know

- Dashboard: `totalVotesCast` and ranged vote-distribution numbers change (bug fixes).
- Roster: denied promote/demote/transfer/remove are now visible-but-disabled with their reason (was: hidden).
- Quick Vote switch denied: tooltip, no toast.
- Importing Jira issues now bumps the room's `lastActivityAt` and enforces the 500-cap.
- Presence: heartbeat writes per viewer are halved.
- Room deletion (cron) is now chunked + per-room scheduled rather than one big transaction; `users.leave` on a non-membership now throws "Not a member of this room" instead of silently no-op'ing (no frontend caller today).

## Follow-ups recorded (not in scope)

- Disabling auto-push in `saveRoomMapping` leaves the old webhook live (pre-existing; re-registration replaces it).
- The StoryNode chain is dead code (nothing builds story nodes) — left in place pending a check for persisted legacy rows.
- Pre-existing jsdom warning: nested `<button>` in `issue-item.tsx` dropdown trigger.
- `admin:dangerouslyDeleteAllData` still collects whole tables per call — acceptable for a manual dev nuke whose failure mode is "run it again"; the production cascade is the chunked one.
